### PR TITLE
Test optional scope parameter in token refresh sequence

### DIFF
--- a/lib/app/modules/smart/token_refresh_sequence.rb
+++ b/lib/app/modules/smart/token_refresh_sequence.rb
@@ -132,6 +132,16 @@ module Inferno
           @instance.update(refresh_token: token_response_body['refresh_token'])
         end
 
+        warning do
+          # These should be required but due to a gap in the SMART App Launch Guide they are not currently required
+          # See https://github.com/HL7/smart-app-launch/issues/293
+          [:cache_control, :pragma].each do |key|
+            assert token_response.headers.key?(key), "Token response headers did not contain #{key} as is recommended for token exchanges."
+          end
+
+          assert token_response.headers[:cache_control].downcase.include?('no-store'), 'Token response header should have cache_control containing no-store.'
+          assert token_response.headers[:pragma].downcase.include?('no-cache'), 'Token response header should have pragma containing no-cache.'
+        end
       end
 
       test 'Server successfully refreshes the access token when optional scope parameter omitted.' do
@@ -144,6 +154,11 @@ module Inferno
 
             The EHR authorization server SHALL return a JSON structure that includes an access token or a message indicating that the authorization request has been denied.
             access_token, expires_in, token_type, and scope are required. access_token must be Bearer.
+
+            Although not required in the token refresh portion of the SMART App Launch Guide,
+            the token refresh response should include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache
+            to be consistent with the requirements of the inital access token exchange.
+
           )
         end
 
@@ -162,7 +177,11 @@ module Inferno
             the body of the request.
 
             The EHR authorization server SHALL return a JSON structure that includes an access token or a message indicating that the authorization request has been denied.
-            access_token, token_type, expires_in, and scope are required. access_token must be Bearer.
+            access_token, token_type, and scope are required. access_token must be Bearer.
+
+            Although not required in the token refresh portion of the SMART App Launch Guide,
+            the token refresh response should include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache
+            to be consistent with the requirements of the inital access token exchange.
           )
         end
 

--- a/lib/app/modules/smart/token_refresh_sequence.rb
+++ b/lib/app/modules/smart/token_refresh_sequence.rb
@@ -25,8 +25,6 @@ module Inferno
       This test attempt to exchange the refresh token for a new access token and verify that the information returned
       contains the required fields and uses the proper headers.
 
-      This test
-
       For more information see:
 
       * [The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)
@@ -160,7 +158,7 @@ module Inferno
 
       test 'Server successfully refreshes the access token when optional scope parameter provided.' do
         metadata do
-          id '05'
+          id '04'
           link 'https://tools.ietf.org/html/rfc6749'
           desc %(
             Server successfully exchanges refresh token at OAuth token endpoint while providing scope in

--- a/lib/app/modules/smart/token_refresh_sequence.rb
+++ b/lib/app/modules/smart/token_refresh_sequence.rb
@@ -22,7 +22,7 @@ module Inferno
 
       # Test Methodology
 
-      This test attempt to exchange the refresh token for a new access token and verify that the information returned
+      This test attempts to exchange the refresh token for a new access token and verify that the information returned
       contains the required fields and uses the proper headers.
 
       For more information see:
@@ -85,6 +85,10 @@ module Inferno
         assert_valid_json(token_response.body)
         token_response_body = JSON.parse(token_response.body)
 
+        # The minimum we need to 'progress' is the access token,
+        # so first just check and save access token, before validating rest of payload.
+        # This is done to make things easier for developers.
+
         assert token_response_body.key?('access_token'), 'Token response did not contain access_token as required'
 
         token_retrieved_at = DateTime.now
@@ -96,7 +100,7 @@ module Inferno
 
         @instance.update(token: token_response_body['access_token'], token_retrieved_at: token_retrieved_at)
 
-        ['token_type', 'scope'].each do |key|
+        ['expires_in', 'token_type', 'scope'].each do |key|
           assert token_response_body.key?(key), "Token response did not contain #{key} as required"
         end
 
@@ -127,12 +131,7 @@ module Inferno
           @instance.save!
           @instance.update(refresh_token: token_response_body['refresh_token'])
         end
-        [:cache_control, :pragma].each do |key|
-          assert token_response.headers.key?(key), "Token response headers did not contain #{key} as is required in the SMART App Launch Guide."
-        end
 
-        assert token_response.headers[:cache_control].downcase.include?('no-store'), 'Token response header must have cache_control containing no-store.'
-        assert token_response.headers[:pragma].downcase.include?('no-cache'), 'Token response header must have pragma containing no-cache.'
       end
 
       test 'Server successfully refreshes the access token when optional scope parameter omitted.' do
@@ -144,9 +143,7 @@ module Inferno
             the body of the request.
 
             The EHR authorization server SHALL return a JSON structure that includes an access token or a message indicating that the authorization request has been denied.
-            access_token, token_type, and scope are required. access_token must be Bearer.
-
-            The authorization servers response must include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache.
+            access_token, expires_in, token_type, and scope are required. access_token must be Bearer.
           )
         end
 
@@ -165,9 +162,7 @@ module Inferno
             the body of the request.
 
             The EHR authorization server SHALL return a JSON structure that includes an access token or a message indicating that the authorization request has been denied.
-            access_token, token_type, and scope are required. access_token must be Bearer.
-
-            The authorization servers response must include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache.
+            access_token, token_type, expires_in, and scope are required. access_token must be Bearer.
           )
         end
 

--- a/test/sequence/token_refresh_sequence_test.rb
+++ b/test/sequence/token_refresh_sequence_test.rb
@@ -45,11 +45,7 @@ class TokenRefreshSequenceTest < MiniTest::Test
 
     body_response_code = 200
 
-    body_with_scope = {
-      'grant_type' => 'refresh_token',
-      'refresh_token' => @instance.refresh_token,
-      'scope' => @instance.scopes
-    }
+    body_with_scope = body.merge('scope' => @instance.scopes)
 
     body_with_scope_response_code = 200
 

--- a/test/sequence/token_refresh_sequence_test.rb
+++ b/test/sequence/token_refresh_sequence_test.rb
@@ -7,18 +7,20 @@ require_relative '../test_helper'
 class TokenRefreshSequenceTest < MiniTest::Test
   def setup
     refresh_token = JSON::JWT.new(iss: 'foo_refresh')
-    @instance = Inferno::Models::TestingInstance.new(url: 'http://www.example.com',
-                                                     client_name: 'Inferno',
-                                                     base_url: 'http://localhost:4567',
-                                                     client_endpoint_key: Inferno::SecureRandomBase62.generate(32),
-                                                     client_id: SecureRandom.uuid,
-                                                     selected_module: 'argonaut',
-                                                     oauth_authorize_endpoint: 'http://oauth_reg.example.com/authorize',
-                                                     oauth_token_endpoint: 'http://oauth_reg.example.com/token',
-                                                     initiate_login_uri: 'http://localhost:4567/launch',
-                                                     redirect_uris: 'http://localhost:4567/redirect',
-                                                     scopes: 'launch openid patient/*.* profile',
-                                                     refresh_token: refresh_token)
+    @instance = Inferno::Models::TestingInstance.new(
+      url: 'http://www.example.com',
+      client_name: 'Inferno',
+      base_url: 'http://localhost:4567',
+      client_endpoint_key: Inferno::SecureRandomBase62.generate(32),
+      client_id: SecureRandom.uuid,
+      selected_module: 'argonaut',
+      oauth_authorize_endpoint: 'http://oauth_reg.example.com/authorize',
+      oauth_token_endpoint: 'http://oauth_reg.example.com/token',
+      initiate_login_uri: 'http://localhost:4567/launch',
+      redirect_uris: 'http://localhost:4567/redirect',
+      scopes: 'launch openid patient/*.* profile',
+      refresh_token: refresh_token
+    )
 
     @instance.save! # this is for convenience.  we could rewrite to ensure nothing gets saved within tests.
     client = FHIR::Client.new(@instance.url)
@@ -28,47 +30,41 @@ class TokenRefreshSequenceTest < MiniTest::Test
     @standalone_token_exchange = load_json_fixture(:standalone_token_exchange)
   end
 
-  def all_pass(confidential)
+  def setup_mocks
     WebMock.reset!
-    if confidential
-      # Responses Must Contain Authorization Header
-      stub_request(:post, @instance.oauth_token_endpoint)
-        .with(headers: { 'Content-Type' => 'application/x-www-form-urlencoded',
-                         'Authorization' =>
-                              "Basic #{Base64.strict_encode64(@instance.client_id +
-                                                                  ':' +
-                                                                  @instance.client_secret)}" },
-              body: { 'grant_type' => 'refresh_token',
-                      'refresh_token' => @instance.refresh_token })
-        .to_return(status: 200,
-                   body: @standalone_token_exchange.to_json,
-                   headers: { content_type: 'application/json; charset=UTF-8',
-                              cache_control: 'no-store',
-                              pragma: 'no-cache' })
 
-      # Responses must NOT contain client_id in the body or the client secret in any situation
-      stub_request(:post, @instance.oauth_token_endpoint)
-        .with(body: /client_id|client_secret/)
-        .to_return(status: 401)
+    headers = {
+      'Content-Type' => 'application/x-www-form-urlencoded',
+    }
+    body = {
+      'grant_type' => 'refresh_token',
+      'refresh_token' => @instance.refresh_token
+    }
+
+    if @instance.client_secret.present?
+      headers['Authorization'] = "Basic #{Base64.strict_encode64(@instance.client_id + ':' + @instance.client_secret)}"
     else
-      stub_request(:post, @instance.oauth_token_endpoint)
-        .with(headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-              body: { 'client_id' => @instance.client_id,
-                      'grant_type' => 'refresh_token',
-                      'refresh_token' => @instance.refresh_token })
-        .to_return(status: 200,
-                   body: @standalone_token_exchange.to_json,
-                   headers: { content_type: 'application/json; charset=UTF-8',
-                              cache_control: 'no-store',
-                              pragma: 'no-cache' })
+      body['client_id'] = @instance.client_id
     end
+
+    stub_request(:post, @instance.oauth_token_endpoint)
+      .with(headers: headers,
+            body: body)
+      .to_return(status: 200,
+                 body: @standalone_token_exchange.to_json,
+                 headers: { content_type: 'application/json; charset=UTF-8',
+                            cache_control: 'no-store',
+                            pragma: 'no-cache' })
 
     # To test rejection of invalid client_id
     stub_request(:post, @instance.oauth_token_endpoint)
       .with(body: /INVALID/,
             headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })
       .to_return(status: 401)
+  end
 
+  def all_pass
+    setup_mocks
     sequence_result = @sequence.start
 
     assert sequence_result.pass?, 'The sequence should be marked as pass.'
@@ -77,12 +73,12 @@ class TokenRefreshSequenceTest < MiniTest::Test
   def test_all_pass_confidential_client
     @instance.client_secret = SecureRandom.uuid
     @instance.confidential_client = true
-    all_pass(true)
+    all_pass
   end
 
   def test_all_pass_public_client
     @instance.client_secret = nil
     @instance.confidential_client = nil
-    all_pass(false)
+    all_pass
   end
 end

--- a/test/sequence/token_refresh_sequence_test.rb
+++ b/test/sequence/token_refresh_sequence_test.rb
@@ -18,7 +18,7 @@ class TokenRefreshSequenceTest < MiniTest::Test
       oauth_token_endpoint: 'http://oauth_reg.example.com/token',
       initiate_login_uri: 'http://localhost:4567/launch',
       redirect_uris: 'http://localhost:4567/redirect',
-      scopes: 'launch openid patient/*.* profile',
+      scopes: 'launch/patient online_access openid profile launch user/*.* patient/*.*',
       refresh_token: refresh_token
     )
 
@@ -28,38 +28,73 @@ class TokenRefreshSequenceTest < MiniTest::Test
     client.default_json
     @sequence = Inferno::Sequence::TokenRefreshSequence.new(@instance, client, true)
     @standalone_token_exchange = load_json_fixture(:standalone_token_exchange)
+    @confidential_client_secret = SecureRandom.uuid
   end
 
-  def setup_mocks
+  def setup_mocks(failure_mode = nil)
     WebMock.reset!
 
     headers = {
-      'Content-Type' => 'application/x-www-form-urlencoded',
+      'Content-Type' => 'application/x-www-form-urlencoded'
     }
     body = {
       'grant_type' => 'refresh_token',
       'refresh_token' => @instance.refresh_token
     }
 
+    body_with_scope = {
+      'grant_type' => 'refresh_token',
+      'refresh_token' => @instance.refresh_token,
+      'scope' => @instance.scopes
+    }
+
+    exchange_response = @standalone_token_exchange.dup
+
+    exchange_response['token_type'] = 'unknown' if failure_mode == :bad_token_type
+    exchange_response.delete('scope') if failure_mode == :no_scope
+    exchange_response.delete('access_token') if failure_mode == :no_access_token
+
     if @instance.client_secret.present?
       headers['Authorization'] = "Basic #{Base64.strict_encode64(@instance.client_id + ':' + @instance.client_secret)}"
     else
-      body['client_id'] = @instance.client_id
+      body['client_id'] = body_with_scope['client_id'] = @instance.client_id
     end
+
+    response_headers = { content_type: 'application/json; charset=UTF-8',
+                         cache_control: 'no-store',
+                         pragma: 'no-cache' }
+
+    response_headers.delete(:cache_control) if failure_mode == :cache_control_off
+    response_headers.delete(:pragma) if failure_mode == :pragma_off
+
+    exchange_response_json = exchange_response.to_json
+    exchange_response_json = '<bad>' if failure_mode == :bad_json_response
 
     stub_request(:post, @instance.oauth_token_endpoint)
       .with(headers: headers,
             body: body)
-      .to_return(status: 200,
-                 body: @standalone_token_exchange.to_json,
-                 headers: { content_type: 'application/json; charset=UTF-8',
-                            cache_control: 'no-store',
-                            pragma: 'no-cache' })
+      .to_return(status: failure_mode == :requires_scope ? 400 : 200,
+                 body: exchange_response_json,
+                 headers: response_headers)
 
-    # To test rejection of invalid client_id
+    stub_request(:post, @instance.oauth_token_endpoint)
+      .with(headers: headers,
+            body: body_with_scope)
+      .to_return(status: 200,
+                 body: exchange_response_json,
+                 headers: response_headers)
+
+    # To test rejection of invalid client_id for public client
     stub_request(:post, @instance.oauth_token_endpoint)
       .with(body: /INVALID/,
             headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })
+      .to_return(status: 401)
+
+    # To test rejection of invalid client_id for confidential client
+    auth_header = "Basic #{Base64.strict_encode64('INVALID_CLIENT_ID:' + @confidential_client_secret)}"
+    stub_request(:post, @instance.oauth_token_endpoint)
+      .with(headers: { 'Content-Type' => 'application/x-www-form-urlencoded',
+                       'Authorization' => auth_header })
       .to_return(status: 401)
   end
 
@@ -71,14 +106,63 @@ class TokenRefreshSequenceTest < MiniTest::Test
   end
 
   def test_all_pass_confidential_client
-    @instance.client_secret = SecureRandom.uuid
+    @instance.client_secret = @confidential_client_secret
     @instance.confidential_client = true
     all_pass
   end
 
   def test_all_pass_public_client
     @instance.client_secret = nil
-    @instance.confidential_client = nil
+    @instance.confidential_client = false
     all_pass
+  end
+
+  def test_fail_if_bad_token_type
+    setup_mocks(:bad_token_type)
+
+    sequence_result = @sequence.start
+    assert sequence_result.fail?
+  end
+
+  def test_fail_if_cache_control_off
+    setup_mocks(:cache_control_off)
+
+    sequence_result = @sequence.start
+    assert sequence_result.fail?
+  end
+
+  def test_fail_if_pragma_off
+    setup_mocks(:pragma_off)
+
+    sequence_result = @sequence.start
+    assert sequence_result.fail?
+  end
+
+  def test_fail_if_no_scope_returned
+    setup_mocks(:no_scope)
+
+    sequence_result = @sequence.start
+    assert sequence_result.fail?
+  end
+
+  def test_fail_if_no_access_token
+    setup_mocks(:no_access_token)
+
+    sequence_result = @sequence.start
+    assert sequence_result.fail?
+  end
+
+  def test_fail_if_bad_json_response
+    setup_mocks(:bad_json_response)
+
+    sequence_result = @sequence.start
+    assert sequence_result.fail?
+  end
+
+  def test_fail_if_scope_must_be_in_payload
+    setup_mocks(:requires_scope)
+
+    sequence_result = @sequence.start
+    assert sequence_result.fail?
   end
 end

--- a/test/sequence/token_refresh_sequence_test.rb
+++ b/test/sequence/token_refresh_sequence_test.rb
@@ -120,7 +120,8 @@ class TokenRefreshSequenceTest < MiniTest::Test
     setup_mocks
     sequence_result = @sequence.start
 
-    assert sequence_result.pass?, 'The sequence should be marked as pass.'
+    assert sequence_result.pass?
+    assert(sequence_result.test_results.none? { |result| result.test_warnings.present? })
   end
 
   def test_pass_if_confidential_client
@@ -137,19 +138,22 @@ class TokenRefreshSequenceTest < MiniTest::Test
 
   # Initial token exchange requires cache control and pragma headers
   # But token exchange does not according to the letter of the smart spec
-  # Check that the next two tests pass
-  def test_pass_if_cache_control_off
+  # This may be updated in future versions of the spec
+  # See https://github.com/HL7/smart-app-launch/issues/293
+  def test_warning_if_cache_control_off
     setup_mocks(:cache_control_off)
 
     sequence_result = @sequence.start
     assert sequence_result.pass?
+    assert(sequence_result.test_results.any? { |result| result.test_warnings.present? })
   end
 
-  def test_pass_if_pragma_off
+  def test_warning_if_pragma_off
     setup_mocks(:pragma_off)
 
     sequence_result = @sequence.start
     assert sequence_result.pass?
+    assert(sequence_result.test_results.any? { |result| result.test_warnings.present? })
   end
 
   def test_fail_if_bad_token_type


### PR DESCRIPTION
Addresses #246 which was a request for improved testing on our token refresh.  We also made a number of changes, including:
* Condensed what used to be three tests into a single test, because we needed to duplicate that single test to handle multiple cases.  It was far too repetitive to keep the same test structure.
* Identified a number of minor issues in the SMART spec that went unnoticed earlier.  We had to change some of our tests to accommodate that (noted in the referenced issue).
* Significantly bulked up our self testing

You can try out these changes by executing out the refresh token sequence on any server