### PR TITLE
FI-289 removed tooltip on warning icon indicating redirect

### DIFF
--- a/lib/app/views/test_list.erb
+++ b/lib/app/views/test_list.erb
@@ -39,7 +39,7 @@
       <% end %>
       <% if result.test_warnings.length > 0 %>
           <div class="result-details-icon result-details-icon-warning" data-toggle="tooltip" title="<%= result.test_warnings.length %> warning(s).  Warnings do not result in a test failure.">
-            <span class="oi oi-warning" data-toggle="tooltip" title="Test is waiting for a server launch or redirect"></span>
+            <span class="oi oi-warning"></span>
           </div>
       <% else %>
           <div class="result-details-icon result-details-icon-warning"></div>


### PR DESCRIPTION
Removed tooltip because it was conflicting for another one (as in issue 289)