### PR TITLE
Add Bundler caching in Travis to speed up test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 services:
   - docker
 before_install:


### PR DESCRIPTION
Adding `cache: bundler` makes Travis cache installed gems between builds. It automatically invalidates the cache and re-runs Bundler when the `Gemfile.lock` changes. Adding this will speed up test runs on Travis.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases N/A
- [x] Tests/code quality metrics have been run locally and pass N/A


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
