### PR TITLE
added a rubocop config file for windows to allow windows users to run…

### DIFF
--- a/.rubocop-windows.yml
+++ b/.rubocop-windows.yml
@@ -1,0 +1,4 @@
+inherit_from: .rubocop.yml
+
+Layout/EndOfLine:
+  EnforcedStyle: crlf


### PR DESCRIPTION
Added rubocop config file that windows users can run locally to avoid rubocop complaints of carriage returns.  This file merely inherits from the .rubocop.yml so it does not need to be updated separately