### PR TITLE
FI-268 add request url to request details

### DIFF
--- a/lib/app/views/request_details.erb
+++ b/lib/app/views/request_details.erb
@@ -9,6 +9,15 @@
 <div class="modal-body">
   <div class="test-result-details-response-values">
     <div class="test-result-details-header">Request</div>
+    <% if rr.direction == 'outbound' %>
+      <span class="oi oi-arrow-thick-right" title="outbound requests" aria-hidden="true"></span>
+    <% else %>
+      <span class="oi oi-arrow-thick-left" title="inbound requests" aria-hidden="true"></span>
+    <% end %>
+    &nbsp;
+    <%= rr.request_method.upcase %> &nbsp;
+    <%= rr.response_code %> &nbsp;
+    <%= rr.request_url %>
     <div class="test-result-details-subheader">Headers</div>
     <ul>
       <% valid_json?(rr.request_headers) && JSON.parse(rr.request_headers).each do |header_name, header_value| %>


### PR DESCRIPTION
Currently, the request details view does not show the request URL. This branch will add the url and request direction to the request details view. You can view this by pressing the "details" link next to one of the requests in the HTTP Requests tab.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-268
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name: Rob Scanlon
- [X] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [X] The tests appropriately test the new code, including edge cases
- [X] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
