### PR TITLE
FI-365 Save resources from all pages from search

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -159,14 +159,7 @@ module Inferno
               skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
               @#{sequence[:resource].downcase} = reply&.resource&.entry&.first&.resource
-              @#{sequence[:resource].downcase}_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-              page_count = 1
-              next_bundle = reply&.resource&.next_bundle
-              until next_bundle.nil? || page_count == 100
-                @#{sequence[:resource].downcase}_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-                next_bundle = next_bundle.next_bundle
-                page_count += 1
-              end
+              @#{sequence[:resource].downcase}_ary = fetch_all_search_results(reply&.resource)
               save_resource_ids_in_bundle(#{save_resource_ids_in_bundle_arguments})
               save_delayed_sequence_references(@#{sequence[:resource].downcase})
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params))

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -159,7 +159,7 @@ module Inferno
               skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
               @#{sequence[:resource].downcase} = reply&.resource&.entry&.first&.resource
-              @#{sequence[:resource].downcase}_ary = fetch_all_search_results(reply&.resource)
+              @#{sequence[:resource].downcase}_ary = fetch_all_bundled_resources(reply&.resource)
               save_resource_ids_in_bundle(#{save_resource_ids_in_bundle_arguments})
               save_delayed_sequence_references(@#{sequence[:resource].downcase})
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params))

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -158,8 +158,15 @@ module Inferno
 
               skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-              @#{sequence[:resource].downcase} = reply.try(:resource).try(:entry).try(:first).try(:resource)
+              @#{sequence[:resource].downcase} = reply&.resource&.entry&.first&.resource
               @#{sequence[:resource].downcase}_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+              page_count = 1
+              next_bundle = reply&.resource&.next_bundle
+              until next_bundle.nil? || page_count == 100
+                @#{sequence[:resource].downcase}_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+                next_bundle = next_bundle.next_bundle
+                page_count += 1
+              end
               save_resource_ids_in_bundle(#{save_resource_ids_in_bundle_arguments})
               save_delayed_sequence_references(@#{sequence[:resource].downcase})
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params))

--- a/lib/app/modules/uscore_v3.0.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/pediatric_bmi_for_age_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/pediatric_bmi_for_age_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @observation = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @observation = reply&.resource&.entry&.first&.resource
         @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/pediatric_bmi_for_age_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/pediatric_weight_for_height_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/pediatric_weight_for_height_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/pediatric_weight_for_height_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @observation = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @observation = reply&.resource&.entry&.first&.resource
         @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_allergyintolerance_sequence.rb
@@ -78,14 +78,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @allergyintolerance = reply&.resource&.entry&.first&.resource
-        @allergyintolerance_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @allergyintolerance_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @allergyintolerance_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
         save_delayed_sequence_references(@allergyintolerance)
         validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_allergyintolerance_sequence.rb
@@ -78,7 +78,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @allergyintolerance = reply&.resource&.entry&.first&.resource
-        @allergyintolerance_ary = fetch_all_search_results(reply&.resource)
+        @allergyintolerance_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
         save_delayed_sequence_references(@allergyintolerance)
         validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_allergyintolerance_sequence.rb
@@ -77,8 +77,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @allergyintolerance = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @allergyintolerance = reply&.resource&.entry&.first&.resource
         @allergyintolerance_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @allergyintolerance_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
         save_delayed_sequence_references(@allergyintolerance)
         validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_careplan_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_careplan_sequence.rb
@@ -84,7 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careplan = reply&.resource&.entry&.first&.resource
-        @careplan_ary = fetch_all_search_results(reply&.resource)
+        @careplan_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
         save_delayed_sequence_references(@careplan)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_careplan_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_careplan_sequence.rb
@@ -83,8 +83,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @careplan = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @careplan = reply&.resource&.entry&.first&.resource
         @careplan_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @careplan_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
         save_delayed_sequence_references(@careplan)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_careplan_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_careplan_sequence.rb
@@ -84,14 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careplan = reply&.resource&.entry&.first&.resource
-        @careplan_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @careplan_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @careplan_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
         save_delayed_sequence_references(@careplan)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_careteam_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_careteam_sequence.rb
@@ -74,7 +74,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careteam = reply&.resource&.entry&.first&.resource
-        @careteam_ary = fetch_all_search_results(reply&.resource)
+        @careteam_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
         save_delayed_sequence_references(@careteam)
         validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_careteam_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_careteam_sequence.rb
@@ -73,8 +73,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @careteam = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @careteam = reply&.resource&.entry&.first&.resource
         @careteam_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @careteam_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
         save_delayed_sequence_references(@careteam)
         validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_careteam_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_careteam_sequence.rb
@@ -74,14 +74,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careteam = reply&.resource&.entry&.first&.resource
-        @careteam_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @careteam_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @careteam_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
         save_delayed_sequence_references(@careteam)
         validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_condition_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_condition_sequence.rb
@@ -92,14 +92,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @condition = reply&.resource&.entry&.first&.resource
-        @condition_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @condition_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @condition_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Condition'), reply)
         save_delayed_sequence_references(@condition)
         validate_search_reply(versioned_resource_class('Condition'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_condition_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_condition_sequence.rb
@@ -91,8 +91,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @condition = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @condition = reply&.resource&.entry&.first&.resource
         @condition_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @condition_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Condition'), reply)
         save_delayed_sequence_references(@condition)
         validate_search_reply(versioned_resource_class('Condition'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_condition_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_condition_sequence.rb
@@ -92,7 +92,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @condition = reply&.resource&.entry&.first&.resource
-        @condition_ary = fetch_all_search_results(reply&.resource)
+        @condition_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Condition'), reply)
         save_delayed_sequence_references(@condition)
         validate_search_reply(versioned_resource_class('Condition'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_device_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_device_sequence.rb
@@ -78,7 +78,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @device = reply&.resource&.entry&.first&.resource
-        @device_ary = fetch_all_search_results(reply&.resource)
+        @device_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Device'), reply)
         save_delayed_sequence_references(@device)
         validate_search_reply(versioned_resource_class('Device'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_device_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_device_sequence.rb
@@ -78,14 +78,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @device = reply&.resource&.entry&.first&.resource
-        @device_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @device_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @device_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Device'), reply)
         save_delayed_sequence_references(@device)
         validate_search_reply(versioned_resource_class('Device'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_device_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_device_sequence.rb
@@ -77,8 +77,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @device = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @device = reply&.resource&.entry&.first&.resource
         @device_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @device_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Device'), reply)
         save_delayed_sequence_references(@device)
         validate_search_reply(versioned_resource_class('Device'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_lab_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @diagnosticreport = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @diagnosticreport = reply&.resource&.entry&.first&.resource
         @diagnosticreport_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @diagnosticreport_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_lab_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = fetch_all_search_results(reply&.resource)
+        @diagnosticreport_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_lab_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @diagnosticreport_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @diagnosticreport_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_note_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @diagnosticreport_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @diagnosticreport_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_note_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = fetch_all_search_results(reply&.resource)
+        @diagnosticreport_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_note_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @diagnosticreport = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @diagnosticreport = reply&.resource&.entry&.first&.resource
         @diagnosticreport_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @diagnosticreport_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_documentreference_sequence.rb
@@ -99,8 +99,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @documentreference = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @documentreference = reply&.resource&.entry&.first&.resource
         @documentreference_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @documentreference_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
         save_delayed_sequence_references(@documentreference)
         validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_documentreference_sequence.rb
@@ -100,14 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @documentreference = reply&.resource&.entry&.first&.resource
-        @documentreference_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @documentreference_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @documentreference_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
         save_delayed_sequence_references(@documentreference)
         validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_documentreference_sequence.rb
@@ -100,7 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @documentreference = reply&.resource&.entry&.first&.resource
-        @documentreference_ary = fetch_all_search_results(reply&.resource)
+        @documentreference_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
         save_delayed_sequence_references(@documentreference)
         validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_encounter_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_encounter_sequence.rb
@@ -99,8 +99,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @encounter = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @encounter = reply&.resource&.entry&.first&.resource
         @encounter_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @encounter_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Encounter'), reply)
         save_delayed_sequence_references(@encounter)
         validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_encounter_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_encounter_sequence.rb
@@ -100,7 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @encounter = reply&.resource&.entry&.first&.resource
-        @encounter_ary = fetch_all_search_results(reply&.resource)
+        @encounter_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Encounter'), reply)
         save_delayed_sequence_references(@encounter)
         validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_encounter_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_encounter_sequence.rb
@@ -100,14 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @encounter = reply&.resource&.entry&.first&.resource
-        @encounter_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @encounter_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @encounter_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Encounter'), reply)
         save_delayed_sequence_references(@encounter)
         validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_goal_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_goal_sequence.rb
@@ -84,14 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @goal = reply&.resource&.entry&.first&.resource
-        @goal_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @goal_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @goal_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Goal'), reply)
         save_delayed_sequence_references(@goal)
         validate_search_reply(versioned_resource_class('Goal'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_goal_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_goal_sequence.rb
@@ -83,8 +83,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @goal = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @goal = reply&.resource&.entry&.first&.resource
         @goal_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @goal_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Goal'), reply)
         save_delayed_sequence_references(@goal)
         validate_search_reply(versioned_resource_class('Goal'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_goal_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_goal_sequence.rb
@@ -84,7 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @goal = reply&.resource&.entry&.first&.resource
-        @goal_ary = fetch_all_search_results(reply&.resource)
+        @goal_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Goal'), reply)
         save_delayed_sequence_references(@goal)
         validate_search_reply(versioned_resource_class('Goal'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_immunization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_immunization_sequence.rb
@@ -84,7 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @immunization = reply&.resource&.entry&.first&.resource
-        @immunization_ary = fetch_all_search_results(reply&.resource)
+        @immunization_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Immunization'), reply)
         save_delayed_sequence_references(@immunization)
         validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_immunization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_immunization_sequence.rb
@@ -84,14 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @immunization = reply&.resource&.entry&.first&.resource
-        @immunization_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @immunization_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @immunization_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Immunization'), reply)
         save_delayed_sequence_references(@immunization)
         validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_immunization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_immunization_sequence.rb
@@ -83,8 +83,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @immunization = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @immunization = reply&.resource&.entry&.first&.resource
         @immunization_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @immunization_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Immunization'), reply)
         save_delayed_sequence_references(@immunization)
         validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
@@ -106,7 +106,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @location = reply&.resource&.entry&.first&.resource
-        @location_ary = fetch_all_search_results(reply&.resource)
+        @location_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Location'), reply)
         save_delayed_sequence_references(@location)
         validate_search_reply(versioned_resource_class('Location'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
@@ -106,14 +106,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @location = reply&.resource&.entry&.first&.resource
-        @location_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @location_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @location_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Location'), reply)
         save_delayed_sequence_references(@location)
         validate_search_reply(versioned_resource_class('Location'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
@@ -105,8 +105,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @location = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @location = reply&.resource&.entry&.first&.resource
         @location_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @location_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Location'), reply)
         save_delayed_sequence_references(@location)
         validate_search_reply(versioned_resource_class('Location'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_medicationrequest_sequence.rb
@@ -82,14 +82,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @medicationrequest = reply&.resource&.entry&.first&.resource
-        @medicationrequest_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @medicationrequest_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @medicationrequest_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
         save_delayed_sequence_references(@medicationrequest)
         validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_medicationrequest_sequence.rb
@@ -82,7 +82,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @medicationrequest = reply&.resource&.entry&.first&.resource
-        @medicationrequest_ary = fetch_all_search_results(reply&.resource)
+        @medicationrequest_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
         save_delayed_sequence_references(@medicationrequest)
         validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_medicationrequest_sequence.rb
@@ -81,8 +81,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @medicationrequest = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @medicationrequest = reply&.resource&.entry&.first&.resource
         @medicationrequest_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @medicationrequest_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
         save_delayed_sequence_references(@medicationrequest)
         validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_medicationstatement_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_medicationstatement_sequence.rb
@@ -83,8 +83,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @medicationstatement = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @medicationstatement = reply&.resource&.entry&.first&.resource
         @medicationstatement_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @medicationstatement_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('MedicationStatement'), reply)
         save_delayed_sequence_references(@medicationstatement)
         validate_search_reply(versioned_resource_class('MedicationStatement'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_medicationstatement_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_medicationstatement_sequence.rb
@@ -84,7 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @medicationstatement = reply&.resource&.entry&.first&.resource
-        @medicationstatement_ary = fetch_all_search_results(reply&.resource)
+        @medicationstatement_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationStatement'), reply)
         save_delayed_sequence_references(@medicationstatement)
         validate_search_reply(versioned_resource_class('MedicationStatement'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_medicationstatement_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_medicationstatement_sequence.rb
@@ -84,14 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @medicationstatement = reply&.resource&.entry&.first&.resource
-        @medicationstatement_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @medicationstatement_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @medicationstatement_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationStatement'), reply)
         save_delayed_sequence_references(@medicationstatement)
         validate_search_reply(versioned_resource_class('MedicationStatement'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_observation_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_observation_lab_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_observation_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_observation_lab_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
@@ -94,7 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @organization = reply&.resource&.entry&.first&.resource
-        @organization_ary = fetch_all_search_results(reply&.resource)
+        @organization_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Organization'), reply)
         save_delayed_sequence_references(@organization)
         validate_search_reply(versioned_resource_class('Organization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
@@ -93,8 +93,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @organization = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @organization = reply&.resource&.entry&.first&.resource
         @organization_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @organization_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Organization'), reply)
         save_delayed_sequence_references(@organization)
         validate_search_reply(versioned_resource_class('Organization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
@@ -94,14 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @organization = reply&.resource&.entry&.first&.resource
-        @organization_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @organization_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @organization_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Organization'), reply)
         save_delayed_sequence_references(@organization)
         validate_search_reply(versioned_resource_class('Organization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_patient_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_patient_sequence.rb
@@ -103,14 +103,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @patient = reply&.resource&.entry&.first&.resource
-        @patient_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @patient_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @patient_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Patient'), reply)
         save_delayed_sequence_references(@patient)
         validate_search_reply(versioned_resource_class('Patient'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_patient_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_patient_sequence.rb
@@ -103,7 +103,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @patient = reply&.resource&.entry&.first&.resource
-        @patient_ary = fetch_all_search_results(reply&.resource)
+        @patient_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Patient'), reply)
         save_delayed_sequence_references(@patient)
         validate_search_reply(versioned_resource_class('Patient'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_patient_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_patient_sequence.rb
@@ -102,8 +102,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @patient = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @patient = reply&.resource&.entry&.first&.resource
         @patient_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @patient_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Patient'), reply)
         save_delayed_sequence_references(@patient)
         validate_search_reply(versioned_resource_class('Patient'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_practitioner_sequence.rb
@@ -101,14 +101,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @practitioner = reply&.resource&.entry&.first&.resource
-        @practitioner_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @practitioner_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @practitioner_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Practitioner'), reply)
         save_delayed_sequence_references(@practitioner)
         validate_search_reply(versioned_resource_class('Practitioner'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_practitioner_sequence.rb
@@ -100,8 +100,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @practitioner = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @practitioner = reply&.resource&.entry&.first&.resource
         @practitioner_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @practitioner_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Practitioner'), reply)
         save_delayed_sequence_references(@practitioner)
         validate_search_reply(versioned_resource_class('Practitioner'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_practitioner_sequence.rb
@@ -101,7 +101,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @practitioner = reply&.resource&.entry&.first&.resource
-        @practitioner_ary = fetch_all_search_results(reply&.resource)
+        @practitioner_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Practitioner'), reply)
         save_delayed_sequence_references(@practitioner)
         validate_search_reply(versioned_resource_class('Practitioner'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_practitionerrole_sequence.rb
@@ -93,8 +93,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @practitionerrole = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @practitionerrole = reply&.resource&.entry&.first&.resource
         @practitionerrole_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @practitionerrole_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('PractitionerRole'), reply)
         save_delayed_sequence_references(@practitionerrole)
         validate_search_reply(versioned_resource_class('PractitionerRole'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_practitionerrole_sequence.rb
@@ -94,7 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @practitionerrole = reply&.resource&.entry&.first&.resource
-        @practitionerrole_ary = fetch_all_search_results(reply&.resource)
+        @practitionerrole_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('PractitionerRole'), reply)
         save_delayed_sequence_references(@practitionerrole)
         validate_search_reply(versioned_resource_class('PractitionerRole'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_practitionerrole_sequence.rb
@@ -94,14 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @practitionerrole = reply&.resource&.entry&.first&.resource
-        @practitionerrole_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @practitionerrole_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @practitionerrole_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('PractitionerRole'), reply)
         save_delayed_sequence_references(@practitionerrole)
         validate_search_reply(versioned_resource_class('PractitionerRole'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_procedure_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_procedure_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @procedure = reply&.resource&.entry&.first&.resource
-        @procedure_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @procedure_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @procedure_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Procedure'), reply)
         save_delayed_sequence_references(@procedure)
         validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_procedure_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_procedure_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @procedure = reply&.resource&.entry&.first&.resource
-        @procedure_ary = fetch_all_search_results(reply&.resource)
+        @procedure_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Procedure'), reply)
         save_delayed_sequence_references(@procedure)
         validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_procedure_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_procedure_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @procedure = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @procedure = reply&.resource&.entry&.first&.resource
         @procedure_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @procedure_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Procedure'), reply)
         save_delayed_sequence_references(@procedure)
         validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_smokingstatus_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_smokingstatus_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @observation = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @observation = reply&.resource&.entry&.first&.resource
         @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.0/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_smokingstatus_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/pediatric_bmi_for_age_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/pediatric_bmi_for_age_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @observation = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @observation = reply&.resource&.entry&.first&.resource
         @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/pediatric_bmi_for_age_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/pediatric_weight_for_height_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/pediatric_weight_for_height_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/pediatric_weight_for_height_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @observation = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @observation = reply&.resource&.entry&.first&.resource
         @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_allergyintolerance_sequence.rb
@@ -78,14 +78,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @allergyintolerance = reply&.resource&.entry&.first&.resource
-        @allergyintolerance_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @allergyintolerance_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @allergyintolerance_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
         save_delayed_sequence_references(@allergyintolerance)
         validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_allergyintolerance_sequence.rb
@@ -78,7 +78,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @allergyintolerance = reply&.resource&.entry&.first&.resource
-        @allergyintolerance_ary = fetch_all_search_results(reply&.resource)
+        @allergyintolerance_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
         save_delayed_sequence_references(@allergyintolerance)
         validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_allergyintolerance_sequence.rb
@@ -77,8 +77,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @allergyintolerance = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @allergyintolerance = reply&.resource&.entry&.first&.resource
         @allergyintolerance_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @allergyintolerance_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
         save_delayed_sequence_references(@allergyintolerance)
         validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_careplan_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_careplan_sequence.rb
@@ -84,7 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careplan = reply&.resource&.entry&.first&.resource
-        @careplan_ary = fetch_all_search_results(reply&.resource)
+        @careplan_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
         save_delayed_sequence_references(@careplan)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_careplan_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_careplan_sequence.rb
@@ -83,8 +83,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @careplan = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @careplan = reply&.resource&.entry&.first&.resource
         @careplan_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @careplan_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
         save_delayed_sequence_references(@careplan)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_careplan_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_careplan_sequence.rb
@@ -84,14 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careplan = reply&.resource&.entry&.first&.resource
-        @careplan_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @careplan_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @careplan_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
         save_delayed_sequence_references(@careplan)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_careteam_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_careteam_sequence.rb
@@ -74,7 +74,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careteam = reply&.resource&.entry&.first&.resource
-        @careteam_ary = fetch_all_search_results(reply&.resource)
+        @careteam_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
         save_delayed_sequence_references(@careteam)
         validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_careteam_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_careteam_sequence.rb
@@ -73,8 +73,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @careteam = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @careteam = reply&.resource&.entry&.first&.resource
         @careteam_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @careteam_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
         save_delayed_sequence_references(@careteam)
         validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_careteam_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_careteam_sequence.rb
@@ -74,14 +74,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @careteam = reply&.resource&.entry&.first&.resource
-        @careteam_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @careteam_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @careteam_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
         save_delayed_sequence_references(@careteam)
         validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_condition_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_condition_sequence.rb
@@ -92,14 +92,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @condition = reply&.resource&.entry&.first&.resource
-        @condition_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @condition_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @condition_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Condition'), reply)
         save_delayed_sequence_references(@condition)
         validate_search_reply(versioned_resource_class('Condition'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_condition_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_condition_sequence.rb
@@ -91,8 +91,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @condition = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @condition = reply&.resource&.entry&.first&.resource
         @condition_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @condition_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Condition'), reply)
         save_delayed_sequence_references(@condition)
         validate_search_reply(versioned_resource_class('Condition'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_condition_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_condition_sequence.rb
@@ -92,7 +92,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @condition = reply&.resource&.entry&.first&.resource
-        @condition_ary = fetch_all_search_results(reply&.resource)
+        @condition_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Condition'), reply)
         save_delayed_sequence_references(@condition)
         validate_search_reply(versioned_resource_class('Condition'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_lab_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @diagnosticreport = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @diagnosticreport = reply&.resource&.entry&.first&.resource
         @diagnosticreport_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @diagnosticreport_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_lab_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = fetch_all_search_results(reply&.resource)
+        @diagnosticreport_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_lab_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @diagnosticreport_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @diagnosticreport_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_note_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @diagnosticreport_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @diagnosticreport_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_note_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = fetch_all_search_results(reply&.resource)
+        @diagnosticreport_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_note_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @diagnosticreport = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @diagnosticreport = reply&.resource&.entry&.first&.resource
         @diagnosticreport_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @diagnosticreport_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
         save_delayed_sequence_references(@diagnosticreport)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_documentreference_sequence.rb
@@ -99,8 +99,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @documentreference = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @documentreference = reply&.resource&.entry&.first&.resource
         @documentreference_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @documentreference_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
         save_delayed_sequence_references(@documentreference)
         validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_documentreference_sequence.rb
@@ -100,14 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @documentreference = reply&.resource&.entry&.first&.resource
-        @documentreference_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @documentreference_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @documentreference_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
         save_delayed_sequence_references(@documentreference)
         validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_documentreference_sequence.rb
@@ -100,7 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @documentreference = reply&.resource&.entry&.first&.resource
-        @documentreference_ary = fetch_all_search_results(reply&.resource)
+        @documentreference_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
         save_delayed_sequence_references(@documentreference)
         validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_encounter_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_encounter_sequence.rb
@@ -99,8 +99,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @encounter = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @encounter = reply&.resource&.entry&.first&.resource
         @encounter_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @encounter_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Encounter'), reply)
         save_delayed_sequence_references(@encounter)
         validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_encounter_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_encounter_sequence.rb
@@ -100,7 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @encounter = reply&.resource&.entry&.first&.resource
-        @encounter_ary = fetch_all_search_results(reply&.resource)
+        @encounter_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Encounter'), reply)
         save_delayed_sequence_references(@encounter)
         validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_encounter_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_encounter_sequence.rb
@@ -100,14 +100,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @encounter = reply&.resource&.entry&.first&.resource
-        @encounter_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @encounter_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @encounter_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Encounter'), reply)
         save_delayed_sequence_references(@encounter)
         validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_goal_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_goal_sequence.rb
@@ -84,14 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @goal = reply&.resource&.entry&.first&.resource
-        @goal_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @goal_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @goal_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Goal'), reply)
         save_delayed_sequence_references(@goal)
         validate_search_reply(versioned_resource_class('Goal'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_goal_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_goal_sequence.rb
@@ -83,8 +83,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @goal = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @goal = reply&.resource&.entry&.first&.resource
         @goal_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @goal_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Goal'), reply)
         save_delayed_sequence_references(@goal)
         validate_search_reply(versioned_resource_class('Goal'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_goal_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_goal_sequence.rb
@@ -84,7 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @goal = reply&.resource&.entry&.first&.resource
-        @goal_ary = fetch_all_search_results(reply&.resource)
+        @goal_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Goal'), reply)
         save_delayed_sequence_references(@goal)
         validate_search_reply(versioned_resource_class('Goal'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_immunization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_immunization_sequence.rb
@@ -84,7 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @immunization = reply&.resource&.entry&.first&.resource
-        @immunization_ary = fetch_all_search_results(reply&.resource)
+        @immunization_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Immunization'), reply)
         save_delayed_sequence_references(@immunization)
         validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_immunization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_immunization_sequence.rb
@@ -84,14 +84,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @immunization = reply&.resource&.entry&.first&.resource
-        @immunization_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @immunization_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @immunization_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Immunization'), reply)
         save_delayed_sequence_references(@immunization)
         validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_immunization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_immunization_sequence.rb
@@ -83,8 +83,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @immunization = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @immunization = reply&.resource&.entry&.first&.resource
         @immunization_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @immunization_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Immunization'), reply)
         save_delayed_sequence_references(@immunization)
         validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_implantable_device_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_implantable_device_sequence.rb
@@ -78,7 +78,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @device = reply&.resource&.entry&.first&.resource
-        @device_ary = fetch_all_search_results(reply&.resource)
+        @device_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Device'), reply)
         save_delayed_sequence_references(@device)
         validate_search_reply(versioned_resource_class('Device'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_implantable_device_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_implantable_device_sequence.rb
@@ -78,14 +78,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @device = reply&.resource&.entry&.first&.resource
-        @device_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @device_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @device_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Device'), reply)
         save_delayed_sequence_references(@device)
         validate_search_reply(versioned_resource_class('Device'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_implantable_device_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_implantable_device_sequence.rb
@@ -77,8 +77,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @device = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @device = reply&.resource&.entry&.first&.resource
         @device_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @device_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Device'), reply)
         save_delayed_sequence_references(@device)
         validate_search_reply(versioned_resource_class('Device'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
@@ -106,7 +106,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @location = reply&.resource&.entry&.first&.resource
-        @location_ary = fetch_all_search_results(reply&.resource)
+        @location_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Location'), reply)
         save_delayed_sequence_references(@location)
         validate_search_reply(versioned_resource_class('Location'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
@@ -106,14 +106,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @location = reply&.resource&.entry&.first&.resource
-        @location_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @location_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @location_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Location'), reply)
         save_delayed_sequence_references(@location)
         validate_search_reply(versioned_resource_class('Location'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
@@ -105,8 +105,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @location = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @location = reply&.resource&.entry&.first&.resource
         @location_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @location_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Location'), reply)
         save_delayed_sequence_references(@location)
         validate_search_reply(versioned_resource_class('Location'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_medicationrequest_sequence.rb
@@ -91,8 +91,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @medicationrequest = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @medicationrequest = reply&.resource&.entry&.first&.resource
         @medicationrequest_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @medicationrequest_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
         save_delayed_sequence_references(@medicationrequest)
         validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_medicationrequest_sequence.rb
@@ -92,7 +92,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @medicationrequest = reply&.resource&.entry&.first&.resource
-        @medicationrequest_ary = fetch_all_search_results(reply&.resource)
+        @medicationrequest_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
         save_delayed_sequence_references(@medicationrequest)
         validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_medicationrequest_sequence.rb
@@ -92,14 +92,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @medicationrequest = reply&.resource&.entry&.first&.resource
-        @medicationrequest_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @medicationrequest_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @medicationrequest_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
         save_delayed_sequence_references(@medicationrequest)
         validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_observation_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_observation_lab_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_observation_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_observation_lab_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
@@ -94,7 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @organization = reply&.resource&.entry&.first&.resource
-        @organization_ary = fetch_all_search_results(reply&.resource)
+        @organization_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Organization'), reply)
         save_delayed_sequence_references(@organization)
         validate_search_reply(versioned_resource_class('Organization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
@@ -93,8 +93,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @organization = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @organization = reply&.resource&.entry&.first&.resource
         @organization_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @organization_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Organization'), reply)
         save_delayed_sequence_references(@organization)
         validate_search_reply(versioned_resource_class('Organization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
@@ -94,14 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @organization = reply&.resource&.entry&.first&.resource
-        @organization_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @organization_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @organization_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Organization'), reply)
         save_delayed_sequence_references(@organization)
         validate_search_reply(versioned_resource_class('Organization'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_patient_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_patient_sequence.rb
@@ -103,14 +103,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @patient = reply&.resource&.entry&.first&.resource
-        @patient_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @patient_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @patient_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Patient'), reply)
         save_delayed_sequence_references(@patient)
         validate_search_reply(versioned_resource_class('Patient'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_patient_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_patient_sequence.rb
@@ -103,7 +103,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @patient = reply&.resource&.entry&.first&.resource
-        @patient_ary = fetch_all_search_results(reply&.resource)
+        @patient_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Patient'), reply)
         save_delayed_sequence_references(@patient)
         validate_search_reply(versioned_resource_class('Patient'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_patient_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_patient_sequence.rb
@@ -102,8 +102,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @patient = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @patient = reply&.resource&.entry&.first&.resource
         @patient_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @patient_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Patient'), reply)
         save_delayed_sequence_references(@patient)
         validate_search_reply(versioned_resource_class('Patient'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_practitioner_sequence.rb
@@ -101,14 +101,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @practitioner = reply&.resource&.entry&.first&.resource
-        @practitioner_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @practitioner_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @practitioner_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Practitioner'), reply)
         save_delayed_sequence_references(@practitioner)
         validate_search_reply(versioned_resource_class('Practitioner'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_practitioner_sequence.rb
@@ -100,8 +100,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @practitioner = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @practitioner = reply&.resource&.entry&.first&.resource
         @practitioner_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @practitioner_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Practitioner'), reply)
         save_delayed_sequence_references(@practitioner)
         validate_search_reply(versioned_resource_class('Practitioner'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_practitioner_sequence.rb
@@ -101,7 +101,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @practitioner = reply&.resource&.entry&.first&.resource
-        @practitioner_ary = fetch_all_search_results(reply&.resource)
+        @practitioner_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Practitioner'), reply)
         save_delayed_sequence_references(@practitioner)
         validate_search_reply(versioned_resource_class('Practitioner'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_practitionerrole_sequence.rb
@@ -93,8 +93,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @practitionerrole = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @practitionerrole = reply&.resource&.entry&.first&.resource
         @practitionerrole_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @practitionerrole_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('PractitionerRole'), reply)
         save_delayed_sequence_references(@practitionerrole)
         validate_search_reply(versioned_resource_class('PractitionerRole'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_practitionerrole_sequence.rb
@@ -94,7 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @practitionerrole = reply&.resource&.entry&.first&.resource
-        @practitionerrole_ary = fetch_all_search_results(reply&.resource)
+        @practitionerrole_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('PractitionerRole'), reply)
         save_delayed_sequence_references(@practitionerrole)
         validate_search_reply(versioned_resource_class('PractitionerRole'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_practitionerrole_sequence.rb
@@ -94,14 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @practitionerrole = reply&.resource&.entry&.first&.resource
-        @practitionerrole_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @practitionerrole_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @practitionerrole_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('PractitionerRole'), reply)
         save_delayed_sequence_references(@practitionerrole)
         validate_search_reply(versioned_resource_class('PractitionerRole'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_procedure_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_procedure_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @procedure = reply&.resource&.entry&.first&.resource
-        @procedure_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @procedure_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @procedure_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Procedure'), reply)
         save_delayed_sequence_references(@procedure)
         validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_procedure_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_procedure_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @procedure = reply&.resource&.entry&.first&.resource
-        @procedure_ary = fetch_all_search_results(reply&.resource)
+        @procedure_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Procedure'), reply)
         save_delayed_sequence_references(@procedure)
         validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_procedure_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_procedure_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @procedure = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @procedure = reply&.resource&.entry&.first&.resource
         @procedure_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @procedure_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Procedure'), reply)
         save_delayed_sequence_references(@procedure)
         validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_pulse_oximetry_sequence.rb
@@ -94,14 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_pulse_oximetry_sequence.rb
@@ -93,8 +93,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @observation = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @observation = reply&.resource&.entry&.first&.resource
         @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_pulse_oximetry_sequence.rb
@@ -94,7 +94,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply)
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_smokingstatus_sequence.rb
@@ -88,7 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_search_results(reply&.resource)
+        @observation_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_smokingstatus_sequence.rb
@@ -87,8 +87,15 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @observation = reply.try(:resource).try(:entry).try(:first).try(:resource)
+        @observation = reply&.resource&.entry&.first&.resource
         @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = reply&.resource&.next_bundle
+        until next_bundle.nil? || page_count == 100
+          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/modules/uscore_v3.0.1/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_smokingstatus_sequence.rb
@@ -88,14 +88,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = reply&.resource&.entry&.map { |entry| entry&.resource }
-        page_count = 1
-        next_bundle = reply&.resource&.next_bundle
-        until next_bundle.nil? || page_count == 100
-          @observation_ary += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle = next_bundle.next_bundle
-          page_count += 1
-        end
+        @observation_ary = fetch_all_search_results(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
         save_delayed_sequence_references(@observation)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -807,11 +807,23 @@ module Inferno
         case comparator
         when 'lt', 'le'
           comparator + (DateTime.xmlschema(date) + 1).xmlschema
-        when 'gt', 'ge'
+        when 'gt', 'ge' 
           comparator + (DateTime.xmlschema(date) - 1).xmlschema
         else
           ''
         end
+      end
+
+      def fetch_all_search_results(bundle)
+        resources = bundle&.entry&.map { |entry| entry&.resource }
+        page_count = 1
+        next_bundle = bundle.next_bundle
+        until next_bundle.nil? || page_count == 20
+          resources += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle = next_bundle.next_bundle
+          page_count += 1
+        end
+        resources
       end
     end
 

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -807,7 +807,7 @@ module Inferno
         case comparator
         when 'lt', 'le'
           comparator + (DateTime.xmlschema(date) + 1).xmlschema
-        when 'gt', 'ge' 
+        when 'gt', 'ge'
           comparator + (DateTime.xmlschema(date) - 1).xmlschema
         else
           ''
@@ -817,10 +817,14 @@ module Inferno
       def fetch_all_search_results(bundle)
         resources = bundle&.entry&.map { |entry| entry&.resource }
         page_count = 1
+        next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url
         next_bundle = bundle.next_bundle
+        assert next_bundle_link.nil? || !next_bundle.nil?, "Could not resolve next bundle. #{next_bundle_link}"
         until next_bundle.nil? || page_count == 20
           resources += next_bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle_link = next_bundle&.link&.find { |link| link.relation == 'next' }&.url
           next_bundle = next_bundle.next_bundle
+          assert next_bundle_link.nil? || !next_bundle.nil?, "Could not resolve next bundle. #{next_bundle_link}"
           page_count += 1
         end
         resources

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -814,7 +814,7 @@ module Inferno
         end
       end
 
-      def fetch_all_search_results(bundle)
+      def fetch_all_bundled_resources(bundle)
         resources = bundle&.entry&.map { |entry| entry&.resource }
         page_count = 1
         next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -815,16 +815,13 @@ module Inferno
       end
 
       def fetch_all_bundled_resources(bundle)
-        resources = bundle&.entry&.map { |entry| entry&.resource }
         page_count = 1
-        next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url
-        next_bundle = bundle.next_bundle
-        assert next_bundle_link.nil? || !next_bundle.nil?, "Could not resolve next bundle. #{next_bundle_link}"
-        until next_bundle.nil? || page_count == 20
-          resources += next_bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle_link = next_bundle&.link&.find { |link| link.relation == 'next' }&.url
-          next_bundle = next_bundle.next_bundle
-          assert next_bundle_link.nil? || !next_bundle.nil?, "Could not resolve next bundle. #{next_bundle_link}"
+        resources = []
+        until bundle.nil? || page_count == 20
+          resources += bundle&.entry&.map { |entry| entry&.resource }
+          next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url
+          bundle = bundle.next_bundle
+          assert next_bundle_link.nil? || !bundle.nil?, "Could not resolve next bundle. #{next_bundle_link}"
           page_count += 1
         end
         resources

--- a/test/fixtures/bundle_1.json
+++ b/test/fixtures/bundle_1.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "1"
+      }
+    }
+  ],
+  "link": [
+    {
+      "relation": "next",
+      "url": "http://www.example.com/2"
+    }
+  ]
+}

--- a/test/fixtures/bundle_2.json
+++ b/test/fixtures/bundle_2.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "2"
+      }
+    }
+  ]
+}

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -49,7 +49,7 @@ class SequenceBaseTest < MiniTest::Test
     resource.recorder = new_reference
   end
 
-  describe '#fetch_all_search_results' do
+  describe '#fetch_all_bundled_resources' do
     before do
       @bundle1 = FHIR.from_contents(load_fixture(:bundle_1))
       @bundle2 = load_fixture(:bundle_2)
@@ -64,7 +64,7 @@ class SequenceBaseTest < MiniTest::Test
       stub_request(:get, @bundle1.link.first.url)
         .to_return(body: @bundle2)
 
-      all_resources = @sequence.fetch_all_search_results(@bundle1)
+      all_resources = @sequence.fetch_all_bundled_resources(@bundle1)
       assert all_resources.map(&:id) == ['1', '2']
     end
 
@@ -73,8 +73,13 @@ class SequenceBaseTest < MiniTest::Test
         .to_return(body: '', status: 404)
 
       assert_raises Inferno::AssertionException do
-        @sequence.fetch_all_search_results(@bundle1)
+        @sequence.fetch_all_bundled_resources(@bundle1)
       end
+    end
+
+    it 'returns resources when no next page' do
+      all_resources = @sequence.fetch_all_bundled_resources(FHIR.from_contents(@bundle2))
+      assert all_resources.map(&:id) == ['2']
     end
   end
 end


### PR DESCRIPTION
Currently, sequences only saves the resources returned in the first page of the search response. This PR updates each sequences to go through all the pages. These results aren't being used for anything special right now, but will allow us to build more robust tests in the future.

You can test this by looking at the HTTP requests from searches. HSPC has 10 resources per page so do a search with >10 resources. I used encounter for Adams, Daniel X in the HSPC sandbox.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-365
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
