### PR TITLE
Fi 489 - Set first search for diagnosticreport

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -304,10 +304,11 @@ module Inferno
         medication_request_sequence = metadata[:sequences].find { |sequence| sequence[:resource] == 'MedicationRequest' }
         set_first_search(medication_request_sequence, ['patient', 'intent'])
 
-        diagnostic_report_sequences = metadata[:sequences].select { |sequence| sequence[:resource] == 'DiagnosticReport' }
-        diagnostic_report_sequences.each do |sequence|
-          set_first_search(sequence, ['patient', 'category'])
-        end
+        metadata[:sequences]
+          .select { |sequence| sequence[:resource] == 'DiagnosticReport' }
+          .each do |sequence|
+            set_first_search(sequence, ['patient', 'category'])
+          end
 
         metadata
       end

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -520,25 +520,7 @@ module Inferno
       end
 
       def search_param_constants(search_parameters, sequence)
-        return { patient: '@instance.patient_id', category: 'assess-plan' } if search_parameters == ['patient', 'category'] &&
-                                                                               sequence[:resource] == 'CarePlan'
-        return { patient: '@instance.patient_id', status: 'active' } if search_parameters == ['patient', 'status'] &&
-                                                                        sequence[:resource] == 'CareTeam'
         return { '_id': '@instance.patient_id' } if search_parameters == ['_id'] && sequence[:resource] == 'Patient'
-        return { patient: '@instance.patient_id', code: '72166-2' } if search_parameters == ['patient', 'code'] &&
-                                                                       sequence[:profile] == PROFILE_URIS[:smoking_status]
-        return { patient: '@instance.patient_id', category: 'laboratory' } if search_parameters == ['patient', 'category'] &&
-                                                                              sequence[:profile] == PROFILE_URIS[:lab_results]
-        return { patient: '@instance.patient_id', code: '77606-2' } if search_parameters == ['patient', 'code'] &&
-                                                                       sequence[:profile] == PROFILE_URIS[:pediatric_weight_height]
-        return { patient: '@instance.patient_id', code: '59576-9' } if search_parameters == ['patient', 'code'] &&
-                                                                       sequence[:profile] == PROFILE_URIS[:pediatric_bmi_age]
-        return { patient: '@instance.patient_id', category: 'LAB' } if search_parameters == ['patient', 'category'] &&
-                                                                       sequence[:profile] == PROFILE_URIS[:diagnostic_report_lab]
-        return { patient: '@instance.patient_id', code: 'LP29684-5' } if search_parameters == ['patient', 'category'] &&
-                                                                         sequence[:profile] == PROFILE_URIS[:diagnostic_report_note]
-        return { patient: '@instance.patient_id', code: '59408-5' } if search_parameters == ['patient', 'code'] &&
-                                                                       sequence[:profile] == PROFILE_URIS[:pulse_oximetry]
       end
 
       def create_search_validation(sequence)

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -76,25 +76,26 @@ module Inferno
           versions :r4
         end
 
-        search_params = {
-          'patient': @instance.patient_id,
-          'code': '59576-9'
-        }
+        code_val = ['59576-9']
+        code_val.each do |val|
+          search_params = { 'patient': @instance.patient_id, 'code': val }
+          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+          resource_count = reply&.resource&.entry&.length || 0
+          @resources_found = true if resource_count.positive?
+          next unless @resources_found
 
-        resource_count = reply&.resource&.entry&.length || 0
-        @resources_found = true if resource_count.positive?
+          @observation = reply&.resource&.entry&.first&.resource
+          @observation_ary = fetch_all_bundled_resources(reply&.resource)
 
+          save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
+          save_delayed_sequence_references(@observation_ary)
+          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          break
+        end
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-
-        @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_bundled_resources(reply&.resource)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
-        save_delayed_sequence_references(@observation_ary)
-        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
       end
 
       test 'Server returns expected results from Observation search by patient+category+date' do
@@ -269,8 +270,9 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'code': '59576-9'
+          'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code'))
         }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -76,25 +76,26 @@ module Inferno
           versions :r4
         end
 
-        search_params = {
-          'patient': @instance.patient_id,
-          'code': '77606-2'
-        }
+        code_val = ['77606-2']
+        code_val.each do |val|
+          search_params = { 'patient': @instance.patient_id, 'code': val }
+          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+          resource_count = reply&.resource&.entry&.length || 0
+          @resources_found = true if resource_count.positive?
+          next unless @resources_found
 
-        resource_count = reply&.resource&.entry&.length || 0
-        @resources_found = true if resource_count.positive?
+          @observation = reply&.resource&.entry&.first&.resource
+          @observation_ary = fetch_all_bundled_resources(reply&.resource)
 
+          save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
+          save_delayed_sequence_references(@observation_ary)
+          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          break
+        end
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-
-        @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_bundled_resources(reply&.resource)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
-        save_delayed_sequence_references(@observation_ary)
-        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
       end
 
       test 'Server returns expected results from Observation search by patient+category+date' do
@@ -269,8 +270,9 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'code': '77606-2'
+          'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code'))
         }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -62,25 +62,26 @@ module Inferno
           versions :r4
         end
 
-        search_params = {
-          'patient': @instance.patient_id,
-          'status': 'active'
-        }
+        status_val = ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error']
+        status_val.each do |val|
+          search_params = { 'patient': @instance.patient_id, 'status': val }
+          reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
 
-        reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+          resource_count = reply&.resource&.entry&.length || 0
+          @resources_found = true if resource_count.positive?
+          next unless @resources_found
 
-        resource_count = reply&.resource&.entry&.length || 0
-        @resources_found = true if resource_count.positive?
+          @care_team = reply&.resource&.entry&.first&.resource
+          @care_team_ary = fetch_all_bundled_resources(reply&.resource)
 
+          save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
+          save_delayed_sequence_references(@care_team_ary)
+          validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)
+          break
+        end
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-
-        @care_team = reply&.resource&.entry&.first&.resource
-        @care_team_ary = fetch_all_bundled_resources(reply&.resource)
-        save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
-        save_delayed_sequence_references(@care_team_ary)
-        validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)
       end
 
       test :read_interaction do
@@ -142,8 +143,9 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'status': 'active'
+          'status': get_value_for_search_param(resolve_element_from_path(@care_team_ary, 'status'))
         }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -76,25 +76,26 @@ module Inferno
           versions :r4
         end
 
-        search_params = {
-          'patient': @instance.patient_id,
-          'category': 'LAB'
-        }
+        category_val = ['LAB']
+        category_val.each do |val|
+          search_params = { 'patient': @instance.patient_id, 'category': val }
+          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
 
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+          resource_count = reply&.resource&.entry&.length || 0
+          @resources_found = true if resource_count.positive?
+          next unless @resources_found
 
-        resource_count = reply&.resource&.entry&.length || 0
-        @resources_found = true if resource_count.positive?
+          @diagnostic_report = reply&.resource&.entry&.first&.resource
+          @diagnostic_report_ary = fetch_all_bundled_resources(reply&.resource)
 
+          save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
+          save_delayed_sequence_references(@diagnostic_report_ary)
+          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          break
+        end
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-
-        @diagnostic_report = reply&.resource&.entry&.first&.resource
-        @diagnostic_report_ary = fetch_all_bundled_resources(reply&.resource)
-        save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
-        save_delayed_sequence_references(@diagnostic_report_ary)
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
       end
 
       test 'Server returns expected results from DiagnosticReport search by patient' do
@@ -289,8 +290,9 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': 'LAB'
+          'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'category'))
         }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -67,7 +67,7 @@ module Inferno
         assert_response_unauthorized reply
       end
 
-      test 'Server returns expected results from DiagnosticReport search by patient' do
+      test 'Server returns expected results from DiagnosticReport search by patient+category' do
         metadata do
           id '02'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
@@ -77,7 +77,8 @@ module Inferno
         end
 
         search_params = {
-          'patient': @instance.patient_id
+          'patient': @instance.patient_id,
+          'category': 'LAB'
         }
 
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
@@ -96,9 +97,30 @@ module Inferno
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
       end
 
-      test 'Server returns expected results from DiagnosticReport search by patient+code' do
+      test 'Server returns expected results from DiagnosticReport search by patient' do
         metadata do
           id '03'
+          link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
+          description %(
+          )
+          versions :r4
+        end
+
+        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
+
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
+        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+        assert_response_ok(reply)
+      end
+
+      test 'Server returns expected results from DiagnosticReport search by patient+code' do
+        metadata do
+          id '04'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -121,7 +143,7 @@ module Inferno
 
       test 'Server returns expected results from DiagnosticReport search by patient+category+date' do
         metadata do
-          id '04'
+          id '05'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -149,28 +171,6 @@ module Inferno
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           assert_response_ok(reply)
         end
-      end
-
-      test 'Server returns expected results from DiagnosticReport search by patient+category' do
-        metadata do
-          id '05'
-          link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
-          description %(
-          )
-          versions :r4
-        end
-
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
-
-        search_params = {
-          'patient': @instance.patient_id,
-          'category': 'LAB'
-        }
-
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-        assert_response_ok(reply)
       end
 
       test 'Server returns expected results from DiagnosticReport search by patient+status' do
@@ -288,7 +288,8 @@ module Inferno
         end
 
         search_params = {
-          'patient': @instance.patient_id
+          'patient': @instance.patient_id,
+          'category': 'LAB'
         }
 
         search_params['_revinclude'] = 'Provenance:target'

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -67,7 +67,7 @@ module Inferno
         assert_response_unauthorized reply
       end
 
-      test 'Server returns expected results from DiagnosticReport search by patient' do
+      test 'Server returns expected results from DiagnosticReport search by patient+category' do
         metadata do
           id '02'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
@@ -77,7 +77,8 @@ module Inferno
         end
 
         search_params = {
-          'patient': @instance.patient_id
+          'patient': @instance.patient_id,
+          'code': 'LP29684-5'
         }
 
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
@@ -96,9 +97,30 @@ module Inferno
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
       end
 
-      test 'Server returns expected results from DiagnosticReport search by patient+code' do
+      test 'Server returns expected results from DiagnosticReport search by patient' do
         metadata do
           id '03'
+          link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
+          description %(
+          )
+          versions :r4
+        end
+
+        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
+
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
+        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+        assert_response_ok(reply)
+      end
+
+      test 'Server returns expected results from DiagnosticReport search by patient+code' do
+        metadata do
+          id '04'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -121,7 +143,7 @@ module Inferno
 
       test 'Server returns expected results from DiagnosticReport search by patient+category+date' do
         metadata do
-          id '04'
+          id '05'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -149,28 +171,6 @@ module Inferno
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           assert_response_ok(reply)
         end
-      end
-
-      test 'Server returns expected results from DiagnosticReport search by patient+category' do
-        metadata do
-          id '05'
-          link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
-          description %(
-          )
-          versions :r4
-        end
-
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
-
-        search_params = {
-          'patient': @instance.patient_id,
-          'code': 'LP29684-5'
-        }
-
-        reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
-        validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-        assert_response_ok(reply)
       end
 
       test 'Server returns expected results from DiagnosticReport search by patient+status' do
@@ -288,7 +288,8 @@ module Inferno
         end
 
         search_params = {
-          'patient': @instance.patient_id
+          'patient': @instance.patient_id,
+          'code': 'LP29684-5'
         }
 
         search_params['_revinclude'] = 'Provenance:target'

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -76,25 +76,26 @@ module Inferno
           versions :r4
         end
 
-        search_params = {
-          'patient': @instance.patient_id,
-          'category': 'laboratory'
-        }
+        category_val = ['laboratory']
+        category_val.each do |val|
+          search_params = { 'patient': @instance.patient_id, 'category': val }
+          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+          resource_count = reply&.resource&.entry&.length || 0
+          @resources_found = true if resource_count.positive?
+          next unless @resources_found
 
-        resource_count = reply&.resource&.entry&.length || 0
-        @resources_found = true if resource_count.positive?
+          @observation = reply&.resource&.entry&.first&.resource
+          @observation_ary = fetch_all_bundled_resources(reply&.resource)
 
+          save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
+          save_delayed_sequence_references(@observation_ary)
+          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          break
+        end
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-
-        @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_bundled_resources(reply&.resource)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
-        save_delayed_sequence_references(@observation_ary)
-        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
       end
 
       test 'Server returns expected results from Observation search by patient+code' do
@@ -269,8 +270,9 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': 'laboratory'
+          'category': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'category'))
         }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -76,25 +76,26 @@ module Inferno
           versions :r4
         end
 
-        search_params = {
-          'patient': @instance.patient_id,
-          'code': '59408-5'
-        }
+        code_val = ['2708-6', '59408-5']
+        code_val.each do |val|
+          search_params = { 'patient': @instance.patient_id, 'code': val }
+          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+          resource_count = reply&.resource&.entry&.length || 0
+          @resources_found = true if resource_count.positive?
+          next unless @resources_found
 
-        resource_count = reply&.resource&.entry&.length || 0
-        @resources_found = true if resource_count.positive?
+          @observation = reply&.resource&.entry&.first&.resource
+          @observation_ary = fetch_all_bundled_resources(reply&.resource)
 
+          save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pulse_oximetry])
+          save_delayed_sequence_references(@observation_ary)
+          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          break
+        end
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-
-        @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_bundled_resources(reply&.resource)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pulse_oximetry])
-        save_delayed_sequence_references(@observation_ary)
-        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
       end
 
       test 'Server returns expected results from Observation search by patient+category+date' do
@@ -269,8 +270,9 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'code': '59408-5'
+          'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code'))
         }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -76,25 +76,26 @@ module Inferno
           versions :r4
         end
 
-        search_params = {
-          'patient': @instance.patient_id,
-          'code': '72166-2'
-        }
+        code_val = ['72166-2']
+        code_val.each do |val|
+          search_params = { 'patient': @instance.patient_id, 'code': val }
+          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
 
-        reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+          resource_count = reply&.resource&.entry&.length || 0
+          @resources_found = true if resource_count.positive?
+          next unless @resources_found
 
-        resource_count = reply&.resource&.entry&.length || 0
-        @resources_found = true if resource_count.positive?
+          @observation = reply&.resource&.entry&.first&.resource
+          @observation_ary = fetch_all_bundled_resources(reply&.resource)
 
+          save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
+          save_delayed_sequence_references(@observation_ary)
+          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          break
+        end
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-
-        @observation = reply&.resource&.entry&.first&.resource
-        @observation_ary = fetch_all_bundled_resources(reply&.resource)
-        save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
-        save_delayed_sequence_references(@observation_ary)
-        validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
       end
 
       test 'Server returns expected results from Observation search by patient+category+date' do
@@ -269,8 +270,9 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'code': '72166-2'
+          'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code'))
         }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)


### PR DESCRIPTION
This pull request sets the first search for diagnostic report sequences to patient+category. It also fixes a bug in the generator that made it not get all the values from a valueset.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-489
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
