### PR TITLE
FI-294: Fix no iss error

### DIFF
--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -40,7 +40,7 @@ module Inferno
             halt 500, no_instance_for_iss_error_message if @instance.nil?
 
             if @instance.waiting_on_sequence&.wait?
-              @error_message = no_iss_error_message
+              @error_message = unknown_iss_error_message
               resume_execution
             else
               redirect "#{base_path}/#{cookies[:instance_id_test_set]}/?error=no_ehr_launch&iss=#{params[:iss]}"

--- a/lib/app/utils/oauth2_error_messages.rb
+++ b/lib/app/utils/oauth2_error_messages.rb
@@ -41,8 +41,8 @@ module Inferno
         )
       end
 
-      def no_iss_error_message
-        'No iss for redirect'
+      def unknown_iss_error_message
+        params[:iss].present? ? "Unknown iss: #{params[:iss]}" : 'No iss for redirect'
       end
 
       def no_running_test_error_message


### PR DESCRIPTION
During the SMART launch tests, it is possible to receive an error message stating that no iss was provided, when the request url clearly displays an iss:
![Screen Shot 2019-08-21 at 11 03 09 AM](https://user-images.githubusercontent.com/15969967/63448741-99c53280-c40c-11e9-86a9-8406a43c865b.png)

This error message has been updated to be more accurate:
![Screen Shot 2019-08-21 at 11 02 47 AM](https://user-images.githubusercontent.com/15969967/63448820-cd07c180-c40c-11e9-869d-d503ee7db6f6.png)

This error message can arise from a SMART launch with an iss parameter different than what was specified when starting the test suite. HSPC updated their endpoints to start with `https://api.logicahealth.org/` rather than something like `https://api-v8-dstu2.hspconsortium.org/`. The old urls still work, so the initial conformance tests pass, but when doing an EHR launch, the new url is sent as the iss. This mismatch causes this error to appear.