### PR TITLE
fi-279-omit authorization test if no bearer token is set

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -122,7 +122,7 @@ module Inferno
 
         authorization_test[:test_code] = %(
               @client.set_no_auth
-              skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+              omit 'Do not test if no bearer token set' if @instance.token.blank?
       #{get_search_params(first_search[:names], sequence)}
               reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
               @client.set_bearer_token(@instance.token)

--- a/lib/app/modules/uscore_v3.0.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/pediatric_bmi_for_age_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, code: '59576-9' }
 

--- a/lib/app/modules/uscore_v3.0.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/pediatric_weight_for_height_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, code: '77606-2' }
 

--- a/lib/app/modules/uscore_v3.0.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_allergyintolerance_sequence.rb
@@ -44,7 +44,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_careplan_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_careplan_sequence.rb
@@ -54,7 +54,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, category: 'assess-plan' }
 

--- a/lib/app/modules/uscore_v3.0.0/us_core_careteam_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_careteam_sequence.rb
@@ -44,7 +44,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, status: 'active' }
 

--- a/lib/app/modules/uscore_v3.0.0/us_core_condition_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_condition_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_device_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_device_sequence.rb
@@ -44,7 +44,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_lab_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, category: 'LAB' }
 

--- a/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_diagnosticreport_note_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, code: 'LP29684-5' }
 

--- a/lib/app/modules/uscore_v3.0.0/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_documentreference_sequence.rb
@@ -66,7 +66,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_encounter_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_encounter_sequence.rb
@@ -66,7 +66,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_goal_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_goal_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_immunization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_immunization_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
@@ -72,7 +72,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         name_val = resolve_element_from_path(@location, 'name')
         search_params = { 'name': name_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_medicationrequest_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_medicationstatement_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_medicationstatement_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_observation_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_observation_lab_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, category: 'laboratory' }
 

--- a/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         name_val = resolve_element_from_path(@organization, 'name')
         search_params = { 'name': name_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_patient_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_patient_sequence.rb
@@ -73,7 +73,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { '_id': @instance.patient_id }
 

--- a/lib/app/modules/uscore_v3.0.0/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_practitioner_sequence.rb
@@ -67,7 +67,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         name_val = resolve_element_from_path(@practitioner, 'name.family')
         search_params = { 'name': name_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_practitionerrole_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         specialty_val = resolve_element_from_path(@practitionerrole, 'specialty.coding.code')
         search_params = { 'specialty': specialty_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_procedure_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_procedure_sequence.rb
@@ -54,7 +54,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.0/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_smokingstatus_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, code: '72166-2' }
 

--- a/lib/app/modules/uscore_v3.0.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/pediatric_bmi_for_age_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, code: '59576-9' }
 

--- a/lib/app/modules/uscore_v3.0.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/pediatric_weight_for_height_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, code: '77606-2' }
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_allergyintolerance_sequence.rb
@@ -44,7 +44,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_careplan_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_careplan_sequence.rb
@@ -54,7 +54,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, category: 'assess-plan' }
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_careteam_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_careteam_sequence.rb
@@ -44,7 +44,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, status: 'active' }
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_condition_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_condition_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_lab_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, category: 'LAB' }
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_diagnosticreport_note_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, code: 'LP29684-5' }
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_documentreference_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_documentreference_sequence.rb
@@ -66,7 +66,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_encounter_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_encounter_sequence.rb
@@ -66,7 +66,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_goal_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_goal_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_immunization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_immunization_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_implantable_device_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_implantable_device_sequence.rb
@@ -44,7 +44,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
@@ -72,7 +72,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         name_val = resolve_element_from_path(@location, 'name')
         search_params = { 'name': name_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_medicationrequest_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_medicationrequest_sequence.rb
@@ -56,7 +56,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         intent_val = resolve_element_from_path(@medicationrequest, 'intent')

--- a/lib/app/modules/uscore_v3.0.1/us_core_observation_lab_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_observation_lab_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, category: 'laboratory' }
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         name_val = resolve_element_from_path(@organization, 'name')
         search_params = { 'name': name_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_patient_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_patient_sequence.rb
@@ -73,7 +73,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { '_id': @instance.patient_id }
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_practitioner_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_practitioner_sequence.rb
@@ -67,7 +67,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         name_val = resolve_element_from_path(@practitioner, 'name.family')
         search_params = { 'name': name_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_practitionerrole_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_practitionerrole_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         specialty_val = resolve_element_from_path(@practitionerrole, 'specialty.coding.code')
         search_params = { 'specialty': specialty_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_procedure_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_procedure_sequence.rb
@@ -54,7 +54,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         search_params = { 'patient': patient_val }

--- a/lib/app/modules/uscore_v3.0.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_pulse_oximetry_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         patient_val = @instance.patient_id
         code_val = resolve_element_from_path(@observation, 'code.coding.code')

--- a/lib/app/modules/uscore_v3.0.1/us_core_smokingstatus_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_smokingstatus_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
         end
 
         @client.set_no_auth
-        skip 'Could not verify this functionality when bearer token is not set' if @instance.token.blank?
+        omit 'Do not test if no bearer token set' if @instance.token.blank?
 
         search_params = { patient: @instance.patient_id, code: '72166-2' }
 


### PR DESCRIPTION
Currently, authorization tests for each sequence are skipped if no bearer token is set. Instead, we should omit them. This is meant for open endpoints that don't need a bearer token.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-279
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
