### PR TITLE
Fi 490 set authorization search params

### DIFF
--- a/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
@@ -4,8 +4,7 @@ describe 'unauthorized search test' do
     @sequence = @sequence_class.new(@instance, @client)
 <% if dynamic_search_params.present? %>
   <% dynamic_search_params.each do |_param, search_param|  %>
-    <%= search_param[:variable_name] %> = load_json_fixture(:<%= "#{name}_#{search_param[:variable_name][1..-1]}" %>)
-      .map { |resource| FHIR.from_contents(resource.to_json) }
+    <%= search_param[:variable_name] %> = FHIR.from_contents(load_fixture(:<%= sequence_name %>))
     @sequence.instance_variable_set(:'<%= search_param[:variable_name] %>', <%= search_param[:variable_name] %>)
   <% end %>
 <% end %>

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -26,13 +26,14 @@ module Inferno
         File.write(file_name, unit_tests)
       end
 
-      def generate_authorization_test(test_key:, resource_type:, search_params:, class_name:)
+      def generate_authorization_test(test_key:, resource_type:, search_params:, class_name:, sequence_name:)
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'authorization_unit_test.rb.erb')))
         test = template.result_with_hash(
           test_key: test_key,
           resource_type: resource_type,
           search_param_string: search_params_to_string(search_params),
-          dynamic_search_params: dynamic_search_params(search_params)
+          dynamic_search_params: dynamic_search_params(search_params),
+          sequence_name: sequence_name
         )
         tests[class_name] << test
       end

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -147,10 +147,13 @@ module Inferno
 
         search_parameters = first_search[:names]
         search_params = if search_parameters == ['patient'] || sequence[:delayed_sequence] || search_param_constants(search_parameters, sequence)
+                          unit_test_params = get_search_param_hash(search_parameters, sequence)
                           get_search_params(search_parameters, sequence)
                         else
                           non_patient_search_param = search_parameters.find { |param| param != 'patient' }
                           non_patient_value = sequence[:search_param_descriptions][non_patient_search_param.to_sym][:values].first
+                          unit_test_params = { patient: '@instance.patient_id' }
+                          unit_test_params[non_patient_search_param] = non_patient_value
                           "search_params = { 'patient': @instance.patient_id, '#{non_patient_search_param}': '#{non_patient_value}' }"
                         end
         authorization_test[:test_code] = %(
@@ -168,7 +171,7 @@ module Inferno
         unit_test_generator.generate_authorization_test(
           test_key: test_key,
           resource_type: sequence[:resource],
-          search_params: { patient: '@instance.patient_id' },
+          search_params: unit_test_params,
           class_name: sequence[:class_name]
         )
       end

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -151,7 +151,7 @@ module Inferno
                         else
                           non_patient_search_param = search_parameters.find { |param| param != 'patient' }
                           non_patient_value = sequence[:search_param_descriptions][non_patient_search_param.to_sym][:values].first
-                          "search_params = { 'patient': @instance.patient_id, '#{non_patient_search_param}': #{non_patient_value} }"
+                          "search_params = { 'patient': @instance.patient_id, '#{non_patient_search_param}': '#{non_patient_value}' }"
                         end
         authorization_test[:test_code] = %(
               skip_if_not_supported(:#{sequence[:resource]}, [:search])

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -165,7 +165,8 @@ module Inferno
           test_key: test_key,
           resource_type: sequence[:resource],
           search_params: unit_test_params,
-          class_name: sequence[:class_name]
+          class_name: sequence[:class_name],
+          sequence_name: sequence[:name]
         )
       end
 

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'code': 59576 - 9 }
+        search_params = { 'patient': @instance.patient_id, 'code': '59576-9' }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -60,7 +60,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'code': '59576-9' }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'code': '59576-9'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -60,8 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'code': 59576 - 9 }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -60,7 +60,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'code': '77606-2' }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'code': '77606-2'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'code': 77606 - 2 }
+        search_params = { 'patient': @instance.patient_id, 'code': '77606-2' }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -60,8 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'code': 77606 - 2 }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/test/fixtures/us_core_goal.json
+++ b/lib/modules/uscore_v3.1.0/test/fixtures/us_core_goal.json
@@ -1,0 +1,26 @@
+{
+  "resourceType": "Goal",
+  "id": "goal-1",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: goal-1</p><p><b>meta</b>: </p><p><b>lifecycleStatus</b>: active</p><p><b>description</b>: Patient is targeting a pulse oximetry of 92% and a weight of 195 lbs <span style=\"background: LightGoldenRodYellow\">(Details )</span></p><p><b>subject</b>: <a href=\"Patient-example.html\">Amy Shaw. Generated Summary: id: example; Medical Record Number = 1032702 (USUAL); active; Amy V. Shaw ; ph: 555-555-5555(HOME), amy.shaw@example.com; gender: female; birthDate: 2007-02-20</a></p><h3>Targets</h3><table class=\"grid\"><tr><td>-</td><td><b>Due[x]</b></td></tr><tr><td>*</td><td>2016-04-05</td></tr></table></div>"
+  },
+  "lifecycleStatus": "active",
+  "description": {
+    "text": "Patient is targeting a pulse oximetry of 92% and a weight of 195 lbs"
+  },
+  "subject": {
+    "reference": "Patient/example",
+    "display": "Amy Shaw"
+  },
+  "target": [
+    {
+      "dueDate": "2016-04-05"
+    }
+  ]
+}

--- a/lib/modules/uscore_v3.1.0/test/fixtures/us_core_location.json
+++ b/lib/modules/uscore_v3.1.0/test/fixtures/us_core_location.json
@@ -1,0 +1,44 @@
+{
+  "resourceType": "Location",
+  "id": "hl7east",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: hl7east</p><p><b>meta</b>: </p><p><b>identifier</b>: 29</p><p><b>status</b>: active</p><p><b>name</b>: Health Level Seven International - Amherst</p><p><b>description</b>: HL7 Headquarters - East</p><p><b>telecom</b>: ph: (+1) 734-677-7777</p><p><b>address</b>: 3300 Washtenaw Avenue, Suite 227 Amherst MA 01002 USA </p><h3>Positions</h3><table class=\"grid\"><tr><td>-</td><td><b>Longitude</b></td><td><b>Latitude</b></td></tr><tr><td>*</td><td>-72.519854</td><td>42.373222</td></tr></table><p><b>managingOrganization</b>: Health Level Seven International</p></div>"
+  },
+  "identifier": [
+    {
+      "system": "http://www.acme.org/location",
+      "value": "29"
+    }
+  ],
+  "status": "active",
+  "name": "Health Level Seven International - Amherst",
+  "description": "HL7 Headquarters - East",
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "(+1) 734-677-7777"
+    }
+  ],
+  "address": {
+    "line": [
+      "3300 Washtenaw Avenue, Suite 227"
+    ],
+    "city": "Amherst",
+    "state": "MA",
+    "postalCode": "01002",
+    "country": "USA"
+  },
+  "position": {
+    "longitude": -72.519854,
+    "latitude": 42.373222
+  },
+  "managingOrganization": {
+    "display": "Health Level Seven International"
+  }
+}

--- a/lib/modules/uscore_v3.1.0/test/fixtures/us_core_organization.json
+++ b/lib/modules/uscore_v3.1.0/test/fixtures/us_core_organization.json
@@ -1,0 +1,57 @@
+{
+  "resourceType": "Organization",
+  "id": "acme-lab",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: acme-lab</p><p><b>meta</b>: </p><p><b>identifier</b>: 1144221847, 12D4567890</p><p><b>active</b>: true</p><p><b>type</b>: Healthcare Provider <span style=\"background: LightGoldenRodYellow\">(Details : {http://terminology.hl7.org/CodeSystem/organization-type code 'prov' = 'Healthcare Provider', given as 'Healthcare Provider'})</span></p><p><b>name</b>: Acme Labs</p><p><b>telecom</b>: ph: (+1) 734-677-7777, hq@acme.org</p><p><b>address</b>: 3300 Washtenaw Avenue, Suite 227 Amherst MA 01002 USA </p></div>"
+  },
+  "identifier": [
+    {
+      "system": "http://hl7.org.fhir/sid/us-npi",
+      "value": "1144221847"
+    },
+    {
+      "system": "urn:oid:2.16.840.1.113883.4.7",
+      "value": "12D4567890"
+    }
+  ],
+  "active": true,
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+          "code": "prov",
+          "display": "Healthcare Provider"
+        }
+      ]
+    }
+  ],
+  "name": "Acme Labs",
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "(+1) 734-677-7777"
+    },
+    {
+      "system": "email",
+      "value": "hq@acme.org"
+    }
+  ],
+  "address": [
+    {
+      "line": [
+        "3300 Washtenaw Avenue, Suite 227"
+      ],
+      "city": "Amherst",
+      "state": "MA",
+      "postalCode": "01002",
+      "country": "USA"
+    }
+  ]
+}

--- a/lib/modules/uscore_v3.1.0/test/fixtures/us_core_practitioner.json
+++ b/lib/modules/uscore_v3.1.0/test/fixtures/us_core_practitioner.json
@@ -1,0 +1,45 @@
+{
+  "resourceType": "Practitioner",
+  "id": "practitioner-1",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: practitioner-1</p><p><b>meta</b>: </p><p><b>identifier</b>: 9941339108, 25456</p><p><b>name</b>: Ronald Bone </p><p><b>address</b>: 1003 Healthcare Drive Amherst MA 01002 (HOME)</p></div>"
+  },
+  "identifier": [
+    {
+      "system": "http://hl7.org.fhir/sid/us-npi",
+      "value": "9941339108"
+    },
+    {
+      "system": "http://www.acme.org/practitioners",
+      "value": "25456"
+    }
+  ],
+  "name": [
+    {
+      "family": "Bone",
+      "given": [
+        "Ronald"
+      ],
+      "prefix": [
+        "Dr"
+      ]
+    }
+  ],
+  "address": [
+    {
+      "use": "home",
+      "line": [
+        "1003 Healthcare Drive"
+      ],
+      "city": "Amherst",
+      "state": "MA",
+      "postalCode": "01002"
+    }
+  ]
+}

--- a/lib/modules/uscore_v3.1.0/test/fixtures/us_core_practitionerrole.json
+++ b/lib/modules/uscore_v3.1.0/test/fixtures/us_core_practitionerrole.json
@@ -1,0 +1,59 @@
+{
+  "resourceType": "PractitionerRole",
+  "id": "PractitionerRole-1",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: PractitionerRole-1</p><p><b>meta</b>: </p><p><b>practitioner</b>: <a href=\"Practitioner/Practitioner-1011\">Brenda Jennings Richard MD</a></p><p><b>organization</b>: <a href=\"Organization-acme-lab.html\">Acme Lab. Generated Summary: id: acme-lab; 1144221847, 12D4567890; active; <span title=\"Codes: {http://terminology.hl7.org/CodeSystem/organization-type prov}\">Healthcare Provider</span>; name: Acme Labs; ph: (+1) 734-677-7777, hq@acme.org</a></p><p><b>code</b>: Primary Care <span style=\"background: LightGoldenRodYellow\">(Details : {http://nucc.org/provider-taxonomy code '261QP2300X' = 'Primary Care', given as 'Primary Care'})</span></p><p><b>specialty</b>: General Practice <span style=\"background: LightGoldenRodYellow\">(Details : {http://nucc.org/provider-taxonomy code '208D00000X' = 'General Practice', given as 'General Practice'})</span></p><p><b>location</b>: <a href=\"Location-hl7east.html\">Health Level Seven International. Generated Summary: id: hl7east; 29; status: active; name: Health Level Seven International - Amherst; description: HL7 Headquarters - East; ph: (+1) 734-677-7777</a></p><p><b>endpoint</b>: </p><ul><li><a href=\"http://52.90.126.238:8080/fhir/baseDstu3/Endpoint/Endpoint-71\">Westwood Physicians Organization ADT</a></li><li><a href=\"http://52.90.126.238:8080/fhir/baseDstu3/Endpoint/Endpoint-71\">Brenda.Jennings.Richard.MD@direct.example.org</a></li></ul></div>"
+  },
+  "practitioner": {
+    "reference": "Practitioner/Practitioner-1011",
+    "display": "Brenda Jennings Richard MD"
+  },
+  "organization": {
+    "reference": "Organization/acme-lab",
+    "display": "Acme Lab"
+  },
+  "code": [
+    {
+      "coding": [
+        {
+          "system": "http://nucc.org/provider-taxonomy",
+          "code": "261QP2300X",
+          "display": "Primary Care"
+        }
+      ]
+    }
+  ],
+  "specialty": [
+    {
+      "coding": [
+        {
+          "system": "http://nucc.org/provider-taxonomy",
+          "code": "208D00000X",
+          "display": "General Practice"
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "reference": "Location/hl7east",
+      "display": "Health Level Seven International"
+    }
+  ],
+  "endpoint": [
+    {
+      "reference": "http://52.90.126.238:8080/fhir/baseDstu3/Endpoint/Endpoint-71",
+      "display": "Westwood Physicians Organization ADT"
+    },
+    {
+      "reference": "http://52.90.126.238:8080/fhir/baseDstu3/Endpoint/Endpoint-71",
+      "display": "Brenda.Jennings.Richard.MD@direct.example.org"
+    }
+  ]
+}

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'code': '59576-9'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'code': '77606-2'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'category': 'assess-plan'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310CareteamSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'status': 'proposed'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'category': 'LAB'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'category': 'LP29684-5'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -111,8 +111,12 @@ describe Inferno::Sequence::USCore310LocationSequence do
       @test = @sequence_class[:unauthorized_search]
       @sequence = @sequence_class.new(@instance, @client)
 
+      @location_ary = load_json_fixture(:us_core_location_location_ary)
+        .map { |resource| FHIR.from_contents(resource.to_json) }
+      @sequence.instance_variable_set(:'@location_ary', @location_ary)
+
       @query = {
-        'patient': @instance.patient_id
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'name'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -111,8 +111,7 @@ describe Inferno::Sequence::USCore310LocationSequence do
       @test = @sequence_class[:unauthorized_search]
       @sequence = @sequence_class.new(@instance, @client)
 
-      @location_ary = load_json_fixture(:us_core_location_location_ary)
-        .map { |resource| FHIR.from_contents(resource.to_json) }
+      @location_ary = FHIR.from_contents(load_fixture(:us_core_location))
       @sequence.instance_variable_set(:'@location_ary', @location_ary)
 
       @query = {

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'intent': 'proposal'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'category': 'laboratory'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -111,8 +111,12 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
       @test = @sequence_class[:unauthorized_search]
       @sequence = @sequence_class.new(@instance, @client)
 
+      @organization_ary = load_json_fixture(:us_core_organization_organization_ary)
+        .map { |resource| FHIR.from_contents(resource.to_json) }
+      @sequence.instance_variable_set(:'@organization_ary', @organization_ary)
+
       @query = {
-        'patient': @instance.patient_id
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@organization_ary, 'name'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -111,8 +111,7 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
       @test = @sequence_class[:unauthorized_search]
       @sequence = @sequence_class.new(@instance, @client)
 
-      @organization_ary = load_json_fixture(:us_core_organization_organization_ary)
-        .map { |resource| FHIR.from_contents(resource.to_json) }
+      @organization_ary = FHIR.from_contents(load_fixture(:us_core_organization))
       @sequence.instance_variable_set(:'@organization_ary', @organization_ary)
 
       @query = {

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        '_id': @instance.patient_id
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -111,8 +111,12 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
       @test = @sequence_class[:unauthorized_search]
       @sequence = @sequence_class.new(@instance, @client)
 
+      @practitioner_ary = load_json_fixture(:us_core_practitioner_practitioner_ary)
+        .map { |resource| FHIR.from_contents(resource.to_json) }
+      @sequence.instance_variable_set(:'@practitioner_ary', @practitioner_ary)
+
       @query = {
-        'patient': @instance.patient_id
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_ary, 'name'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -111,8 +111,7 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
       @test = @sequence_class[:unauthorized_search]
       @sequence = @sequence_class.new(@instance, @client)
 
-      @practitioner_ary = load_json_fixture(:us_core_practitioner_practitioner_ary)
-        .map { |resource| FHIR.from_contents(resource.to_json) }
+      @practitioner_ary = FHIR.from_contents(load_fixture(:us_core_practitioner))
       @sequence.instance_variable_set(:'@practitioner_ary', @practitioner_ary)
 
       @query = {

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -111,12 +111,11 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
       @test = @sequence_class[:unauthorized_search]
       @sequence = @sequence_class.new(@instance, @client)
 
-      @practitionerrole_ary = load_json_fixture(:us_core_practitionerrole_practitionerrole_ary)
-        .map { |resource| FHIR.from_contents(resource.to_json) }
-      @sequence.instance_variable_set(:'@practitionerrole_ary', @practitionerrole_ary)
+      @practitioner_role_ary = FHIR.from_contents(load_fixture(:us_core_practitionerrole))
+      @sequence.instance_variable_set(:'@practitioner_role_ary', @practitioner_role_ary)
 
       @query = {
-        'specialty': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitionerrole_ary, 'specialty'))
+        'specialty': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_role_ary, 'specialty'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -111,8 +111,12 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
       @test = @sequence_class[:unauthorized_search]
       @sequence = @sequence_class.new(@instance, @client)
 
+      @practitionerrole_ary = load_json_fixture(:us_core_practitionerrole_practitionerrole_ary)
+        .map { |resource| FHIR.from_contents(resource.to_json) }
+      @sequence.instance_variable_set(:'@practitionerrole_ary', @practitionerrole_ary)
+
       @query = {
-        'patient': @instance.patient_id
+        'specialty': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitionerrole_ary, 'specialty'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'code': '2708-6'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -24,7 +24,8 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': @instance.patient_id
+        'patient': @instance.patient_id,
+        'code': '72166-2'
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -47,7 +47,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -56,8 +56,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'category': assess - plan }
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -56,7 +56,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'category': 'assess-plan' }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'category': 'assess-plan'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -56,7 +56,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'category': assess - plan }
+        search_params = { 'patient': @instance.patient_id, 'category': 'assess-plan' }
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -46,7 +46,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'status': proposed }
+        search_params = { 'patient': @instance.patient_id, 'status': 'proposed' }
         reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -46,8 +46,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'status': proposed }
         reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -46,7 +46,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'status': 'proposed' }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'status': 'proposed'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -61,7 +61,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -60,7 +60,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'category': LAB }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'category': 'LAB'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -60,8 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'category': LAB }
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -60,8 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'category': LP29684 - 5 }
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -60,7 +60,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'category': LP29684 - 5 }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'category': 'LP29684-5'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -69,7 +69,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -69,7 +69,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Encounter'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -53,7 +53,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -53,7 +53,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -47,7 +47,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -89,7 +89,11 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'name': get_value_for_search_param(resolve_element_from_path(@location_ary, 'name'))
+        }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -58,7 +58,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'intent': proposal }
+        search_params = { 'patient': @instance.patient_id, 'intent': 'proposal' }
         reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -58,7 +58,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'intent': 'proposal' }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'intent': 'proposal'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -58,8 +58,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'intent': proposal }
         reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'category': laboratory }
+        search_params = { 'patient': @instance.patient_id, 'category': 'laboratory' }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -60,7 +60,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'category': 'laboratory' }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'category': 'laboratory'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -60,8 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'category': laboratory }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -77,7 +77,11 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'name': get_value_for_search_param(resolve_element_from_path(@organization_ary, 'name'))
+        }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+
         reply = get_resource_by_params(versioned_resource_class('Organization'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -76,7 +76,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          '_id': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -78,7 +78,11 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'name': get_value_for_search_param(resolve_element_from_path(@practitioner_ary, 'name'))
+        }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+
         reply = get_resource_by_params(versioned_resource_class('Practitioner'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -71,7 +71,11 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
+        }
+        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+
         reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -57,7 +57,10 @@ module Inferno
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
 
-        search_params = { patient: @instance.patient_id }
+        search_params = {
+          'patient': @instance.patient_id
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -60,8 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'code': 2708 - 6 }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'code': 2708 - 6 }
+        search_params = { 'patient': @instance.patient_id, 'code': '2708-6' }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -60,7 +60,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'code': '2708-6' }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'code': '2708-6'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -60,8 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-
-        search_params = { patient: @instance.patient_id }
+        search_params = { 'patient': @instance.patient_id, 'code': 72166 - 2 }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -60,7 +60,12 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'code': '72166-2' }
+
+        search_params = {
+          'patient': @instance.patient_id,
+          'code': '72166-2'
+        }
+
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -60,7 +60,7 @@ module Inferno
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
-        search_params = { 'patient': @instance.patient_id, 'code': 72166 - 2 }
+        search_params = { 'patient': @instance.patient_id, 'code': '72166-2' }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
         assert_response_unauthorized reply


### PR DESCRIPTION
This PR sets the search params for authorization tests back to the first search. If there are multiple possible search values, it will use the first one. 

**Submitter:**
- [X] This pull request describes why these changes were made 
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-490
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
