### PR TITLE
FI-98: Add issue and PR templates to the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: "Bug report"
+about: "Report a bug in Inferno"
+---
+
+Thank you for reporting a possible bug in Inferno! Please fill in as much of the template below as you can.
+
+**Subject of the issue**
+Describe your issue here.
+
+
+
+**Your environment**
+* Edition of inferno (Community or Program):
+* Version of inferno:
+* Which browser and version(s) is the bug present on?:
+
+
+**Steps to reproduce**
+Tell us how to reproduce this issue.
+
+Include:
+
+* The selected test suite
+* The URL of the FHIR server being tested
+* The Test ID, if it's a problem with a specific test.
+* Any required configuration options (client ID, client secret, etc.)
+* Anything else needed to make the issue occur
+
+
+**Expected behavior**
+Tell us what should happen
+
+
+
+**Actual behavior**
+Tell us what happens instead. Include screenshots if possible.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,11 +25,11 @@ Include:
 * The URL of the FHIR server being tested
 * The Test ID, if it's a problem with a specific test.
 * Any required configuration options (client ID, client secret, etc.)
-* Anything else needed to make the issue occur
+* Anything else needed to make the issue occur.
 
 
 **Expected behavior**
-Tell us what should happen
+Tell us what should happen.
 
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: "Feature Request"
+about: "Request a feature you would like to be added to Inferno"
+---
+
+**Is your feature request related to a problem? Please describe it.**
+Describe the problem you are trying to solve.
+
+**Describe the solution you'd like to see implemented**
+Things you can put in this section include (but aren't limited to):
+* A description of the solution.
+* Details of the technical implementation, if you've thought about it.
+* Any caveats/tradeoffs of the proposed solution.
+
+**Describe alternatives you've considered**
+Describe any alternative solutions or features you have considered.

--- a/.github/PULL_REQUEST_TEMPLATE/default_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_pr_template.md
@@ -1,0 +1,28 @@
+Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
+should check the relevant check boxes when the associated item is done. For items that are not 
+applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
+Requests do not require ticket links.
+
+**Submitter:**
+- [ ] This pull request describes why these changes were made.
+- [ ] Internal ticket for this PR:
+- [ ] Internal ticket links to this PR
+- [ ] Internal ticket is properly labeled (Community/Program)
+- [ ] Code diff has been reviewed for extraneous/missing code
+- [ ] Tests are included and test edge cases
+- [ ] Tests/code quality metrics have been run locally and pass
+
+
+**Reviewer 1:**
+
+Name:
+- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task's purpose
+- [ ] The tests appropriately test the new code, including edge cases
+- [ ] You have tried to break the code
+
+**Reviewer 2:**
+
+Name:
+- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task's purpose
+- [ ] The tests appropriately test the new code, including edge cases
+- [ ] You have tried to break the code

--- a/.github/PULL_REQUEST_TEMPLATE/default_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_pr_template.md
@@ -4,7 +4,7 @@ applicable, note it's not applicable ("N/A") and check the box. For example, ext
 Requests do not require ticket links.
 
 **Submitter:**
-- [ ] This pull request describes why these changes were made.
+- [ ] This pull request describes why these changes were made
 - [ ] Internal ticket for this PR:
 - [ ] Internal ticket links to this PR
 - [ ] Internal ticket is properly labeled (Community/Program)


### PR DESCRIPTION
This PR adds 3 templates to the repository, through the use of the `.github/` hidden folder:

* `ISSUE_TEMPLATE/bug_report.md`: A template for external users to report suspected bugs through the Inferno "Issues" tab. Selectable by the user if they want to report a bug.
* `ISSUE_TEMPLATE/feature_request.md`: A template for external users to request features in Inferno through the "Issues" tab. Selectable by the user if they want to request a feature.
* `PULL_REQUEST_TEMPLATE/default_pr_template.md`: A Pull Request Checklist, to be filled out by the submitters and both reviewers on every Inferno PR.