### PR TITLE
FI-385: Check for US Core profile support

### DIFF
--- a/lib/app/models/server_capabilities.rb
+++ b/lib/app/models/server_capabilities.rb
@@ -30,6 +30,12 @@ module Inferno
         end
       end
 
+      def supported_profiles
+        statement.rest.flat_map(&:resource)
+          &.flat_map { |resource| resource.supportedProfile + [resource.profile] }
+          &.compact || []
+      end
+
       def operation_supported?(operation_name)
         statement.rest.any? { |rest| rest.operation.any? { |operation| operation.name == operation_name } }
       end

--- a/lib/app/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
+++ b/lib/app/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
@@ -88,9 +88,10 @@ module Inferno
         'Provenance' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance']
       }.freeze
 
-      test 'FHIR server capability states JSON support' do
+      test :json_support do
         metadata do
           id '04'
+          name 'FHIR server capability states JSON support'
           link 'http://hl7.org/fhir/us/core/2019Jan/CapabilityStatement-us-core-server.html'
           description %(
 
@@ -118,9 +119,10 @@ module Inferno
         assert json_formats.any? { |format| @conformance.format.include? format }, 'Conformance does not state support for json.'
       end
 
-      test 'Capability Statement lists support for required US Core Profiles' do
+      test :profile_support do
         metadata do
           id '05'
+          name 'Capability Statement lists support for required US Core Profiles'
           link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html#behavior'
           description %(
            The US Core Implementation Guide states:
@@ -146,10 +148,11 @@ module Inferno
 
         PROFILES.each do |resource, profiles|
           next unless supported_resources.include? resource
+
           profiles.each do |profile|
             warning do
               message = "CapabilityStatement does not claim support for US Core #{resource} profile: #{profile}"
-              assert supported_profiles.include? profile, message
+              assert supported_profiles&.include?(profile), message
             end
           end
         end

--- a/lib/app/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
+++ b/lib/app/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
@@ -55,6 +55,35 @@ module Inferno
         * [DSTU2 Conformance Statement](https://www.hl7.org/fhir/DSTU2/conformance.html)
       )
 
+      PROFILES = [
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
+        'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
+        'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
+        'http://hl7.org/fhir/StructureDefinition/vitalsigns'
+      ].freeze
+
       test 'FHIR server capability states JSON support' do
         metadata do
           id '04'
@@ -85,26 +114,33 @@ module Inferno
         assert json_formats.any? { |format| @conformance.format.include? format }, 'Conformance does not state support for json.'
       end
 
-      test 'Capability Statement lists supported US Core profiles, operations and search parameters' do
+      test 'Capability Statement lists support for required US Core Profiles' do
         metadata do
           id '05'
-          link 'http://hl7.org/fhir/us/core/2019Jan/CapabilityStatement-us-core-server.html'
-          desc %(
+          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html#behavior'
+          description %(
            The US Core Implementation Guide states:
 
            ```
            The US Core Server SHALL:
-
-               1. Support the US Core Patient resource profile.
-               2. Support at least one additional resource profile from the list of US Core Profiles.
+           1. Support the US Core Patient resource profile.
+           2. Support at least one additional resource profile from the list of
+              US Core Profiles.
            ```
-
           )
         end
 
+        patient_profile = PROFILES.find { |profile| profile.end_with? 'patient' }
+
         assert_valid_conformance
 
-        assert @instance.conformance_supported?(:Patient, [:read]), 'Patient resource with read interaction is not listed in capability statement.'
+        assert @server_capabilities.supported_profiles.include?(patient_profile), 'US Core Patient profile not supported'
+
+        other_profiles = PROFILES.reject { |profile| profile == patient_profile }
+
+        other_profiles_supported = other_profiles & @server_capabilities.supported_profiles
+
+        assert other_profiles_supported.present?, 'No US Core profiles other than Patient are supported'
       end
     end
   end

--- a/lib/app/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
+++ b/lib/app/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
@@ -55,34 +55,38 @@ module Inferno
         * [DSTU2 Conformance Statement](https://www.hl7.org/fhir/DSTU2/conformance.html)
       )
 
-      PROFILES = [
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
-        'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
-        'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
-        'http://hl7.org/fhir/StructureDefinition/vitalsigns'
-      ].freeze
+      PROFILES = {
+        'AllergyIntolerance' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance'],
+        'CarePlan' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan'],
+        'CareTeam' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam'],
+        'Condition' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition'],
+        'Device' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'],
+        'DiagnosticReport' => [
+          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
+          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note'
+        ],
+        'DocumentReference' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'],
+        'Encounter' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'],
+        'Goal' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal'],
+        'Immunization' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization'],
+        'Location' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-location'],
+        'Medication' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'],
+        'MedicationRequest' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest'],
+        'Observation' => [
+          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
+          'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
+          'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
+          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
+          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
+          'http://hl7.org/fhir/StructureDefinition/vitalsigns'
+        ],
+        'Organization' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'],
+        'Patient' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'],
+        'Practitioner' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'],
+        'PractitionerRole' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'],
+        'Procedure' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure'],
+        'Provenance' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance']
+      }.freeze
 
       test 'FHIR server capability states JSON support' do
         metadata do
@@ -130,17 +134,25 @@ module Inferno
           )
         end
 
-        patient_profile = PROFILES.find { |profile| profile.end_with? 'patient' }
-
         assert_valid_conformance
+        supported_resources = @server_capabilities.supported_resources
+        supported_profiles = @server_capabilities.supported_profiles
 
-        assert @server_capabilities.supported_profiles.include?(patient_profile), 'US Core Patient profile not supported'
+        assert supported_resources.include?('Patient'), 'US Core Patient profile not supported'
 
-        other_profiles = PROFILES.reject { |profile| profile == patient_profile }
+        other_resources = PROFILES.keys.reject { |resource_type| resource_type == 'Patient' }
+        other_resources_supported = other_resources.any? { |resource| supported_resources.include? resource }
+        assert other_resources_supported, 'No US Core resources other than Patient are supported'
 
-        other_profiles_supported = other_profiles & @server_capabilities.supported_profiles
-
-        assert other_profiles_supported.present?, 'No US Core profiles other than Patient are supported'
+        PROFILES.each do |resource, profiles|
+          next unless supported_resources.include? resource
+          profiles.each do |profile|
+            warning do
+              message = "CapabilityStatement does not claim support for US Core #{resource} profile: #{profile}"
+              assert supported_profiles.include? profile, message
+            end
+          end
+        end
       end
     end
   end

--- a/test/model/server_capabilities_test.rb
+++ b/test/model/server_capabilities_test.rb
@@ -21,13 +21,18 @@ class ServerCapabilitiesTest < MiniTest::Test
             },
             {
               type: 'Condition',
+              profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
               interaction: [
                 { code: 'delete' },
                 { code: 'update' }
               ]
             },
             {
-              type: 'Observation'
+              type: 'Observation',
+              supportedProfile: [
+                'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
+                'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'
+              ]
             }
           ]
         }
@@ -119,5 +124,15 @@ class ServerCapabilitiesTest < MiniTest::Test
   def test_smart_capabilities
     assert @capabilities.smart_capabilities == []
     assert @smart_capabilities.smart_capabilities == ['launch-ehr', 'launch-standalone']
+  end
+
+  def test_supported_profiles
+    expected_profiles = [
+      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
+      'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
+      'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'
+    ]
+
+    assert_equal(expected_profiles, @capabilities.supported_profiles)
   end
 end

--- a/test/sequence/smart/token_refresh_sequence_test.rb
+++ b/test/sequence/smart/token_refresh_sequence_test.rb
@@ -3,8 +3,6 @@
 require_relative '../../test_helper'
 
 describe Inferno::Sequence::TokenRefreshSequence do
-  SEQUENCE = Inferno::Sequence::TokenRefreshSequence
-
   let(:full_body) do
     {
       'access_token' => 'abc',
@@ -15,6 +13,7 @@ describe Inferno::Sequence::TokenRefreshSequence do
   end
 
   before do
+    @sequence_class = Inferno::Sequence::TokenRefreshSequence
     @token_endpoint = 'http://www.example.com/token'
     @client = FHIR::Client.new('http://www.example.com/fhir')
     @instance = Inferno::Models::TestingInstance.new(oauth_token_endpoint: @token_endpoint, scopes: 'jkl')
@@ -22,13 +21,13 @@ describe Inferno::Sequence::TokenRefreshSequence do
 
   describe 'invalid refresh token test' do
     before do
-      @test = SEQUENCE[:invalid_refresh_token]
-      @sequence = SEQUENCE.new(@instance, @client)
+      @test = @sequence_class[:invalid_refresh_token]
+      @sequence = @sequence_class.new(@instance, @client)
     end
 
     it 'fails when the token refresh response has a success status' do
       stub_request(:post, @token_endpoint)
-        .with(body: hash_including(refresh_token: SEQUENCE::INVALID_REFRESH_TOKEN))
+        .with(body: hash_including(refresh_token: @sequence_class::INVALID_REFRESH_TOKEN))
         .to_return(status: 200)
 
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
@@ -36,7 +35,7 @@ describe Inferno::Sequence::TokenRefreshSequence do
 
     it 'succeeds when the token refresh response has an error status' do
       stub_request(:post, @token_endpoint)
-        .with(body: hash_including(refresh_token: SEQUENCE::INVALID_REFRESH_TOKEN))
+        .with(body: hash_including(refresh_token: @sequence_class::INVALID_REFRESH_TOKEN))
         .to_return(status: 400)
 
       @sequence.run_test(@test)
@@ -45,13 +44,13 @@ describe Inferno::Sequence::TokenRefreshSequence do
 
   describe 'invalid client id test' do
     before do
-      @test = SEQUENCE[:invalid_client_id]
-      @sequence = SEQUENCE.new(@instance, @client)
+      @test = @sequence_class[:invalid_client_id]
+      @sequence = @sequence_class.new(@instance, @client)
     end
 
     it 'fails when the token refresh response has a success status' do
       stub_request(:post, @token_endpoint)
-        .with(body: hash_including(client_id: SEQUENCE::INVALID_CLIENT_ID))
+        .with(body: hash_including(client_id: @sequence_class::INVALID_CLIENT_ID))
         .to_return(status: 200)
 
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
@@ -59,7 +58,7 @@ describe Inferno::Sequence::TokenRefreshSequence do
 
     it 'succeeds when the token refresh has an error status' do
       stub_request(:post, @token_endpoint)
-        .with(body: hash_including(client_id: SEQUENCE::INVALID_CLIENT_ID))
+        .with(body: hash_including(client_id: @sequence_class::INVALID_CLIENT_ID))
         .to_return(status: 400)
 
       @sequence.run_test(@test)
@@ -68,8 +67,8 @@ describe Inferno::Sequence::TokenRefreshSequence do
 
   describe 'refresh with scope parameter test' do
     before do
-      @test = SEQUENCE[:refresh_with_scope]
-      @sequence = SEQUENCE.new(@instance, @client)
+      @test = @sequence_class[:refresh_with_scope]
+      @sequence = @sequence_class.new(@instance, @client)
     end
 
     it 'succeeds when the token refresh succeeds' do
@@ -91,8 +90,8 @@ describe Inferno::Sequence::TokenRefreshSequence do
 
   describe 'refresh without scope parameter test' do
     before do
-      @test = SEQUENCE[:refresh_without_scope]
-      @sequence = SEQUENCE.new(@instance, @client)
+      @test = @sequence_class[:refresh_without_scope]
+      @sequence = @sequence_class.new(@instance, @client)
     end
 
     it 'succeeds when the token refresh succeeds' do
@@ -122,7 +121,7 @@ describe Inferno::Sequence::TokenRefreshSequence do
     end
 
     before do
-      @sequence = SEQUENCE.new(@instance, @client)
+      @sequence = @sequence_class.new(@instance, @client)
     end
 
     it 'fails when the token response has an error status' do

--- a/test/sequence/us_core_guidance/us_core_r4_capability_statement_sequence_test.rb
+++ b/test/sequence/us_core_guidance/us_core_r4_capability_statement_sequence_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+describe Inferno::Sequence::UsCoreR4CapabilityStatementSequence do
+  before do
+    @sequence_class = Inferno::Sequence::UsCoreR4CapabilityStatementSequence
+    @client = FHIR::Client.new('http://www.example.com/fhir')
+    @instance = Inferno::Models::TestingInstance.new(oauth_token_endpoint: @token_endpoint, scopes: 'jkl')
+    @instance.instance_variable_set(:'@module', OpenStruct.new(fhir_version: 'r4'))
+  end
+
+  # TODO: check assertion error messages
+  describe 'JSON support test' do
+    before do
+      @test = @sequence_class[:json_support]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'fails when the CapabilityStatement is invalid' do
+      @sequence.instance_variable_set(:'@conformance', FHIR::DSTU2::Conformance.new)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected valid CapabilityStatement resource.', exception.message
+    end
+
+    it 'fails when the CapabilityStatement has no JSON support' do
+      @sequence.instance_variable_set(:'@conformance', FHIR::CapabilityStatement.new)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Conformance does not state support for json.', exception.message
+    end
+
+    it 'succeeds when the CapabilityStatement has JSON support' do
+      @sequence.instance_variable_set(:'@conformance', FHIR::CapabilityStatement.new(format: ['application/fhir+json']))
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Profile support test' do
+    before do
+      @test = @sequence_class[:profile_support]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@conformance', FHIR::CapabilityStatement.new)
+    end
+
+    it 'fails when the CapabilityStatement is invalid' do
+      @sequence.instance_variable_set(:'@conformance', FHIR::DSTU2::Conformance.new)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected valid CapabilityStatement resource.', exception.message
+    end
+
+    it 'fails when the CapabilityStatement has no Patient support' do
+      @sequence.instance_variable_set(:'@server_capabilities', OpenStruct.new(supported_resources: ['Observation']))
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'US Core Patient profile not supported', exception.message
+    end
+
+    it 'fails when the CapabilityStatement has only Patient support' do
+      @sequence.instance_variable_set(:'@server_capabilities', OpenStruct.new(supported_resources: ['Patient']))
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal 'No US Core resources other than Patient are supported', exception.message
+    end
+
+    it 'generates a warning when the CapabilityStatement does not claim support for a US Core Profile' do
+      supported_resources = ['Patient', 'Condition']
+      @sequence.instance_variable_set(
+        :'@server_capabilities',
+        OpenStruct.new(supported_resources: supported_resources)
+      )
+
+      @sequence.run_test(@test)
+
+      warnings = @sequence.instance_variable_get(:'@test_warnings')
+      supported_resources.each do |resource|
+        profile = @sequence_class::PROFILES[resource].first
+        warning_message = "CapabilityStatement does not claim support for US Core #{resource} profile: #{profile}"
+
+        assert_includes(warnings, warning_message)
+      end
+    end
+
+    it 'succeeds without warnings when multiple US Core resources support all US Core profiles' do
+      supported_resources = ['Patient', 'Condition']
+      supported_profiles = supported_resources.map { |resource| @sequence_class::PROFILES[resource].first }
+      @sequence.instance_variable_set(
+        :'@server_capabilities',
+        OpenStruct.new(supported_resources: supported_resources, supported_profiles: supported_profiles)
+      )
+
+      @sequence.run_test(@test)
+
+      warnings = @sequence.instance_variable_get(:'@test_warnings')
+
+      assert warnings.blank?
+    end
+  end
+end


### PR DESCRIPTION
Update the US Core Capability Statement sequence to include a test that checks for support of the US Core Patient profile + one other US Core profile.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-385
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
