### PR TITLE
FI-421 cancel sequence fix

### DIFF
--- a/lib/app/endpoint/test_set_endpoints.rb
+++ b/lib/app/endpoint/test_set_endpoints.rb
@@ -86,12 +86,12 @@ module Inferno
             sequence.tests.each_with_index do |test, index|
               next if index < current_test_count
 
-              sequence_result.test_results << Inferno::Models::TestResult.new(test_id: test[:test_id],
-                                                                              name: test[:name],
+              sequence_result.test_results << Inferno::Models::TestResult.new(test_id: test.id,
+                                                                              name: test.name,
                                                                               result: 'cancel',
-                                                                              url: test[:url],
-                                                                              description: test[:description],
-                                                                              test_index: test[:test_index],
+                                                                              url: test.link,
+                                                                              description: test.description,
+                                                                              test_index: test.index,
                                                                               message: cancel_message)
             end
 


### PR DESCRIPTION
This PR fixes the "cancel sequence" button so it doesn't cause a server error when clicked (see below for a screenshot of the "before" behavior).

![Screen Shot 2019-10-11 at 2 13 42 PM](https://user-images.githubusercontent.com/49001/66675684-d30f6700-ec33-11e9-90db-3901cef2def2.png)

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-421
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
