### PR TITLE
Save R4 resources from the conformance statement

### DIFF
--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -163,6 +163,7 @@ module Inferno
         resources = ['Patient',
                      'AllergyIntolerance',
                      'CarePlan',
+                     'CareTeam',
                      'Condition',
                      'Device',
                      'DiagnosticReport',
@@ -171,14 +172,19 @@ module Inferno
                      'ExplanationOfBenefit',
                      'Goal',
                      'Immunization',
+                     'Location',
                      'Medication',
                      'MedicationDispense',
                      'MedicationStatement',
+                     'MedicationRequest',
                      'MedicationOrder',
                      'Observation',
+                     'Organization',
                      'Procedure',
                      'DocumentReference',
-                     'Provenance']
+                     'Provenance',
+                     'Practitioner',
+                     'PractitionerRole']
 
         supported_resource_capabilities =
           conformance


### PR DESCRIPTION
FI-266
Added R4 resources so that they are saved from reading the conformance statement. 

To test this, run the MedicationRequest sequence in HSPC. It should now run the read, vread, and history tests. 