### PR TITLE
FI-356: Remove double warning tooltip

### DIFF
--- a/lib/app/views/test_list.erb
+++ b/lib/app/views/test_list.erb
@@ -42,8 +42,8 @@
         </div>
       <% end %>
       <% if result.test_warnings.length > 0 %>
-          <div class="result-details-icon result-details-icon-warning" style="float:right;" data-toggle="tooltip" title="<%= result.test_warnings.length %> warning(s).  Warnings do not result in a test failure.">
-            <span class="oi oi-warning" data-toggle="tooltip" title="Test is waiting for a server launch or redirect"></span>
+          <div class="result-details-icon result-details-icon-warning" style="float:right;" data-toggle="tooltip" title="<%= result.test_warnings.length %> warning(s). Warnings do not result in a test failure.">
+            <span class="oi oi-warning"></span>
           </div>
       <% end %>
 


### PR DESCRIPTION
Tests with warnings currently display two tooltips which can be viewed by slowly moving the cursor over the warning icon:
![Screen Shot 2019-09-19 at 8 33 25 AM](https://user-images.githubusercontent.com/15969967/65247110-d04ea580-dabd-11e9-9938-7cb4c27c13d9.png)
![Screen Shot 2019-09-19 at 8 33 17 AM](https://user-images.githubusercontent.com/15969967/65247115-d2b0ff80-dabd-11e9-9048-99f2e172f6ad.png)

This branch removes the erroneous tooltip.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-356
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- N/A Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- N/A The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- N/A The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
