### PR TITLE
FI-273: Refactor OAuth2 endpoints 

### DIFF
--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -45,7 +45,7 @@ module Inferno
           end
 
           get '/oauth2/:key/launch/?' do
-            @instance = Inferno::Models::SequenceResult.recent_results_for_iss(params[:iss]).testing_instance
+            @instance = Inferno::Models::SequenceResult.recent_results_for_iss(params[:iss])&.testing_instance
             pass if @instance.present?
 
             @instance = Inferno::Models::TestingInstance.get(instance_id_from_cookie)

--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -8,67 +8,69 @@ module Inferno
           # Resume oauth2 flow
           # This must be early so it doesn't get picked up by the other routes
           get '/oauth2/:key/:endpoint/?' do
-            instance = nil
-            error_message = nil
-
             if params[:endpoint] == 'redirect'
-              instance = Inferno::Models::TestingInstance.first(state: params[:state])
-              if instance.nil?
-                instance = Inferno::Models::TestingInstance.get(cookies[:instance_id_test_set]&.split('/')&.first)
-                if instance.nil?
-                  error_message = %(
-                               <p>
-                                  Inferno has detected an issue with the SMART launch.
-                                  No actively running launch sequences found with a state of #{params[:state]}.
-                                  The authorization server is not returning the correct state variable and
-                                  therefore Inferno cannot identify which server is currently under test.
-                                  Please click your browser's "Back" button to return to Inferno,
-                                  and click "Refresh" to ensure that the most recent test results are visible.
-                                </p>
-                                )
+              @instance = Inferno::Models::TestingInstance.first(state: params[:state])
+              if @instance.nil?
+                @instance = Inferno::Models::TestingInstance.get(cookies[:instance_id_test_set]&.split('/')&.first)
+                if @instance.nil?
+                  message = %(
+                             <p>
+                               Inferno has detected an issue with the SMART launch.
+                               No actively running launch sequences found with a state of #{params[:state]}.
+                               The authorization server is not returning the correct state variable and
+                               therefore Inferno cannot identify which server is currently under test.
+                               Please click your browser's "Back" button to return to Inferno,
+                               and click "Refresh" to ensure that the most recent test results are visible.
+                             </p>
+                             )
 
-                  error_message += "<p>Error returned by server: <strong>#{params[:error]}</strong>.</p>" if params[:error].present?
+                  message += "<p>Error returned by server: <strong>#{params[:error]}</strong>.</p>" if params[:error].present?
 
-                  error_message += "<p>Error description returned by server: <strong>#{params[:error_description]}</strong>.</p>" unless params[:error_description].nil?
+                  message += "<p>Error description returned by server: <strong>#{params[:error_description]}</strong>.</p>" unless params[:error_description].nil?
 
-                  halt 500, error_message
-                elsif instance&.waiting_on_sequence&.wait?
-                  error_message = "State provided in redirect (#{params[:state]}) does not match expected state (#{instance.state})."
+                  halt 500, message
+                elsif @instance&.waiting_on_sequence&.wait?
+                  @error_message = "State provided in redirect (#{params[:state]}) does not match expected state (#{@instance.state})."
                 else
                   redirect "#{base_path}/#{cookies[:instance_id_test_set]}/?error=no_state&state=#{params[:state]}"
                 end
               end
             end
+            pass
+          end
 
-            if params[:endpoint] == 'launch'
-              instance = Inferno::Models::SequenceResult.recent_results_for_iss(params[:iss]).testing_instance
-              if instance.nil?
-                instance = Inferno::Models::TestingInstance.get(cookies[:instance_id_test_set]&.split('/')&.first)
-                if instance.nil?
-                  message = "Error: No actively running launch sequences found for iss #{params[:iss]}. " \
-                            'Please ensure that the EHR launch test is actively running before attempting to launch Inferno from the EHR.'
-                  halt 500, message
-                elsif instance.waiting_on_sequence&.wait?
-                  error_message = 'No iss for redirect'
-                else
-                  redirect "#{base_path}/#{cookies[:instance_id_test_set]}/?error=no_ehr_launch&iss=#{params[:iss]}"
-                end
+          get '/oauth2/:key/launch/?' do
+            @instance = Inferno::Models::SequenceResult.recent_results_for_iss(params[:iss]).testing_instance
+            if @instance.nil?
+              @instance = Inferno::Models::TestingInstance.get(cookies[:instance_id_test_set]&.split('/')&.first)
+              if @instance.nil?
+                message = "Error: No actively running launch sequences found for iss #{params[:iss]}. " \
+                          'Please ensure that the EHR launch test is actively running before attempting to launch Inferno from the EHR.'
+                halt 500, message
+              elsif @instance.waiting_on_sequence&.wait?
+                @error_message = 'No iss for redirect'
+              else
+                redirect "#{base_path}/#{cookies[:instance_id_test_set]}/?error=no_ehr_launch&iss=#{params[:iss]}"
               end
             end
-            halt 500, 'Error: Could not find a running test that match this set of criteria' unless !instance.nil? &&
-                                                                                                    instance.client_endpoint_key == params[:key] &&
+            pass
+          end
+
+          get '/oauth2/:key/:endpoint/?' do
+            halt 500, 'Error: Could not find a running test that match this set of criteria' unless !@instance.nil? &&
+                                                                                                    @instance.client_endpoint_key == params[:key] &&
                                                                                                     %w[launch redirect].include?(params[:endpoint])
 
-            sequence_result = instance.waiting_on_sequence
+            sequence_result = @instance.waiting_on_sequence
             if sequence_result&.wait?
-              test_set = instance.module.test_sets[sequence_result.test_set_id.to_sym]
+              test_set = @instance.module.test_sets[sequence_result.test_set_id.to_sym]
               failed_test_cases = []
               all_test_cases = []
               test_case = test_set.test_case_by_id(sequence_result.test_case_id)
               test_group = test_case.test_group
 
-              client = FHIR::Client.new(instance.url)
-              case instance.fhir_version
+              client = FHIR::Client.new(@instance.url)
+              case @instance.fhir_version
               when 'stu3'
                 client.use_stu3
               when 'dstu2'
@@ -77,7 +79,7 @@ module Inferno
                 client.use_r4
               end
               client.default_json
-              sequence = test_case.sequence.new(instance, client, settings.disable_tls_tests, sequence_result)
+              sequence = test_case.sequence.new(@instance, client, settings.disable_tls_tests, sequence_result)
               first_test_count = sequence.test_count
 
               timer_count = 0
@@ -93,11 +95,11 @@ module Inferno
 
                 # finish the inprocess stream
 
-                out << erb(instance.module.view_by_test_set(test_set.id),
+                out << erb(@instance.module.view_by_test_set(test_set.id),
                            {},
-                           instance: instance,
+                           instance: @instance,
                            test_set: test_set,
-                           sequence_results: instance.latest_results_by_case,
+                           sequence_results: @instance.latest_results_by_case,
                            tests_running: true,
                            test_group: test_group.id)
 
@@ -111,22 +113,22 @@ module Inferno
                   total + sequence_test_count
                 end
 
-                sequence_result = sequence.resume(request, headers, request.params, error_message) do |result|
+                sequence_result = sequence.resume(request, headers, request.params, @error_message) do |result|
                   count += 1
                   out << js_update_result(sequence, test_set, result, count, sequence.test_count, count, total_tests)
-                  instance.save!
+                  @instance.save!
                 end
                 all_test_cases << test_case.id
                 failed_test_cases << test_case.id if sequence_result.fail?
-                instance.sequence_results.push(sequence_result)
-                instance.save!
+                @instance.sequence_results.push(sequence_result)
+                @instance.save!
 
                 submitted_test_cases = sequence_result.next_test_cases.split(',')
 
                 next_test_case = submitted_test_cases.shift
                 finished = next_test_case.nil?
                 if sequence_result.redirect_to_url
-                  out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result, instance)
+                  out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result, @instance)
                   next_test_case = nil
                   finished = false
                 elsif !submitted_test_cases.empty?
@@ -149,8 +151,8 @@ module Inferno
 
                   out << js_show_test_modal
 
-                  instance.reload # ensure that we have all the latest data
-                  sequence = test_case.sequence.new(instance, client, settings.disable_tls_tests)
+                  @instance.reload # ensure that we have all the latest data
+                  sequence = test_case.sequence.new(@instance, client, settings.disable_tls_tests)
                   count = 0
                   sequence_result = sequence.start do |result|
                     test_count += 1
@@ -167,7 +169,7 @@ module Inferno
 
                   sequence_result.save!
                   if sequence_result.redirect_to_url
-                    out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result, instance)
+                    out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result, @instance)
                     finished = false
                   elsif !submitted_test_cases.empty?
                     out << js_next_sequence(sequence_result.next_test_cases)
@@ -181,12 +183,12 @@ module Inferno
 
                 query_target = "#{test_group.id}/#{query_target}" unless test_group.nil?
 
-                out << js_redirect("#{base_path}/#{instance.id}/test_sets/#{test_set.id}/##{query_target}") if finished
+                out << js_redirect("#{base_path}/#{@instance.id}/test_sets/#{test_set.id}/##{query_target}") if finished
               end
             else
-              latest_sequence_result = Inferno::Models::SequenceResult.first(testing_instance: instance)
-              test_set_id = latest_sequence_result&.test_set_id || instance.module.default_test_set
-              redirect "#{BASE_PATH}/#{instance.id}/test_sets/#{test_set_id}/?error=no_#{params[:endpoint]}"
+              latest_sequence_result = Inferno::Models::SequenceResult.first(testing_instance: @instance)
+              test_set_id = latest_sequence_result&.test_set_id || @instance.module.default_test_set
+              redirect "#{BASE_PATH}/#{@instance.id}/test_sets/#{test_set_id}/?error=no_#{params[:endpoint]}"
             end
           end
         end

--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -69,16 +69,7 @@ module Inferno
               test_case = test_set.test_case_by_id(sequence_result.test_case_id)
               test_group = test_case.test_group
 
-              client = FHIR::Client.new(@instance.url)
-              case @instance.fhir_version
-              when 'stu3'
-                client.use_stu3
-              when 'dstu2'
-                client.use_dstu2
-              else
-                client.use_r4
-              end
-              client.default_json
+              client = FHIR::Client.for_testing_instance(@instance)
               sequence = test_case.sequence.new(@instance, client, settings.disable_tls_tests, sequence_result)
               first_test_count = sequence.test_count
 

--- a/lib/app/endpoint/test_set_endpoints.rb
+++ b/lib/app/endpoint/test_set_endpoints.rb
@@ -124,16 +124,7 @@ module Inferno
 
             instance.save!
 
-            client = FHIR::Client.new(instance.url)
-            case instance.fhir_version
-            when 'stu3'
-              client.use_stu3
-            when 'dstu2'
-              client.use_dstu2
-            else
-              client.use_r4
-            end
-            client.default_json
+            client = FHIR::Client.for_testing_instance(instance)
             submitted_test_cases = params[:test_case].split(',')
 
             instance.reload # ensure that we have all the latest data

--- a/lib/app/ext/fhir_client.rb
+++ b/lib/app/ext/fhir_client.rb
@@ -26,5 +26,19 @@ module FHIR
         RUBY
       end
     end
+
+    def self.for_testing_instance(instance)
+      new(instance.url).tap do |client|
+        case instance.fhir_version
+        when 'stu3'
+          client.use_stu3
+        when 'dstu2'
+          client.use_dstu2
+        else
+          client.use_r4
+        end
+        client.default_json
+      end
+    end
   end
 end

--- a/lib/app/models/sequence_result.rb
+++ b/lib/app/models/sequence_result.rb
@@ -46,11 +46,6 @@ module Inferno
         ).find { |result| normalize_url(result.testing_instance.url) == normalize_url(iss) }
       end
 
-      # TODO: find this a home
-      def self.normalize_url(url)
-        url&.downcase&.split('://')&.last&.chomp('/')
-      end
-
       def failures
         test_results.select(&:fail?)
       end
@@ -105,6 +100,11 @@ module Inferno
           end
         end
       end
+
+      def self.normalize_url(url)
+        url&.downcase&.split('://')&.last&.chomp('/')
+      end
+      private_class_method :normalize_url
     end
   end
 end

--- a/lib/app/models/sequence_result.rb
+++ b/lib/app/models/sequence_result.rb
@@ -38,6 +38,19 @@ module Inferno
       has n, :test_results, order: [:test_index.asc]
       belongs_to :testing_instance
 
+      def self.recent_results_for_iss(iss)
+        all(
+          :created_at.gte => 5.minutes.ago,
+          :result => 'wait',
+          :order => [:created_at.desc]
+        ).find { |result| normalize_url(result.testing_instance.url) == normalize_url(iss) }
+      end
+
+      # TODO: find this a home
+      def self.normalize_url(url)
+        url&.downcase&.split('://')&.last&.chomp('/')
+      end
+
       def failures
         test_results.select(&:fail?)
       end

--- a/lib/app/utils/oauth2_error_messages.rb
+++ b/lib/app/utils/oauth2_error_messages.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Inferno
+  class App
+    module OAuth2ErrorMessages
+      def no_instance_for_state_error_message
+        %(
+          <p>
+            Inferno has detected an issue with the SMART launch.
+            No actively running launch sequences found with a state of #{params[:state]}.
+            The authorization server is not returning the correct state variable and
+            therefore Inferno cannot identify which server is currently under test.
+            Please click your browser's "Back" button to return to Inferno,
+            and click "Refresh" to ensure that the most recent test results are visible.
+          </p>
+          #{server_error_message}
+          #{server_error_description}
+        )
+      end
+
+      def server_error_message
+        return '' if params[:error].blank?
+
+        "<p>Error returned by server: <strong>#{params[:error]}</strong>.</p>"
+      end
+
+      def server_error_description
+        return '' if params[:error_description].blank?
+
+        "<p>Error description returned by server: <strong>#{params[:error_description]}</strong>.</p>"
+      end
+
+      def bad_state_error_message
+        "State provided in redirect (#{params[:state]}) does not match expected state (#{@instance.state})."
+      end
+
+      def no_instance_for_iss_error_message
+        %(
+          Error: No actively running launch sequences found for iss #{params[:iss]}.
+          Please ensure that the EHR launch test is actively running before attempting to launch Inferno from the EHR.
+        )
+      end
+
+      def no_iss_error_message
+        'No iss for redirect'
+      end
+
+      def no_running_test_error_message
+        'Error: Could not find a running test that matches this set of criteria'
+      end
+    end
+  end
+end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -41,18 +41,7 @@ def print_requests(result)
 end
 
 def execute(instance, sequences)
-  client = FHIR::Client.new(instance.url)
-
-  case instance.module.fhir_version
-  when 'stu3'
-    client.use_stu3
-  when 'dstu2'
-    client.use_dstu2
-  else
-    client.use_r4
-  end
-
-  client.default_json
+  client = FHIR::Client.for_testing_instance(instance)
 
   sequence_results = []
 

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -126,7 +126,8 @@ class OAuth2EndpointsTest < MiniTest::Test
   end
 
   def test_redirect_response_success
-    instance = create_testing_instance(state: 'abc123')
+    state = SecureRandom.uuid
+    instance = create_testing_instance(state: state)
     sequence_result = create_sequence_result(
       testing_instance: instance,
       wait_at_endpoint: 'redirect'
@@ -136,7 +137,7 @@ class OAuth2EndpointsTest < MiniTest::Test
     )
 
     EventMachine.run do
-      get '/inferno/oauth2/static/redirect?state=abc123'
+      get "/inferno/oauth2/static/redirect?state=#{state}"
 
       assert last_response.ok?
 
@@ -162,7 +163,8 @@ class OAuth2EndpointsTest < MiniTest::Test
   end
 
   def test_redirect_response_bad_state
-    instance = create_testing_instance(state: '123')
+    state = SecureRandom.uuid
+    instance = create_testing_instance(state: state)
     sequence_result = create_sequence_result(
       testing_instance: instance,
       wait_at_endpoint: 'redirect'
@@ -173,7 +175,7 @@ class OAuth2EndpointsTest < MiniTest::Test
 
     EventMachine.run do
       cookies = { 'HTTP_COOKIE' => "instance_id_test_set=#{instance.id}/" }
-      get '/inferno/oauth2/static/redirect?state=abc', {}, cookies
+      get "/inferno/oauth2/static/redirect?state=#{state}x", {}, cookies
 
       assert last_response.ok?
 
@@ -188,7 +190,8 @@ class OAuth2EndpointsTest < MiniTest::Test
   end
 
   def test_redirect_response_not_waiting
-    instance = create_testing_instance(state: 'abc123')
+    state = SecureRandom.uuid
+    instance = create_testing_instance(state: state)
     sequence_result = create_sequence_result(
       testing_instance: instance,
       result: 'pass'
@@ -199,7 +202,7 @@ class OAuth2EndpointsTest < MiniTest::Test
 
     EventMachine.run do
       cookies = { 'HTTP_COOKIE' => "instance_id_test_set=#{instance.id}/" }
-      get '/inferno/oauth2/static/redirect?state=xyz', {}, cookies
+      get "/inferno/oauth2/static/redirect?state=#{state}x", {}, cookies
 
       assert last_response.redirect?
       assert last_response.headers['Location'].include? '?error=no_state'

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -63,6 +63,21 @@ class OAuth2EndpointsTest < MiniTest::Test
     end
   end
 
+  def test_launch_response_not_running
+    create_testing_instance
+
+    EventMachine.run do
+      bad_iss = 'http://example.com/UNKNOWN_ISS'
+      get "/inferno/oauth2/static/launch?iss=#{bad_iss}"
+
+      assert last_response.status == 500
+
+      expected_error_message = "Error: No actively running launch sequences found for iss #{bad_iss}"
+      assert last_response.body.include? expected_error_message
+      break
+    end
+  end
+
   def test_redirect_response_success
     instance = create_testing_instance(state: 'abc123')
     sequence_result = create_sequence_result(
@@ -84,8 +99,18 @@ class OAuth2EndpointsTest < MiniTest::Test
     end
   end
 
-  def test_404_page
-    get '/asdfasdf'
-    assert last_response.not_found?
+  def test_redirect_response_not_running
+    create_testing_instance
+
+    EventMachine.run do
+      bad_state = 'xyz'
+      get "/inferno/oauth2/static/redirect?state=#{bad_state}"
+
+      assert last_response.status == 500
+
+      expected_error_message = "No actively running launch sequences found with a state of #{bad_state}"
+      assert last_response.body.include? expected_error_message
+      break
+    end
   end
 end

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -3,7 +3,7 @@
 require File.expand_path '../test_helper.rb', __dir__
 require 'eventmachine'
 
-class HomePageTest < MiniTest::Test
+class OAuth2EndpointsTest < MiniTest::Test
   include Rack::Test::Methods
   include Inferno::App::Helpers::BrowserLogic
 
@@ -15,62 +15,71 @@ class HomePageTest < MiniTest::Test
     Inferno::App.new
   end
 
-  def setup
-    WebMock.disable_net_connect!
-    # stub_request(:any, 'http://example.com/')
-  end
-
-  def test_launch_response_success
-    instance = Inferno::Models::TestingInstance.create(
+  def create_testing_instance(params = {})
+    default_params = {
       url: 'http://example.com',
       client_endpoint_key: 'static',
       selected_module: 'smart',
       initiate_login_uri: '/login'
-    )
-    sr = Inferno::Models::SequenceResult.create(
+    }
+
+    Inferno::Models::TestingInstance.create(default_params.merge(params))
+  end
+
+  def create_sequence_result(params = {})
+    default_params = {
       result: 'wait',
-      testing_instance: instance,
       test_set_id: 'developer',
       test_case_id: 'developer_SMARTonFHIRTesting_EHRLaunchSequence',
+      next_test_cases: ''
+    }
+
+    Inferno::Models::SequenceResult.create(default_params.merge(params))
+  end
+
+  def setup
+    WebMock.disable_net_connect!
+  end
+
+  def test_launch_response_success
+    instance = create_testing_instance
+    sequence_result = create_sequence_result(
+      testing_instance: instance,
       wait_at_endpoint: 'launch',
-      next_test_cases: '',
       redirect_to_url: '/redirect'
     )
     Inferno::Models::TestResult.create(
-      sequence_result: sr
+      sequence_result: sequence_result
     )
 
     EventMachine.run do
       get '/inferno/oauth2/static/launch?iss=http://example.com'
+
       assert last_response.ok?
-      assert last_response.body.include? js_redirect("#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sr.test_set_id}/#SMARTonFHIRTesting/#{sr.test_case_id}")
+
+      redirect_path = "#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sequence_result.test_set_id}/#SMARTonFHIRTesting/#{sequence_result.test_case_id}"
+      assert last_response.body.include? js_redirect(redirect_path)
       break
     end
   end
 
   def test_redirect_response_success
-    instance = Inferno::Models::TestingInstance.create(
-      state: 'abc123',
-      client_endpoint_key: 'static',
-      selected_module: 'smart',
-      initiate_login_uri: '/login'
-    )
-    sr = Inferno::Models::SequenceResult.create(
-      result: 'wait',
+    instance = create_testing_instance(state: 'abc123')
+    sequence_result = create_sequence_result(
       testing_instance: instance,
-      test_set_id: 'developer',
-      test_case_id: 'developer_SMARTonFHIRTesting_EHRLaunchSequence',
-      wait_at_endpoint: 'redirect',
-      next_test_cases: ''
+      wait_at_endpoint: 'redirect'
     )
     Inferno::Models::TestResult.create(
-      sequence_result: sr
+      sequence_result: sequence_result
     )
 
     EventMachine.run do
       get '/inferno/oauth2/static/redirect?state=abc123'
+
       assert last_response.ok?
-      assert last_response.body.include? js_redirect("#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sr.test_set_id}/#SMARTonFHIRTesting/#{sr.test_case_id}")
+
+      redirect_path = "#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sequence_result.test_set_id}/#SMARTonFHIRTesting/#{sequence_result.test_case_id}"
+      assert last_response.body.include? js_redirect(redirect_path)
       break
     end
   end

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require File.expand_path '../test_helper.rb', __dir__
+require 'eventmachine'
+
+class HomePageTest < MiniTest::Test
+  include Rack::Test::Methods
+  include Inferno::App::Helpers::BrowserLogic
+
+  def base_path
+    '/inferno'
+  end
+
+  def app
+    Inferno::App.new
+  end
+
+  def setup
+    WebMock.disable_net_connect!
+    # stub_request(:any, 'http://example.com/')
+  end
+
+  def test_launch_response_success
+    instance = Inferno::Models::TestingInstance.new(
+      url: 'http://example.com',
+      client_endpoint_key: 'static',
+      selected_module: 'smart',
+      initiate_login_uri: '/launch'
+    )
+    instance.save
+    sr = Inferno::Models::SequenceResult.new(
+      result: 'wait',
+      testing_instance: instance,
+      test_set_id: 'developer',
+      test_case_id: 'developer_SMARTonFHIRTesting_EHRLaunchSequence',
+      wait_at_endpoint: 'launch',
+      next_test_cases: '',
+      redirect_to_url: '/redirect'
+    )
+    sr.save
+    tr = Inferno::Models::TestResult.new(
+      sequence_result: sr
+    )
+    tr.save
+
+    EventMachine.run do
+      get '/inferno/oauth2/static/launch?iss=http://example.com'
+      assert last_response.ok?
+      assert last_response.body.include? js_redirect("#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sr.test_set_id}/#SMARTonFHIRTesting/#{sr.test_case_id}")
+      break
+    end
+  end
+
+  def test_404_page
+    get '/asdfasdf'
+    assert last_response.not_found?
+  end
+end

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -78,6 +78,53 @@ class OAuth2EndpointsTest < MiniTest::Test
     end
   end
 
+  def test_launch_response_no_iss
+    instance = create_testing_instance(url: 'http://example.com/no_iss')
+    sequence_result = create_sequence_result(
+      testing_instance: instance,
+      wait_at_endpoint: 'launch',
+      redirect_to_url: '/redirect'
+    )
+    Inferno::Models::TestResult.create(
+      sequence_result: sequence_result
+    )
+
+    EventMachine.run do
+      cookies = { 'HTTP_COOKIE' => "instance_id_test_set=#{instance.id}/" }
+      get '/inferno/oauth2/static/launch', {}, cookies
+
+      assert last_response.ok?
+
+      redirect_path = "#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sequence_result.test_set_id}/#SMARTonFHIRTesting/#{sequence_result.test_case_id}"
+      assert last_response.body.include? js_redirect(redirect_path)
+
+      assert sequence_result.test_results.any? do |result|
+        result.fail? && result.message == 'No iss for redirect'
+      end
+      break
+    end
+  end
+
+  def test_launch_response_not_waiting
+    instance = create_testing_instance
+    sequence_result = create_sequence_result(
+      testing_instance: instance,
+      result: 'pass'
+    )
+    Inferno::Models::TestResult.create(
+      sequence_result: sequence_result
+    )
+
+    EventMachine.run do
+      cookies = { 'HTTP_COOKIE' => "instance_id_test_set=#{instance.id}/" }
+      get '/inferno/oauth2/static/launch?iss=http://example.com', {}, cookies
+
+      assert last_response.redirect?
+      assert last_response.headers['Location'].include? '?error=no_ehr_launch'
+      break
+    end
+  end
+
   def test_redirect_response_success
     instance = create_testing_instance(state: 'abc123')
     sequence_result = create_sequence_result(
@@ -110,6 +157,52 @@ class OAuth2EndpointsTest < MiniTest::Test
 
       expected_error_message = "No actively running launch sequences found with a state of #{bad_state}"
       assert last_response.body.include? expected_error_message
+      break
+    end
+  end
+
+  def test_redirect_response_bad_state
+    instance = create_testing_instance(state: '123')
+    sequence_result = create_sequence_result(
+      testing_instance: instance,
+      wait_at_endpoint: 'redirect'
+    )
+    Inferno::Models::TestResult.create(
+      sequence_result: sequence_result
+    )
+
+    EventMachine.run do
+      cookies = { 'HTTP_COOKIE' => "instance_id_test_set=#{instance.id}/" }
+      get '/inferno/oauth2/static/redirect?state=abc', {}, cookies
+
+      assert last_response.ok?
+
+      redirect_path = "#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sequence_result.test_set_id}/#SMARTonFHIRTesting/#{sequence_result.test_case_id}"
+      assert last_response.body.include? js_redirect(redirect_path)
+
+      assert sequence_result.test_results.any? do |result|
+        result.fail? && result.message.start_with?('State provided in redirect')
+      end
+      break
+    end
+  end
+
+  def test_redirect_response_not_waiting
+    instance = create_testing_instance(state: 'abc123')
+    sequence_result = create_sequence_result(
+      testing_instance: instance,
+      result: 'pass'
+    )
+    Inferno::Models::TestResult.create(
+      sequence_result: sequence_result
+    )
+
+    EventMachine.run do
+      cookies = { 'HTTP_COOKIE' => "instance_id_test_set=#{instance.id}/" }
+      get '/inferno/oauth2/static/redirect?state=xyz', {}, cookies
+
+      assert last_response.redirect?
+      assert last_response.headers['Location'].include? '?error=no_state'
       break
     end
   end

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -21,14 +21,13 @@ class HomePageTest < MiniTest::Test
   end
 
   def test_launch_response_success
-    instance = Inferno::Models::TestingInstance.new(
+    instance = Inferno::Models::TestingInstance.create(
       url: 'http://example.com',
       client_endpoint_key: 'static',
       selected_module: 'smart',
-      initiate_login_uri: '/launch'
+      initiate_login_uri: '/login'
     )
-    instance.save
-    sr = Inferno::Models::SequenceResult.new(
+    sr = Inferno::Models::SequenceResult.create(
       result: 'wait',
       testing_instance: instance,
       test_set_id: 'developer',
@@ -37,14 +36,39 @@ class HomePageTest < MiniTest::Test
       next_test_cases: '',
       redirect_to_url: '/redirect'
     )
-    sr.save
-    tr = Inferno::Models::TestResult.new(
+    Inferno::Models::TestResult.create(
       sequence_result: sr
     )
-    tr.save
 
     EventMachine.run do
       get '/inferno/oauth2/static/launch?iss=http://example.com'
+      assert last_response.ok?
+      assert last_response.body.include? js_redirect("#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sr.test_set_id}/#SMARTonFHIRTesting/#{sr.test_case_id}")
+      break
+    end
+  end
+
+  def test_redirect_response_success
+    instance = Inferno::Models::TestingInstance.create(
+      state: 'abc123',
+      client_endpoint_key: 'static',
+      selected_module: 'smart',
+      initiate_login_uri: '/login'
+    )
+    sr = Inferno::Models::SequenceResult.create(
+      result: 'wait',
+      testing_instance: instance,
+      test_set_id: 'developer',
+      test_case_id: 'developer_SMARTonFHIRTesting_EHRLaunchSequence',
+      wait_at_endpoint: 'redirect',
+      next_test_cases: ''
+    )
+    Inferno::Models::TestResult.create(
+      sequence_result: sr
+    )
+
+    EventMachine.run do
+      get '/inferno/oauth2/static/redirect?state=abc123'
       assert last_response.ok?
       assert last_response.body.include? js_redirect("#{Inferno::BASE_PATH}/#{instance.id}/test_sets/#{sr.test_set_id}/#SMARTonFHIRTesting/#{sr.test_case_id}")
       break


### PR DESCRIPTION
This branch adds happy path tests and separates `launch` and `redirect` into separate endpoints. When these endpoints successfully find a testing instance, they `pass` to a shared route which continues test execution.