### PR TITLE
Presets with s4s demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,12 @@ RUN bundle install
 
 # Expose the port
 EXPOSE 4567
+
+RUN apt-get update
+RUN apt-get install -y libnss3 fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libgtk-3-0 libnspr4 libx11-xcb1 libxss1 libxtst6 lsb-release xdg-utils
+
+# Install Chrome
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
+
+ADD ./chromedriver /usr/local/bin

--- a/lib/app/endpoint/landing.rb
+++ b/lib/app/endpoint/landing.rb
@@ -11,8 +11,7 @@ module Inferno
 
         # Return the index page of the application
         get '/' do
-          logger.info 'loading index page.'
-          erb :index, {}, modules: settings.modules.map{|m| Inferno::Module.get(m)}.select{|m| !m.nil?}
+          redirect BASE_PATH
         end
 
         get '/landing/?' do

--- a/lib/app/modules/bluebutton_demo_module.yml
+++ b/lib/app/modules/bluebutton_demo_module.yml
@@ -11,6 +11,7 @@ test_sets:
           This is an overview of the Discovery group
         sequences:
           - CapabilityStatementSequence
+          - SMARTDiscoverySequence
         run_all: false
       - name: Authorization and Authentication
         overview: >

--- a/lib/app/utils/instance_config.rb
+++ b/lib/app/utils/instance_config.rb
@@ -1,0 +1,16 @@
+def configure_instance(instance, arguments)
+  arguments.each do |key, val|
+    if instance.respond_to?(key)
+      if val.is_a?(Array) || val.is_a?(Hash)
+        instance.send("#{key.to_s}=", val.to_json) if instance.respond_to? key.to_s
+      elsif val.is_a?(String) && val.downcase == 'true'
+        instance.send("#{key.to_s}=", true) if instance.respond_to? key.to_s
+      elsif val.is_a?(String) && val.downcase == 'false'
+        instance.send("#{key.to_s}=", false) if instance.respond_to? key.to_s
+      else
+        instance.send("#{key.to_s}=", val) if instance.respond_to? key.to_s
+      end
+    end
+  end
+  instance
+end

--- a/lib/app/utils/web_driver.rb
+++ b/lib/app/utils/web_driver.rb
@@ -11,6 +11,7 @@ module Inferno
       options.add_argument('--kiosk')
       options.add_argument('--disable-gpu')
       options.add_argument('--incognito')
+      options.add_argument('--no-sandbox')
 
 
       # options.add_argument('--remote-debugging-port=9222')

--- a/lib/app/views/index.erb
+++ b/lib/app/views/index.erb
@@ -27,6 +27,17 @@
       </div>
 
     </div>
+    <% if !presets.empty? %>
+      <div class="form-group">
+        <span class="oi oi-lightbulb"></span> Optionally, choose a preset vendor configuration to test:
+        <select class="custom-select custom-select-lg" name="preset" style="margin-left: 10px;" id="preset-select">
+          <option value="" data-uri="">None</option>
+          <% presets.each do |preset| %>
+            <option value="<%=preset[:file] %>" data-uri="<%=preset[:uri] %>"><%=preset[:name] %></option>
+          <% end %>
+        </select>
+      </div>
+    <% end %>
   </form>
 
   <div class='alert alert-warning'>

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -10,6 +10,7 @@ require_relative '../app/endpoint'
 require_relative '../app/helpers/configuration'
 require_relative '../app/sequence_base'
 require_relative '../app/models'
+require_relative '../app/utils/instance_config'
 
 include Inferno
 
@@ -328,19 +329,7 @@ namespace :inferno do |argv|
     client.use_dstu2 if instance.module.fhir_version == 'dstu2'
     client.default_json
 
-    config['arguments'].each do |key, val|
-      if instance.respond_to?(key)
-        if val.is_a?(Array) || val.is_a?(Hash)
-          instance.send("#{key.to_s}=", val.to_json) if instance.respond_to? key.to_s
-        elsif val.is_a?(String) && val.downcase == 'true'
-          instance.send("#{key.to_s}=", true) if instance.respond_to? key.to_s
-        elsif val.is_a?(String) && val.downcase == 'false'
-          instance.send("#{key.to_s}=", false) if instance.respond_to? key.to_s
-        else
-          instance.send("#{key.to_s}=", val) if instance.respond_to? key.to_s
-        end
-      end
-    end
+    configure_instance(instance, config['arguments'])
 
     sequences = config['sequences'].map do |sequence|
       sequence_name = sequence

--- a/presets/SMART_EHR_DSTU2.json
+++ b/presets/SMART_EHR_DSTU2.json
@@ -1,0 +1,24 @@
+{
+  "server": "https://portal.demo.syncfor.science/api/fhir",
+  "module": "onc",
+  "preset_name": "S4S Reference Server",
+  "arguments": {
+    "client_id": "test-suite",
+    "confidential_client": "true",
+    "client_secret": "demo-secret-s4s",
+    "scopes": "launch/patient patient/*.read offline_access",
+    "redirect_uris": "https://tests.demo.syncfor.science/authorized/",
+    "standalone_launch_script": [
+      {"cmd": "click", "type": "id", "find_value": "sign-in"},
+      {"cmd": "click", "type": "css", "find_value": "[data-patient-id=smart-1288992]"},
+      {"cmd": "click", "type": "css", "find_value": "[data-slide=next]", "index": 0},
+      {"cmd": "click", "type": "css", "find_value": "[rel=confirm]", "index": 0},
+      {"cmd": "click", "type": "css", "find_value": "[rel=confirm]", "index": 1},
+      {"cmd": "click", "type": "css", "find_value": "[rel=confirm]", "index": 2},
+      {"cmd": "click", "type": "css", "find_value": "[rel=confirm]", "index": 3},
+      {"cmd": "click", "type": "css", "find_value": "[rel=confirm]", "index": 4},
+      {"cmd": "click", "type": "css", "find_value": "[data-slide=next]", "index": 1},
+      {"cmd": "click", "type": "id", "find_value": "authorize"}
+    ]
+  }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -291,4 +291,11 @@ $(function(){
   // Then register the handler
   $(window).on('scroll', handleScroll)
 
+  $('#preset-select').on('change', function() {
+    var uri = $('#preset-select option:selected').data('uri');
+    $el = $('input[name=fhir_server]');
+    $el.val(uri);
+    $el.prop('readonly', uri !== '');
+  });
+
 }); 


### PR DESCRIPTION
Hi again,

I've put together a small example of some additional functionality that we need in a test suite for use at S4S: the ability to store configurations for vendors, and to complete the authorization process in an automated fashion. I've included a configuration file for the [S4S reference implementations](https://github.com/sync-for-science/reference-stack-docker). I've also made a few rough changes to get the headless Chrome instance running in the Docker container.

### Vendor configurations
Vendor configurations are the same format as the existing batch script configuration with the addition of an optional `preset_name` in the root object. I've stored these "presets" in a `presets/` directory. The directory is scanned for the configuration files, and a dropdown is added to the home page allowing the user to select one.

![image](https://user-images.githubusercontent.com/10468793/53353462-b9165380-38f2-11e9-93a4-fc995c251891.png)

When a preset is selected, Inferno populates the interface with the vendor's URI. Upon submission, the new testing instance will be populated with the data from the configuration.

![image](https://user-images.githubusercontent.com/10468793/53353504-e400a780-38f2-11e9-9327-2e4132c8338e.png)

The rest of the Inferno workflow is mostly unchanged, except for the registration and standalone launch sequences.

### Automated authentication
Since the testing instance now includes the `standalone_launch_script` from the configuration, Inferno automatically uses the script during the standalone launch sequence, requiring no input from the user.

---

If your team thinks this type of functionality is useful, S4S would be happy to collaborate further to refine and extend it. (This is my last week at S4S, but @jmandel and my eventual replacement will continue to work on adapting Inferno to meet our test suite needs!)