### PR TITLE
FI-321 Fix pluralization on omit reporting.

### DIFF
--- a/lib/app/views/report.erb
+++ b/lib/app/views/report.erb
@@ -145,14 +145,14 @@
                         </span> - 
                         <div class="sequence-out-of">
                           <% if sequence_results[test_case.id].nil? %>
-                            <%= test_case.sequence.test_count %> tests
+                            <%= test_case.sequence.test_count %> <% 'test'.pluralize(test_case.sequence.test_count) %>
                           <% else %>
                             <%= sequence_results[test_case.id].required_passed %>/<%= sequence_results[test_case.id].total_required_tests_except_omitted%> Required Tests Passed
                             <% if sequence_results[test_case.id].optional_total > 0%> -
                               <%= sequence_results[test_case.id].optional_passed%>/<%= sequence_results[test_case.id].optional_total%> Optional Tests Passed
                             <% end%>
                             <% if sequence_results[test_case.id].total_omitted.positive?%> -
-                               <%= sequence_results[test_case.id].total_omitted %> Test <% if sequence_results[test_case.id].total_omitted != 1%>s<% end%> Omitted
+                               <%= sequence_results[test_case.id].total_omitted %> <%= 'Test'.pluralize(sequence_results[test_case.id].total_omitted) %> Omitted
                             <% end%>
                           <% end %>
                         </div>


### PR DESCRIPTION
This was already partially taken care of in #272

There used to be a space when added when pluralizing test on when the number of ommited were greater than one.  This fixes the report view case.