### PR TITLE
FI-428: Check for duplicate keys

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -364,8 +364,13 @@ module Inferno
       # block - The Block test to be executed
       def self.test(name, &block)
         @@test_index += 1
+        new_test = InfernoTest.new(name, @@test_index, @@test_id_prefixes[sequence_name], &block)
 
-        tests << InfernoTest.new(name, @@test_index, @@test_id_prefixes[sequence_name], &block)
+        if new_test.key.present? && tests.any? { |test| test.key == new_test.key }
+          raise InvalidKeyException, "Duplicate test key #{new_test.key.inspect} in #{self.name.demodulize}"
+        end
+
+        tests << new_test
       end
 
       def wrap_test(test)

--- a/lib/app/utils/exceptions.rb
+++ b/lib/app/utils/exceptions.rb
@@ -101,6 +101,9 @@ module Inferno
 
   class InvalidMetadataException < RuntimeError
   end
+
+  class InvalidKeyException < RuntimeError
+  end
 end
 
 # monkey patch this exception from fhir_client

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -110,4 +110,23 @@ class SequenceBaseTest < MiniTest::Test
       assert all_resources.map(&:id) == ['2']
     end
   end
+
+  describe '.test' do
+    it 'raises an error if two tests have duplicate keys' do
+      assert_raises(Inferno::InvalidKeyException) do
+        class InvalidKeySequence < Inferno::Sequence::SequenceBase
+          2.times do |index|
+            test :a do
+              metadata do
+                id "0#{index}"
+                name 'a'
+                description 'a'
+                link 'http://example.com'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This branch checks sequences when Inferno starts to ensure test keys are unique within a sequence. A sample failure:
```
ᐅ be rake
INFO | Inferno | Environment: development
rake aborted!
Inferno::InvalidKeyException: Duplicate test key :invalid_refresh_token in TokenRefreshSequence
inferno/lib/app/sequence_base.rb:370:in `test'
inferno/lib/app/modules/smart/token_refresh_sequence.rb:50:in `<class:TokenRefreshSequence>'
...
```

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-428
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name: @okeefm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
