### PR TITLE
Fi 446 fix address checking bug

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -331,6 +331,7 @@ module Inferno
             if param == 'patient'
               '@instance.patient_id'
             else
+
               resolve_element_path(sequence[:search_param_descriptions][param.to_sym])
             end
           search_values << "#{variable_name} = #{variable_value}"
@@ -432,11 +433,11 @@ module Inferno
           when 'Address'
             search_validators += %(
                 value_found = can_resolve_path(resource, '#{path_parts.join('.')}') do |address|
-                  address&.text&.starts_with(value) ||
-                    address&.city&.starts_with(value) ||
-                    address&.state&.starts_with(value) ||
-                    address&.postalCode&.starts_with(value) ||
-                    address&.country&.starts_with(value)
+                  address&.text&.start_with?(value) ||
+                    address&.city&.start_with?(value) ||
+                    address&.state&.start_with?(value) ||
+                    address&.postalCode&.start_with?(value) ||
+                    address&.country&.start_with?(value)
                 end
                 assert value_found, '#{element} on resource does not match #{element} requested'
             )

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -331,7 +331,6 @@ module Inferno
             if param == 'patient'
               '@instance.patient_id'
             else
-
               resolve_element_path(sequence[:search_param_descriptions][param.to_sym])
             end
           search_values << "#{variable_name} = #{variable_value}"

--- a/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_location_sequence.rb
@@ -22,11 +22,11 @@ module Inferno
 
         when 'address'
           value_found = can_resolve_path(resource, 'address') do |address|
-            address&.text&.starts_with(value) ||
-              address&.city&.starts_with(value) ||
-              address&.state&.starts_with(value) ||
-              address&.postalCode&.starts_with(value) ||
-              address&.country&.starts_with(value)
+            address&.text&.start_with?(value) ||
+              address&.city&.start_with?(value) ||
+              address&.state&.start_with?(value) ||
+              address&.postalCode&.start_with?(value) ||
+              address&.country&.start_with?(value)
           end
           assert value_found, 'address on resource does not match address requested'
 

--- a/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.0/us_core_organization_sequence.rb
@@ -22,11 +22,11 @@ module Inferno
 
         when 'address'
           value_found = can_resolve_path(resource, 'address') do |address|
-            address&.text&.starts_with(value) ||
-              address&.city&.starts_with(value) ||
-              address&.state&.starts_with(value) ||
-              address&.postalCode&.starts_with(value) ||
-              address&.country&.starts_with(value)
+            address&.text&.start_with?(value) ||
+              address&.city&.start_with?(value) ||
+              address&.state&.start_with?(value) ||
+              address&.postalCode&.start_with?(value) ||
+              address&.country&.start_with?(value)
           end
           assert value_found, 'address on resource does not match address requested'
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_location_sequence.rb
@@ -22,11 +22,11 @@ module Inferno
 
         when 'address'
           value_found = can_resolve_path(resource, 'address') do |address|
-            address&.text&.starts_with(value) ||
-              address&.city&.starts_with(value) ||
-              address&.state&.starts_with(value) ||
-              address&.postalCode&.starts_with(value) ||
-              address&.country&.starts_with(value)
+            address&.text&.start_with?(value) ||
+              address&.city&.start_with?(value) ||
+              address&.state&.start_with?(value) ||
+              address&.postalCode&.start_with?(value) ||
+              address&.country&.start_with?(value)
           end
           assert value_found, 'address on resource does not match address requested'
 

--- a/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
+++ b/lib/app/modules/uscore_v3.0.1/us_core_organization_sequence.rb
@@ -22,11 +22,11 @@ module Inferno
 
         when 'address'
           value_found = can_resolve_path(resource, 'address') do |address|
-            address&.text&.starts_with(value) ||
-              address&.city&.starts_with(value) ||
-              address&.state&.starts_with(value) ||
-              address&.postalCode&.starts_with(value) ||
-              address&.country&.starts_with(value)
+            address&.text&.start_with?(value) ||
+              address&.city&.start_with?(value) ||
+              address&.state&.start_with?(value) ||
+              address&.postalCode&.start_with?(value) ||
+              address&.country&.start_with?(value)
           end
           assert value_found, 'address on resource does not match address requested'
 


### PR DESCRIPTION
Location and Organization sequences had a bug where validating addresses tried to do starts_with, but it should've been start_with?



**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-446
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
