### PR TITLE
FI-470: Fix order-dependent unit test

### DIFF
--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -118,7 +118,7 @@ class SequenceBaseTest < MiniTest::Test
           2.times do |index|
             test :a do
               metadata do
-                id "0#{index}"
+                id "0#{index + 1}"
                 name 'a'
                 description 'a'
                 link 'http://example.com'


### PR DESCRIPTION
PR #339 introduced a unit test which created a sequence with test ids starting at 0. The sequence validation test that checks for sequential test ids doesn't like tests starting at 0, so it would fail if it ran after the other test.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-470
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
