### PR TITLE
FI-423 ID errors

### DIFF
--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -114,8 +114,8 @@
               <div class='align-items-center'>
                 <div class='group-overview-box'>
                   <% if group.test_cases.length > 1 %>
-                    
-                    <a class="sequence-anchor" id="<%=group.test_cases.map {|tc| tc.sequence.sequence_name}%>" name="<%=group.test_cases.map {|tc| tc.sequence.sequence_name}.join(',')%>"></a>
+
+                    <a class="sequence-anchor" id="<%=group.test_cases.map {|tc| tc.sequence.sequence_name}.join(',')%>" name="<%=group.test_cases.map {|tc| tc.sequence.sequence_name}.join(',')%>"></a>
 
                   <% end %>
                   <h1>

--- a/lib/app/views/report.erb
+++ b/lib/app/views/report.erb
@@ -76,7 +76,7 @@
         <div class='row align-items-center'>
           <div class='col'>
             <% if group.test_cases.length > 1 %>
-              <a class="sequence-anchor" id="<%=group.test_cases.map {|tc| tc.sequence.sequence_name}%>" name="<%=group.test_cases.map {|tc| tc.sequence.sequence_name}.join(',')%>"></a>
+              <a class="sequence-anchor" id="<%=group.test_cases.map {|tc| tc.sequence.sequence_name}.join(',')%>" name="<%=group.test_cases.map {|tc| tc.sequence.sequence_name}.join(',')%>"></a>
             <% end %>
             <h3>
               <%= group.name %>


### PR DESCRIPTION
When building the ID attribute of some HTML elements, we would occasionally get double-quotes in the ID string, because we were just dumping an array of Ruby String objects into the ID attribute field. This PR avoids that by calling `.join(',')` on the array, like is already done for the `name` attribute in the same elements.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-423
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
