### PR TITLE
FI-473: Make TestingInstance#patient_id deterministic

### DIFF
--- a/lib/app/models/resource_reference.rb
+++ b/lib/app/models/resource_reference.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dm-timestamps'
+
 module Inferno
   module Models
     class ResourceReference
@@ -8,6 +10,7 @@ module Inferno
       property :resource_type, String
       property :resource_id, String
       property :profile, String
+      property :created_at, DateTime
 
       belongs_to :testing_instance
     end

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -147,8 +147,8 @@ module Inferno
 
       def patient_id
         resource_references
-          .select { |ref| ref.resource_type == 'Patient' }
-          .first&.resource_id
+          .first(resource_type: 'Patient', order: [:created_at.asc])
+          &.resource_id
       end
 
       def patient_id=(patient_id)
@@ -156,11 +156,10 @@ module Inferno
 
         resource_references.destroy
 
-        save!
-
-        resource_references << ResourceReference.new(
+        ResourceReference.create(
           resource_type: 'Patient',
-          resource_id: patient_id
+          resource_id: patient_id,
+          testing_instance: self
         )
 
         save!

--- a/test/sequence/medication_order_sequence_test.rb
+++ b/test/sequence/medication_order_sequence_test.rb
@@ -40,23 +40,24 @@ class MedicationOrderSequenceTest < MiniTest::Test
     @patient_resource = FHIR::DSTU2::Patient.new(id: @patient_id)
     @practitioner_resource = FHIR::DSTU2::Practitioner.new(id: 432)
 
-    @instance = Inferno::Models::TestingInstance.new(url: 'http://www.example.com',
-                                                     client_name: 'Inferno',
-                                                     base_url: 'http://localhost:4567',
-                                                     client_endpoint_key: Inferno::SecureRandomBase62.generate(32),
-                                                     client_id: SecureRandom.uuid,
-                                                     selected_module: 'argonaut',
-                                                     oauth_authorize_endpoint: 'http://oauth_reg.example.com/authorize',
-                                                     oauth_token_endpoint: 'http://oauth_reg.example.com/token',
-                                                     scopes: 'launch openid patient/*.* profile',
-                                                     token: 99_897_979)
-
-    @instance.save! # this is for convenience.  we could rewrite to ensure nothing gets saved within tests.
+    @instance = Inferno::Models::TestingInstance.create(
+      url: 'http://www.example.com',
+      client_name: 'Inferno',
+      base_url: 'http://localhost:4567',
+      client_endpoint_key: Inferno::SecureRandomBase62.generate(32),
+      client_id: SecureRandom.uuid,
+      selected_module: 'argonaut',
+      oauth_authorize_endpoint: 'http://oauth_reg.example.com/authorize',
+      oauth_token_endpoint: 'http://oauth_reg.example.com/token',
+      scopes: 'launch openid patient/*.* profile',
+      token: 99_897_979
+    )
 
     # Assume we already have a patient
-    @instance.resource_references << Inferno::Models::ResourceReference.new(
+    Inferno::Models::ResourceReference.create(
       resource_type: 'Patient',
-      resource_id: @patient_id
+      resource_id: @patient_id,
+      testing_instance: @instance
     )
 
     set_resource_support(@instance, 'MedicationOrder')

--- a/test/sequence/r4_provenance_sequence_test.rb
+++ b/test/sequence/r4_provenance_sequence_test.rb
@@ -29,7 +29,7 @@ class R4ProvenanceSequenceTest < MiniTest::Test
       ]
     }
 
-    @instance = Inferno::Models::TestingInstance.new(
+    @instance = Inferno::Models::TestingInstance.create(
       url: 'http://www.example.com',
       client_name: 'Inferno',
       base_url: 'http://localhost:4567',
@@ -42,11 +42,10 @@ class R4ProvenanceSequenceTest < MiniTest::Test
       token: 99_897_979
     )
 
-    @instance.save!
-
-    @instance.resource_references << Inferno::Models::ResourceReference.new(
+    Inferno::Models::ResourceReference.create(
       resource_type: 'Patient',
-      resource_id: @patient_id
+      resource_id: @patient_id,
+      testing_instance: @instance
     )
 
     set_resource_support(@instance, 'Provenance')

--- a/test/sequence/us_core_r4/clinicalnotes_sequence_test.rb
+++ b/test/sequence/us_core_r4/clinicalnotes_sequence_test.rb
@@ -8,7 +8,7 @@ class USCoreR4ClinicalNotesSequenceTest < MiniTest::Test
     @docref_bundle = FHIR.from_contents(load_fixture(:us_core_r4_clinicalnotes_docref_bundle))
     @diagrpt_bundle = FHIR.from_contents(load_fixture(:us_core_r4_clinicalnotes_diagrpt_bundle))
 
-    @instance = Inferno::Models::TestingInstance.new(
+    @instance = Inferno::Models::TestingInstance.create(
       url: 'http://www.example.com',
       client_name: 'Inferno',
       base_url: 'http://localhost:4567',
@@ -21,11 +21,10 @@ class USCoreR4ClinicalNotesSequenceTest < MiniTest::Test
       token: 99_897_979
     )
 
-    @instance.save!
-
-    @instance.resource_references << Inferno::Models::ResourceReference.new(
+    Inferno::Models::ResourceReference.create(
       resource_type: 'Patient',
-      resource_id: @patient_id
+      resource_id: @patient_id,
+      testing_instance: @instance
     )
 
     set_resource_support(@instance, 'DocumentReference')

--- a/test/unit/test_instance_test.rb
+++ b/test/unit/test_instance_test.rb
@@ -74,4 +74,26 @@ describe Inferno::Models::TestingInstance do
       assert !@instance.fhir_version_match?(fhir_versions)
     end
   end
+
+  describe '#patient_id' do
+    it 'returns the id of the Patient reference which was created first' do
+      10.times do |index|
+        Inferno::Models::ResourceReference.create(
+          resource_type: 'Patient',
+          resource_id: index.to_s,
+          testing_instance: @instance
+        )
+      end
+
+      assert_equal '0', @instance.patient_id
+    end
+  end
+
+  describe '#patient_id=' do
+    it 'sets the patient id' do
+      @instance.patient_id = '123'
+
+      assert_equal '123', @instance.patient_id
+    end
+  end
 end

--- a/test/unit/test_instance_test.rb
+++ b/test/unit/test_instance_test.rb
@@ -94,6 +94,10 @@ describe Inferno::Models::TestingInstance do
       @instance.patient_id = '123'
 
       assert_equal '123', @instance.patient_id
+
+      @instance.patient_id = '456'
+
+      assert_equal '456', @instance.patient_id
     end
   end
 end


### PR DESCRIPTION
This PR adds a `created_at` timestamp to `ResourceReference` and makes `TestingInstance#patient_id` retrieve the id of the Patient reference which was created first. Previously, the first Patient reference was chosen from a list sorted by a randomly generated id, so the id returned was non-deterministic when multiple Patient references were present.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-473
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
