### PR TITLE
FI-435 Track assertions in helpers

### DIFF
--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -7,12 +7,7 @@ module Inferno
   module Assertions
     def assert(test, message = 'assertion failed, no message', data = '')
       if ENV['RACK_ENV'] == 'test' && create_assertion_report?
-        sequence_line_regex = %r{inferno/lib/app/modules/(\w+/\w+\.rb:\d+)}
-        backtrace_location = caller_locations.find { |location| location.to_s.match? sequence_line_regex }
-        call_site = backtrace_location&.to_s&.match(sequence_line_regex)&.[](1)
-        if call_site.present?
-          AssertionTracker.add_assertion_call(call_site, !!test) # rubocop:disable Style/DoubleNegation
-        end
+        AssertionTracker.add_assertion_call(!!test) # rubocop:disable Style/DoubleNegation
       end
 
       raise AssertionException.new message, data unless test

--- a/test/support/sequence_coverage_reporting.rb
+++ b/test/support/sequence_coverage_reporting.rb
@@ -30,7 +30,7 @@ class SequenceProcessor
   end
 
   def stripped_file_name
-    @stripped_file_name ||= file_name.split('lib/app/modules/').last
+    @stripped_file_name ||= file_name.split('lib/app/').last
   end
 end
 
@@ -38,13 +38,14 @@ end
 # assertion is called
 class AssertionTracker
   class << self
+
     def assertion_method_names
       @assertion_method_names ||= Set.new(Inferno::Assertions.instance_methods)
     end
 
     # Assertion locations determined through analyzing the AST
     def assertion_locations
-      @assertion_locations ||= []
+      @assertion_locations ||= Set.new
     end
 
     # Assertion calls detected at runtime
@@ -60,9 +61,65 @@ class AssertionTracker
       assertion_locations << location
     end
 
-    def add_assertion_call(location, result)
+    def add_assertion_call(result)
+      location = AssertionCallLocationFormatter.new.location
+      return if location.blank?
+
+      add_assertion_location(location)
       assertion_calls[location] << result
     end
+  end
+end
+
+class AssertionCallLocationFormatter
+  SEQUENCE_LINE_REGEX = %r{inferno/lib/app/(modules/\w+/\w+\.rb:\d+)}
+  LINE_REGEX = %r{inferno/lib/app/((?:\w+/?)+\.rb:\d+)}
+  ASSERTION_CALL_REGEX = %r{inferno/lib/app/utils/assertions.rb:\d+}
+
+  attr_accessor :sequence_call_index, :assertion_call_index
+
+  def initialize
+    generate_sequence_call_index
+    generate_assertion_call_index
+  end
+
+  def backtrace
+    @backtrace ||= caller_locations
+  end
+
+  def generate_sequence_call_index
+    self.sequence_call_index = backtrace.rindex { |location| location.to_s.match? SEQUENCE_LINE_REGEX }
+
+    adjust_index_to_handle_blocks
+  end
+
+  def generate_assertion_call_index
+    self.assertion_call_index = backtrace.rindex { |location| location.to_s.match? ASSERTION_CALL_REGEX }
+  end
+
+  def method_name
+    @method_name ||= backtrace[sequence_call_index].to_s.match(/`(.*)'/)&.[](1)
+  end
+
+  # This adjusts sequence_call_index so that when assertions are wrapped in a
+  # warning block, this index refers to the method call inside the warning block
+  # rather than the warning call itself
+  def adjust_index_to_handle_blocks
+    return if sequence_call_index.blank? || assertion_call_index.blank?
+
+    (assertion_call_index...sequence_call_index).to_a.reverse.each do |index|
+      if backtrace[index].to_s.match?(/block .*in #{method_name}/)
+        self.sequence_call_index = index
+      end
+    end
+  end
+
+  def location
+    return unless sequence_call_index.present? && assertion_call_index.present?
+    [backtrace[sequence_call_index], backtrace[assertion_call_index + 1]]
+      .uniq
+      .map { |location| location&.to_s&.match(LINE_REGEX)&.[](1) }
+      .join(' -> ')
   end
 end
 
@@ -70,39 +127,27 @@ class AssertionReporter
   class << self
     def report
       create_csv
-      print_unknown_call_sites
     end
 
     def create_csv
       CSV.open(File.join(__dir__, '..', '..', 'sequence_coverage.csv'), 'wb') do |csv|
         csv << ['Assertion Location', 'Pass Count', 'Fail Count']
         AssertionTracker.assertion_locations.sort.each do |location|
-          results = AssertionTracker.assertion_calls[location]
-          csv << [location, pass_count(results), fail_count(results)]
+          csv << [location, pass_count(location), fail_count(location)]
         end
       end
     end
 
-    def pass_count(results)
-      results.count { |result| result }
+    def pass_count(location)
+      AssertionTracker.assertion_calls.reduce(0) do |count, (key, results)|
+        key.end_with?(location) ? count + results.count { |result| result } : count
+      end
     end
 
-    def fail_count(results)
-      results.count(&:!)
-    end
-
-    # Locations which called an assertion which was not detected in the AST.
-    # This happens when a method from outside of the sequence makes an assertion
-    # (e.g., a method from SequenceBase).
-    def unknown_call_sites
-      AssertionTracker.assertion_calls.keys - AssertionTracker.assertion_locations
-    end
-
-    def print_unknown_call_sites
-      return if unknown_call_sites.blank?
-
-      puts "\nUnrecognized assertion call sites:"
-      puts unknown_call_sites.join("\n")
+    def fail_count(location)
+      AssertionTracker.assertion_calls.reduce(0) do |count, (key, results)|
+        key.end_with?(location) ? count + results.count(&:!) : count
+      end
     end
   end
 end

--- a/test/support/sequence_coverage_reporting.rb
+++ b/test/support/sequence_coverage_reporting.rb
@@ -112,7 +112,7 @@ class AssertionCallLocationFormatter
   def adjust_index_to_handle_blocks
     return if sequence_call_index.blank? || assertion_call_index.blank?
 
-    (assertion_call_index...sequence_call_index).to_a.reverse.each do |index|
+    (assertion_call_index...sequence_call_index).to_a.reverse_each do |index|
       self.sequence_call_index = index if backtrace[index].to_s.match?(/block .*in #{method_name}/)
     end
   end


### PR DESCRIPTION
This PR updates the assertion tracking to track assertion calls in helper methods. For assertions not directly called in a test, the output will now look like this:
```
location_of_method_call_in_test -> location_of_assertion
modules/argonaut/argonaut_procedure_sequence.rb:110 => sequence_base.rb:490
```
This allows us to verify that the helper methods are being exercised in each test, rather than only once. The output also differentiates between direct and indirect assertion calls.

A unit test of the following test would record a direct assertion call because the item being unit tested is making the assertion.
```
test 'direct' do
  assert true
end
```

A unit test of the following test would record an indirect assertion call because the assertion happens in a separate method. A unit test of the `validate` method would record the assertion as a direct assertion because the assertion is called within that method.
```
test 'indirect' do
  validate
end

def validate
  assert true
end
```
Differentiating direct and indirect assertions allows us to determine whether helper methods are themselves being unit tested or only being tested through the tests that use them.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-435
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- N/A Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
