### PR TITLE
FI-330: Make sequences more testable

### DIFF
--- a/lib/app/models/inferno_test.rb
+++ b/lib/app/models/inferno_test.rb
@@ -3,14 +3,22 @@
 module Inferno
   module Sequence
     class InfernoTest
-      attr_reader :name, :index, :id_prefix, :test_block
+      attr_reader :key, :index, :id_prefix, :test_block
 
-      def initialize(name, index, id_prefix, &test_block)
-        @name = name
+      def initialize(key_or_name, index, id_prefix, &test_block)
+        if key_or_name.instance_of? Symbol
+          @key = key_or_name
+        else
+          @name = key_or_name
+        end
         @index = index
         @id_prefix = id_prefix
         @test_block = test_block
         load_metadata
+      end
+
+      def name(name = nil)
+        @name ||= name
       end
 
       def id(id = nil)
@@ -72,7 +80,13 @@ module Inferno
 
       def load_metadata
         instance_eval(&test_block)
-      rescue MetadataException # rubocop:disable Lint/HandleExceptions
+      rescue MetadataException
+        validate_metadata
+      end
+
+      def validate_metadata
+        raise InvalidMetadataException, 'Test id must be populated' if id.blank?
+        raise InvalidMetadataException, 'Test name must be populated' if name.blank?
       end
     end
   end

--- a/lib/app/modules/smart/token_refresh_sequence.rb
+++ b/lib/app/modules/smart/token_refresh_sequence.rb
@@ -56,7 +56,8 @@ module Inferno
         LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params, oauth2_headers)
       end
 
-      test 'Refresh token exchange fails when provided invalid Refresh Token.' do
+      INVALID_REFRESH_TOKEN_TEST = 'Refresh token exchange fails when provided invalid Refresh Token.'
+      test INVALID_REFRESH_TOKEN_TEST do
         metadata do
           id '01'
           link 'https://tools.ietf.org/html/rfc6749'
@@ -68,7 +69,8 @@ module Inferno
         assert_response_bad_or_unauthorized token_response
       end
 
-      test 'Refresh token exchange fails when provided invalid Client ID.' do
+      INVALID_CLIENT_ID_TEST = 'Refresh token exchange fails when provided invalid Client ID.'
+      test INVALID_CLIENT_ID_TEST do
         metadata do
           id '02'
           link 'https://tools.ietf.org/html/rfc6749'
@@ -144,7 +146,9 @@ module Inferno
         end
       end
 
-      test 'Server successfully refreshes the access token when optional scope parameter omitted.' do
+      REFRESH_WITHOUT_SCOPE_PARAMETER_TEST =
+        'Server successfully refreshes the access token when optional scope parameter omitted.'
+      test REFRESH_WITHOUT_SCOPE_PARAMETER_TEST do
         metadata do
           id '03'
           link 'https://tools.ietf.org/html/rfc6749'
@@ -168,7 +172,9 @@ module Inferno
         validate_and_save_refresh_response(token_response)
       end
 
-      test 'Server successfully refreshes the access token when optional scope parameter provided.' do
+      REFRESH_WITH_SCOPE_PARAMETER_TEST =
+        'Server successfully refreshes the access token when optional scope parameter provided.'
+      test REFRESH_WITH_SCOPE_PARAMETER_TEST do
         metadata do
           id '04'
           link 'https://tools.ietf.org/html/rfc6749'

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -311,8 +311,8 @@ module Inferno
         @tests ||= []
       end
 
-      def self.[](name)
-        tests.find { |test| test.name == name }
+      def self.[](key)
+        tests.find { |test| test.key == key }
       end
 
       def optional?

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -311,6 +311,10 @@ module Inferno
         @tests ||= []
       end
 
+      def self.[](name)
+        tests.find { |test| test.name == name }
+      end
+
       def optional?
         self.class.optional?
       end
@@ -382,7 +386,7 @@ module Inferno
               fhir_version_included = @instance.fhir_version.present? && self.class.versions.include?(@instance.fhir_version&.to_sym)
               skip_unless(fhir_version_included, 'This test does not run with this FHIR version')
               Inferno.logger.info "Starting Test: #{test.id} [#{test.name}]"
-              instance_eval(&test.test_block)
+              run_test(test)
             rescue StandardError => e
               if e.respond_to? :update_result
                 e.update_result(result)
@@ -398,6 +402,10 @@ module Inferno
             Inferno.logger.info "Finished Test: #{test.id} [#{result.result}]"
           end
         end
+      end
+
+      def run_test(test)
+        instance_eval(&test.test_block)
       end
 
       # Metadata loading is handled by InfernoTest

--- a/lib/app/utils/exceptions.rb
+++ b/lib/app/utils/exceptions.rb
@@ -98,6 +98,9 @@ module Inferno
 
   class MetadataException < RuntimeError
   end
+
+  class InvalidMetadataException < RuntimeError
+  end
 end
 
 # monkey patch this exception from fhir_client

--- a/test/sequence/smart/token_refresh_sequence_test.rb
+++ b/test/sequence/smart/token_refresh_sequence_test.rb
@@ -4,10 +4,6 @@ require_relative '../../test_helper'
 
 describe Inferno::Sequence::TokenRefreshSequence do
   SEQUENCE = Inferno::Sequence::TokenRefreshSequence
-  INVALID_REFRESH_TOKEN_TEST = SEQUENCE::INVALID_REFRESH_TOKEN_TEST
-  INVALID_CLIENT_ID_TEST = SEQUENCE::INVALID_CLIENT_ID_TEST
-  REFRESH_WITH_SCOPE_PARAMETER_TEST = SEQUENCE::REFRESH_WITH_SCOPE_PARAMETER_TEST
-  REFRESH_WITHOUT_SCOPE_PARAMETER_TEST = SEQUENCE::REFRESH_WITHOUT_SCOPE_PARAMETER_TEST
 
   let(:full_body) do
     {
@@ -24,9 +20,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
     @instance = Inferno::Models::TestingInstance.new(oauth_token_endpoint: @token_endpoint, scopes: 'jkl')
   end
 
-  describe INVALID_REFRESH_TOKEN_TEST do
+  describe 'invalid refresh token test' do
     before do
-      @test = SEQUENCE[INVALID_REFRESH_TOKEN_TEST]
+      @test = SEQUENCE[:invalid_refresh_token]
       @sequence = SEQUENCE.new(@instance, @client)
     end
 
@@ -47,9 +43,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
     end
   end
 
-  describe INVALID_CLIENT_ID_TEST do
+  describe 'invalid client id test' do
     before do
-      @test = SEQUENCE[INVALID_CLIENT_ID_TEST]
+      @test = SEQUENCE[:invalid_client_id]
       @sequence = SEQUENCE.new(@instance, @client)
     end
 
@@ -70,9 +66,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
     end
   end
 
-  describe REFRESH_WITH_SCOPE_PARAMETER_TEST do
+  describe 'refresh with scope parameter test' do
     before do
-      @test = SEQUENCE[REFRESH_WITH_SCOPE_PARAMETER_TEST]
+      @test = SEQUENCE[:refresh_with_scope]
       @sequence = SEQUENCE.new(@instance, @client)
     end
 
@@ -93,9 +89,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
     end
   end
 
-  describe REFRESH_WITHOUT_SCOPE_PARAMETER_TEST do
+  describe 'refresh without scope parameter test' do
     before do
-      @test = SEQUENCE[REFRESH_WITHOUT_SCOPE_PARAMETER_TEST]
+      @test = SEQUENCE[:refresh_without_scope]
       @sequence = SEQUENCE.new(@instance, @client)
     end
 

--- a/test/sequence/smart/token_refresh_sequence_test.rb
+++ b/test/sequence/smart/token_refresh_sequence_test.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+describe Inferno::Sequence::TokenRefreshSequence do
+  SEQUENCE = Inferno::Sequence::TokenRefreshSequence
+  INVALID_REFRESH_TOKEN_TEST = SEQUENCE::INVALID_REFRESH_TOKEN_TEST
+  INVALID_CLIENT_ID_TEST = SEQUENCE::INVALID_CLIENT_ID_TEST
+  REFRESH_WITH_SCOPE_PARAMETER_TEST = SEQUENCE::REFRESH_WITH_SCOPE_PARAMETER_TEST
+  REFRESH_WITHOUT_SCOPE_PARAMETER_TEST = SEQUENCE::REFRESH_WITHOUT_SCOPE_PARAMETER_TEST
+
+  let(:full_body) do
+    {
+      'access_token' => 'abc',
+      'expires_in' => 'def',
+      'token_type' => 'Bearer',
+      'scope' => 'jkl'
+    }
+  end
+
+  before do
+    @token_endpoint = 'http://www.example.com/token'
+    @client = FHIR::Client.new('http://www.example.com/fhir')
+    @instance = Inferno::Models::TestingInstance.new(oauth_token_endpoint: @token_endpoint, scopes: 'jkl')
+  end
+
+  describe INVALID_REFRESH_TOKEN_TEST do
+    before do
+      @test = SEQUENCE[INVALID_REFRESH_TOKEN_TEST]
+      @sequence = SEQUENCE.new(@instance, @client)
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:post, @token_endpoint)
+        .with(body: hash_including(refresh_token: SEQUENCE::INVALID_REFRESH_TOKEN))
+        .to_return(status: 200)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:post, @token_endpoint)
+        .with(body: hash_including(refresh_token: SEQUENCE::INVALID_REFRESH_TOKEN))
+        .to_return(status: 400)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe INVALID_CLIENT_ID_TEST do
+    before do
+      @test = SEQUENCE[INVALID_CLIENT_ID_TEST]
+      @sequence = SEQUENCE.new(@instance, @client)
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:post, @token_endpoint)
+        .with(body: hash_including(client_id: SEQUENCE::INVALID_CLIENT_ID))
+        .to_return(status: 200)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'succeeds when the token refresh has an error status' do
+      stub_request(:post, @token_endpoint)
+        .with(body: hash_including(client_id: SEQUENCE::INVALID_CLIENT_ID))
+        .to_return(status: 400)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe REFRESH_WITH_SCOPE_PARAMETER_TEST do
+    before do
+      @test = SEQUENCE[REFRESH_WITH_SCOPE_PARAMETER_TEST]
+      @sequence = SEQUENCE.new(@instance, @client)
+    end
+
+    it 'succeeds when the token refresh succeeds' do
+      stub_request(:post, @token_endpoint)
+        .with(body: hash_including(scope: 'jkl'))
+        .to_return(status: 200, body: full_body.to_json, headers: {})
+
+      @sequence.run_test(@test)
+    end
+
+    it 'fails when the token refresh fails' do
+      stub_request(:post, @token_endpoint)
+        .with(body: hash_including(scope: 'jkl'))
+        .to_return(status: 400)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+
+  describe REFRESH_WITHOUT_SCOPE_PARAMETER_TEST do
+    before do
+      @test = SEQUENCE[REFRESH_WITHOUT_SCOPE_PARAMETER_TEST]
+      @sequence = SEQUENCE.new(@instance, @client)
+    end
+
+    it 'succeeds when the token refresh succeeds' do
+      stub_request(:post, @token_endpoint)
+        .with { |request| !request.body.include? 'scope' }
+        .to_return(status: 200, body: full_body.to_json, headers: {})
+
+      @sequence.run_test(@test)
+    end
+
+    it 'fails when the token refresh fails' do
+      stub_request(:post, @token_endpoint)
+        .with { |request| !request.body.include? 'scope' }
+        .to_return(status: 400)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+
+  describe '#validate_and_save_refresh_response' do
+    let(:successful_response) do
+      OpenStruct.new(
+        code: 200,
+        body: full_body.to_json,
+        headers: {}
+      )
+    end
+
+    before do
+      @sequence = SEQUENCE.new(@instance, @client)
+    end
+
+    it 'fails when the token response has an error status' do
+      response = OpenStruct.new(code: 400)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.validate_and_save_refresh_response(response) }
+      assert_equal('Bad response code: expected 200, 201, but found 400. ', exception.message)
+    end
+
+    it 'fails when the token response body is invalid json' do
+      response = OpenStruct.new(code: 200, body: '{')
+      exception = assert_raises(Inferno::AssertionException) { @sequence.validate_and_save_refresh_response(response) }
+      assert_equal('Invalid JSON', exception.message)
+    end
+
+    it 'fails when the token response does not contain an access token' do
+      response = OpenStruct.new(code: 200, body: '{"not_access_token":"abc"}')
+      exception = assert_raises(Inferno::AssertionException) { @sequence.validate_and_save_refresh_response(response) }
+      assert_equal('Token response did not contain access_token as required', exception.message)
+    end
+
+    it 'fails when the token response does not contain a required field' do
+      required_fields = ['expires_in', 'token_type', 'scope']
+      required_fields.each do |field|
+        body = full_body.reject { |key, _| key == field }.to_json
+        response = OpenStruct.new(code: 200, body: body)
+        exception = assert_raises(Inferno::AssertionException) { @sequence.validate_and_save_refresh_response(response) }
+        assert_equal("Token response did not contain #{field} as required", exception.message)
+      end
+    end
+
+    it 'fails when the token_type is not "Bearer"' do
+      full_body['token_type'] = 'ghi'
+      response = OpenStruct.new(code: 200, body: full_body.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.validate_and_save_refresh_response(response) }
+      assert_equal('Token type must be Bearer.', exception.message)
+    end
+
+    it 'creates a warning when scopes are missing' do
+      @instance.scopes = 'jkl mno'
+      @sequence.validate_and_save_refresh_response(successful_response)
+
+      warnings = @sequence.instance_variable_get(:'@test_warnings')
+      assert_includes(warnings, 'Token exchange response did not include expected scopes: ["mno"]')
+    end
+
+    it 'creates a warning when the body has no patient field' do
+      @sequence.validate_and_save_refresh_response(successful_response)
+
+      warnings = @sequence.instance_variable_get(:'@test_warnings')
+      assert_includes(warnings, 'No patient id provided in token exchange.')
+    end
+
+    it 'creates a warning when the cache_control header is missing' do
+      @sequence.validate_and_save_refresh_response(successful_response)
+
+      warnings = @sequence.instance_variable_get(:'@test_warnings')
+      assert_includes(warnings, 'Token response headers did not contain cache_control as is recommended for token exchanges.')
+    end
+
+    it 'creates a warning when the pragma header is missing' do
+      successful_response.headers = { cache_control: 'abc' }
+      @sequence.validate_and_save_refresh_response(successful_response)
+
+      warnings = @sequence.instance_variable_get(:'@test_warnings')
+      assert_includes(warnings, 'Token response headers did not contain pragma as is recommended for token exchanges.')
+    end
+
+    it 'creates a warning when the cache_control header is not set to "no-store"' do
+      successful_response.headers = { cache_control: 'abc', pragma: 'def' }
+      @sequence.validate_and_save_refresh_response(successful_response)
+
+      warnings = @sequence.instance_variable_get(:'@test_warnings')
+      assert_includes(warnings, 'Token response header should have cache_control containing no-store.')
+    end
+
+    it 'creates a warning when the pragma header is not set to "no-cache"' do
+      successful_response.headers = { cache_control: 'no-store', pragma: 'def' }
+      @sequence.validate_and_save_refresh_response(successful_response)
+
+      warnings = @sequence.instance_variable_get(:'@test_warnings')
+      assert_includes(warnings, 'Token response header should have pragma containing no-cache.')
+    end
+  end
+end


### PR DESCRIPTION
This branch adds methods to find and execute a single test within a sequence. It also adds sample unit tests for a sequence.

The sample sequence was updated to use constants for the test names to avoid duplicating these, but this is a change we may want to revert.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-330
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
