### PR TITLE
FI-291: Fix Sort Order of Extended Sequences

### DIFF
--- a/lib/app/modules/argonaut/argonaut_conformance_sequence.rb
+++ b/lib/app/modules/argonaut/argonaut_conformance_sequence.rb
@@ -128,7 +128,7 @@ module Inferno
 
       test 'Conformance Statement lists supported Argonaut profiles, operations and search parameters' do
         metadata do
-          id '05'
+          id '06'
           link 'https://www.fhir.org/guides/argonaut/r2/Conformance-server.html'
           desc %(
            The Argonaut Data Query Implementation Guide states:

--- a/lib/app/modules/onc_program/onc_standalone_launch_sequence.rb
+++ b/lib/app/modules/onc_program/onc_standalone_launch_sequence.rb
@@ -11,7 +11,7 @@ module Inferno
 
       description 'Demonstrate the ONC SMART Standalone Launch Sequence.'
 
-      test_id_prefix 'OELS'
+      test_id_prefix 'OSLS'
 
       requires :client_id, :confidential_client, :client_secret, :oauth_authorize_endpoint, :oauth_token_endpoint, :scopes, :initiate_login_uri, :redirect_uris
 

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -350,7 +350,6 @@ module Inferno
       def self.extends_sequence(klass)
         @@test_metadata[klass.sequence_name].each do |metadata|
           @@test_metadata[sequence_name] << metadata
-          @@test_metadata[sequence_name].last[:test_index] = @@test_metadata[sequence_name].length - 1
           define_method metadata[:method_name], metadata[:method]
         end
       end

--- a/lib/app/views/test_case.erb
+++ b/lib/app/views/test_case.erb
@@ -68,7 +68,7 @@
                 </span> - 
                 <div class="sequence-out-of">
                   <% if sequence_results[test_case.id].nil? %>
-                    <%= test_case.sequence.test_count %> tests
+                    <%= test_case.sequence.test_count %> <%= 'test'.pluralize(test_case.sequence.test_count) %>
                   <% else %>
                     <%= sequence_results[test_case.id].required_passed %>/<%= sequence_results[test_case.id].total_required_tests_except_omitted %> Required Tests Passed
 
@@ -77,7 +77,7 @@
                     <% end%>
 
                     <% if sequence_results[test_case.id].total_omitted.positive?%> -
-                      <%= sequence_results[test_case.id].total_omitted %> Test <% if sequence_results[test_case.id].total_omitted != 1%>s<% end%> Omitted
+                      <%= sequence_results[test_case.id].total_omitted %> <%= 'Test'.pluralize(sequence_results[test_case.id].total_omitted) %> Omitted
                     <% end%>
                   <% end %>
                   -


### PR DESCRIPTION
### Problem: 
`TestResult`s used to display in a non-obvious/nondeterministic order (see the "before" screenshot below) after a test was cancelled. This is because of how test indexes are assigned to base tests in extended sequences. See ticket https://oncprojectracking.healthit.gov/support/browse/FI-291 for more information.

### Solution:  
No longer reassign test indexes for the base tests when they're added to extended sequences, e.g. the `CapabilityStatementSequence` tests in the `ArgonautConformanceStatement` sequence. See the "after" screenshots below for examples of the Cancelled EHR Launch Sequence test results, a completed test suite, and a test suite that hasn't yet been run, to show that they are all sorted as expected.

### Before:
<img width="950" alt="Screen Shot 2019-08-16 at 10 45 00 AM" src="https://user-images.githubusercontent.com/49001/63175913-f55d7d80-c012-11e9-980c-5e37bd5be111.png">

### After:
Cancelled test suite:
<img width="944" alt="Screen Shot 2019-08-16 at 8 21 10 AM" src="https://user-images.githubusercontent.com/49001/63175932-fdb5b880-c012-11e9-8145-4313e5fbc810.png">

Completed test suite:
<img width="941" alt="Screen Shot 2019-08-16 at 8 24 28 AM" src="https://user-images.githubusercontent.com/49001/63175979-10c88880-c013-11e9-80d2-3c55007f132a.png">

Not-run test suite:
<img width="948" alt="Screen Shot 2019-08-16 at 8 24 12 AM" src="https://user-images.githubusercontent.com/49001/63175996-17ef9680-c013-11e9-8248-4ca9a95841f8.png">
