### PR TITLE
Make authorization search params the same as first search

### DIFF
--- a/generators/uscore-r4/generator.rb
+++ b/generators/uscore-r4/generator.rb
@@ -80,7 +80,7 @@ def create_authorization_test(sequence)
   }
 
   first_search = sequence[:searches].select { |search_param| search_param[:expectation] == 'SHALL' }.first ||
-                 sequence[:searches].select { |search_param| search_param[:expectation] == 'SHOULD' }.first
+                 sequence[:searches].find { |search_param| search_param[:expectation] == 'SHOULD' }
   return if first_search.nil?
 
   authorization_test[:test_code] = %(

--- a/generators/uscore-r4/generator.rb
+++ b/generators/uscore-r4/generator.rb
@@ -79,7 +79,7 @@ def create_authorization_test(sequence)
     link: 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
   }
 
-  first_search = sequence[:searches].select { |search_param| search_param[:expectation] == 'SHALL' }.first ||
+  first_search = sequence[:searches].find { |search_param| search_param[:expectation] == 'SHALL' } ||
                  sequence[:searches].find { |search_param| search_param[:expectation] == 'SHOULD' }
   return if first_search.nil?
 

--- a/generators/uscore-r4/generator.rb
+++ b/generators/uscore-r4/generator.rb
@@ -79,11 +79,15 @@ def create_authorization_test(sequence)
     link: 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
   }
 
+  first_search = sequence[:searches].select { |search_param| search_param[:expectation] == 'SHALL' }.first ||
+                 sequence[:searches].select { |search_param| search_param[:expectation] == 'SHOULD' }.first
+  return if first_search.nil?
+
   authorization_test[:test_code] = %(
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
-
-        reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), patient: @instance.patient_id)
+#{get_search_params(first_search[:names], sequence)}
+        reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply)
 

--- a/generators/uscore-r4/metadata_extractor.rb
+++ b/generators/uscore-r4/metadata_extractor.rb
@@ -2,7 +2,6 @@
 
 class MetadataExtractor
   CAPABILITY_STATEMENT_URI = 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.json'
-  OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 
   def profile_uri(profile)
     "https://build.fhir.org/ig/HL7/US-Core-R4/StructureDefinition-#{profile}.json"

--- a/lib/app/modules/us_core_r4/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/us_core_r4/pediatric_bmi_for_age_sequence.rb
@@ -59,7 +59,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, code: '59576-9' }
+
+        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/us_core_r4/pediatric_weight_for_height_sequence.rb
@@ -59,7 +59,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, code: '77606-2' }
+
+        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_allergyintolerance_sequence.rb
@@ -49,7 +49,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_careplan_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_careplan_sequence.rb
@@ -54,7 +54,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('CarePlan'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, category: 'assess-plan' }
+
+        reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_careteam_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_careteam_sequence.rb
@@ -47,7 +47,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('CareTeam'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, status: 'active' }
+
+        reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_condition_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_condition_sequence.rb
@@ -61,7 +61,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Condition'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_device_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_device_sequence.rb
@@ -49,7 +49,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Device'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_diagnosticreport_lab_sequence.rb
@@ -59,7 +59,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, category: 'LAB' }
+
+        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_diagnosticreport_note_sequence.rb
@@ -59,7 +59,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, code: 'LP29684-5' }
+
+        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_documentreference_sequence.rb
@@ -64,7 +64,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('DocumentReference'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_encounter_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_encounter_sequence.rb
@@ -63,7 +63,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Encounter'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('Encounter'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_goal_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_goal_sequence.rb
@@ -49,7 +49,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Goal'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_immunization_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_immunization_sequence.rb
@@ -49,7 +49,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Immunization'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_location_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_location_sequence.rb
@@ -55,7 +55,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Location'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, name: 'Boston' }
+
+        reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_medication_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_medication_sequence.rb
@@ -23,26 +23,9 @@ module Inferno
 
       @resources_found = false
 
-      test 'Server rejects Medication search without authorization' do
-        metadata do
-          id '01'
-          link 'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
-          desc %(
-          )
-          versions :r4
-        end
-
-        @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
-
-        reply = get_resource_by_params(versioned_resource_class('Medication'), patient: @instance.patient_id)
-        @client.set_bearer_token(@instance.token)
-        assert_response_unauthorized reply
-      end
-
       test 'Medication read resource supported' do
         metadata do
-          id '02'
+          id '01'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           desc %(
           )
@@ -57,7 +40,7 @@ module Inferno
 
       test 'Medication vread resource supported' do
         metadata do
-          id '03'
+          id '02'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           desc %(
           )
@@ -72,7 +55,7 @@ module Inferno
 
       test 'Medication history resource supported' do
         metadata do
-          id '04'
+          id '03'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           desc %(
           )
@@ -87,7 +70,7 @@ module Inferno
 
       test 'Medication resources associated with Patient conform to US Core R4 profiles' do
         metadata do
-          id '05'
+          id '04'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/StructureDefinition-us-core-medication.json'
           desc %(
           )
@@ -100,7 +83,7 @@ module Inferno
 
       test 'At least one of every must support element is provided in any Medication for this patient.' do
         metadata do
-          id '06'
+          id '05'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/general-guidance.html/#must-support'
           desc %(
           )
@@ -127,7 +110,7 @@ module Inferno
 
       test 'All references can be resolved' do
         metadata do
-          id '07'
+          id '06'
           link 'https://www.hl7.org/fhir/DSTU2/references.html'
           desc %(
           )

--- a/lib/app/modules/us_core_r4/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_medicationrequest_sequence.rb
@@ -49,7 +49,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_medicationstatement_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_medicationstatement_sequence.rb
@@ -49,7 +49,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('MedicationStatement'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('MedicationStatement'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_observation_lab_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_observation_lab_sequence.rb
@@ -59,7 +59,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, category: 'laboratory' }
+
+        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_organization_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_organization_sequence.rb
@@ -46,7 +46,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Organization'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, name: 'Boston' }
+
+        reply = get_resource_by_params(versioned_resource_class('Organization'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_patient_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_patient_sequence.rb
@@ -67,7 +67,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Patient'), patient: @instance.patient_id)
+        search_params = { '_id': @instance.patient_id }
+
+        reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_practitioner_sequence.rb
@@ -53,7 +53,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Practitioner'), patient: @instance.patient_id)
+        name_val = @practitioner&.name&.first&.family
+        search_params = { 'name': name_val }
+
+        reply = get_resource_by_params(versioned_resource_class('Practitioner'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_practitionerrole_sequence.rb
@@ -49,7 +49,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), patient: @instance.patient_id)
+        specialty_val = @practitionerrole&.specialty&.coding&.first&.code
+        search_params = { 'specialty': specialty_val }
+
+        reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_procedure_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_procedure_sequence.rb
@@ -54,7 +54,10 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Procedure'), patient: @instance.patient_id)
+        patient_val = @instance.patient_id
+        search_params = { 'patient': patient_val }
+
+        reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end

--- a/lib/app/modules/us_core_r4/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/us_core_r4/us_core_smokingstatus_sequence.rb
@@ -59,7 +59,9 @@ module Inferno
         @client.set_no_auth
         skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), patient: @instance.patient_id)
+        search_params = { patient: @instance.patient_id, code: '72166-2' }
+
+        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply
       end


### PR DESCRIPTION
FI-288

This PR sets the search parameters of the authorization tests to be the same as the first search's parameters. If there are no searches, then we won't do the authorization test. 