### PR TITLE
FI-487: Generate unit tests for US Core resource read tests

### DIFF
--- a/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
@@ -1,6 +1,6 @@
 describe 'unauthorized search test' do
   before do
-    @test = @sequence_class[:<%= key %>]
+    @test = @sequence_class[:<%= test_key %>]
     @sequence = @sequence_class.new(@instance, @client)
 <% if dynamic_search_params.present? %>
   <% dynamic_search_params.each do |_param, search_param|  %>

--- a/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
@@ -14,6 +14,15 @@ describe 'unauthorized search test' do
     }
   end
 
+  it 'skips if the <%= resource_type %> search interaction is not supported' do
+    @instance.server_capabilities.destroy
+    @instance.reload
+    exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+    skip_message = 'This server does not support <%= resource_type %> search operation(s) according to conformance statement.'
+    assert_equal skip_message, exception.message
+  end
+
   it 'fails when the token refresh response has a success status' do
     stub_request(:get, "#{@base_url}/<%= resource_type %>")
       .with(query: @query)

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -1,7 +1,7 @@
 describe '<%= resource_type %> read test' do
   before do
     @<%= resource_var_name %>_id = '456'
-    @test = @sequence_class[:<%= key %>]
+    @test = @sequence_class[:<%= test_key %>]
     @sequence = @sequence_class.new(@instance, @client)
     <% if interaction_test %>@sequence.instance_variable_set(:'@resources_found', true)
       @sequence.instance_variable_set(:'@<%= resource_var_name %>', FHIR::<%= resource_type %>.new(id: @<%= resource_var_name %>_id))

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -1,0 +1,61 @@
+describe 'resource read test' do
+  before do
+    @<%= resource_var_name %>_id = '456'
+    @test = @sequence_class[:<%= key %>]
+    @sequence = @sequence_class.new(@instance, @client)
+  end
+
+  it 'skips if no <%= resource_type %> has been found' do
+    exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+    assert_equal 'No <%= resource_type %> references found from the prior searches', exception.message
+  end
+
+  it 'fails if a non-success response code is received' do
+    Inferno::Models::ResourceReference.create(
+      resource_type: '<%= resource_type %>',
+      resource_id: @<%= resource_var_name %>_id,
+      testing_instance: @instance
+    )
+    stub_request(:get, "#{@base_url}/<%= resource_type %>/#{@<%= resource_var_name %>_id}")
+      .with(query: @query, headers: @auth_header)
+      .to_return(status: 401)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal "Bad response code: expected 200, 201, but found 401. ", exception.message
+  end
+
+  it 'fails if the resource returned is not a <%= resource_type %>' do
+    Inferno::Models::ResourceReference.create(
+      resource_type: '<%= resource_type %>',
+      resource_id: @<%= resource_var_name %>_id,
+      testing_instance: @instance
+    )
+
+    stub_request(:get, "#{@base_url}/<%= resource_type %>/#{@<%= resource_var_name %>_id}")
+      .with(query: @query, headers: @auth_header)
+      .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal "Expected resource to be of type <%= resource_type %>", exception.message
+  end
+
+  it 'succeeds when a <%= resource_type %> resource is read successfully' do
+    <%= resource_var_name %> = FHIR::<%= resource_type %>.new(
+      id: @<%= resource_var_name %>_id
+    )
+    Inferno::Models::ResourceReference.create(
+      resource_type: '<%= resource_type %>',
+      resource_id: @<%= resource_var_name %>_id,
+      testing_instance: @instance
+    )
+
+    stub_request(:get, "#{@base_url}/<%= resource_type %>/#{@<%= resource_var_name %>_id}")
+      .with(query: @query, headers: @auth_header)
+      .to_return(status: 200, body: <%= resource_var_name %>.to_json)
+
+    @sequence.run_test(@test)
+  end
+end

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -5,6 +5,15 @@ describe 'resource read test' do
     @sequence = @sequence_class.new(@instance, @client)
   end
 
+  it 'skips if the <%= resource_type %> read interaction is not supported' do
+    @instance.server_capabilities.destroy
+    @instance.reload
+    exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+    skip_message = 'This server does not support <%= resource_type %> read operation(s) according to conformance statement.'
+    assert_equal skip_message, exception.message
+  end
+
   it 'skips if no <%= resource_type %> has been found' do
     exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -1,4 +1,4 @@
-describe 'resource read test' do
+describe '<%= resource_type %> read test' do
   before do
     @<%= resource_var_name %>_id = '456'
     @test = @sequence_class[:<%= key %>]

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -26,6 +26,21 @@ describe 'resource read test' do
     assert_equal "Bad response code: expected 200, 201, but found 401. ", exception.message
   end
 
+  it 'fails if no resource is received' do
+    Inferno::Models::ResourceReference.create(
+      resource_type: '<%= resource_type %>',
+      resource_id: @<%= resource_var_name %>_id,
+      testing_instance: @instance
+    )
+    stub_request(:get, "#{@base_url}/<%= resource_type %>/#{@<%= resource_var_name %>_id}")
+      .with(query: @query, headers: @auth_header)
+      .to_return(status: 200)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal 'Expected <%= resource_type %> resource to be present.', exception.message
+  end
+
   it 'fails if the resource returned is not a <%= resource_type %>' do
     Inferno::Models::ResourceReference.create(
       resource_type: '<%= resource_type %>',

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -39,7 +39,7 @@ describe 'resource read test' do
 
     exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-    assert_equal "Expected resource to be of type <%= resource_type %>", exception.message
+    assert_equal "Expected resource to be of type <%= resource_type %>.", exception.message
   end
 
   it 'succeeds when a <%= resource_type %> resource is read successfully' do

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -32,7 +32,7 @@ describe 'resource read test' do
 
     exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-    assert_equal "Bad response code: expected 200, 201, but found 401. ", exception.message
+    assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
   end
 
   it 'fails if no resource is received' do
@@ -63,7 +63,7 @@ describe 'resource read test' do
 
     exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-    assert_equal "Expected resource to be of type <%= resource_type %>.", exception.message
+    assert_equal 'Expected resource to be of type <%= resource_type %>.', exception.message
   end
 
   it 'succeeds when a <%= resource_type %> resource is read successfully' do

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -3,6 +3,9 @@ describe 'resource read test' do
     @<%= resource_var_name %>_id = '456'
     @test = @sequence_class[:<%= key %>]
     @sequence = @sequence_class.new(@instance, @client)
+    <% if interaction_test %>@sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@<%= resource_var_name %>', FHIR::<%= resource_type %>.new(id: @<%= resource_var_name %>_id))
+    <% end %>
   end
 
   it 'skips if the <%= resource_type %> read interaction is not supported' do
@@ -15,9 +18,10 @@ describe 'resource read test' do
   end
 
   it 'skips if no <%= resource_type %> has been found' do
+    <% if interaction_test %>@sequence.instance_variable_set(:'@resources_found', false)<% end %>
     exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-    assert_equal 'No <%= resource_type %> references found from the prior searches', exception.message
+    assert_equal '<%= no_resources_found_message %>', exception.message
   end
 
   it 'fails if a non-success response code is received' do
@@ -26,6 +30,7 @@ describe 'resource read test' do
       resource_id: @<%= resource_var_name %>_id,
       testing_instance: @instance
     )
+
     stub_request(:get, "#{@base_url}/<%= resource_type %>/#{@<%= resource_var_name %>_id}")
       .with(query: @query, headers: @auth_header)
       .to_return(status: 401)
@@ -41,6 +46,7 @@ describe 'resource read test' do
       resource_id: @<%= resource_var_name %>_id,
       testing_instance: @instance
     )
+
     stub_request(:get, "#{@base_url}/<%= resource_type %>/#{@<%= resource_var_name %>_id}")
       .with(query: @query, headers: @auth_header)
       .to_return(status: 200)
@@ -59,7 +65,7 @@ describe 'resource read test' do
 
     stub_request(:get, "#{@base_url}/<%= resource_type %>/#{@<%= resource_var_name %>_id}")
       .with(query: @query, headers: @auth_header)
-      .to_return(status: 200, body: FHIR::Patient.new.to_json)
+      .to_return(status: 200, body: FHIR::<%= wrong_resource_type %>.new.to_json)
 
     exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 

--- a/generator/uscore/templates/unit_tests/unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/unit_test.rb.erb
@@ -11,11 +11,9 @@ describe Inferno::Sequence::<%= class_name %> do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: '<%= module_name %>')
     @patient_id = '123'
     @instance.patient_id = @patient_id
-    @module = OpenStruct.new(resources_to_test: Set.new(['<%= resource_type %>']))
-    @instance.instance_variable_set(:'@module', @module)
     set_resource_support(@instance, '<%= resource_type %>')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end

--- a/generator/uscore/templates/unit_tests/unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/unit_test.rb.erb
@@ -14,6 +14,9 @@ describe Inferno::Sequence::<%= class_name %> do
     @instance = Inferno::Models::TestingInstance.create(token: @token)
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    @module = OpenStruct.new(resources_to_test: Set.new(['<%= resource_type %>']))
+    @instance.instance_variable_set(:'@module', @module)
+    set_resource_support(@instance, '<%= resource_type %>')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -37,16 +37,27 @@ module Inferno
         tests[class_name] << test
       end
 
-      def generate_resource_read_test(key:, resource_type:, class_name:)
+      def generate_resource_read_test(key:, resource_type:, class_name:, interaction_test: false)
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'resource_read_unit_test.rb.erb')))
         resource_var_name = resource_type.underscore
 
         test = template.result_with_hash(
           key: key,
           resource_type: resource_type,
-          resource_var_name: resource_var_name
+          resource_var_name: resource_var_name,
+          interaction_test: interaction_test,
+          no_resources_found_message: no_resources_found_message(interaction_test, resource_type),
+          wrong_resource_type: resource_type == 'Patient' ? 'Observation' : 'Patient'
         )
         tests[class_name] << test
+      end
+
+      def no_resources_found_message(interaction_test, resource_type)
+        if interaction_test
+          "No #{resource_type} resources could be found for this patient. Please use patients with more information."
+        else
+          "No #{resource_type} references found from the prior searches"
+        end
       end
 
       def search_params_to_string(search_params)

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -26,10 +26,10 @@ module Inferno
         File.write(file_name, unit_tests)
       end
 
-      def generate_authorization_test(key:, resource_type:, search_params:, class_name:)
+      def generate_authorization_test(test_key:, resource_type:, search_params:, class_name:)
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'authorization_unit_test.rb.erb')))
         test = template.result_with_hash(
-          key: key,
+          test_key: test_key,
           resource_type: resource_type,
           search_param_string: search_params_to_string(search_params),
           dynamic_search_params: dynamic_search_params(search_params)
@@ -37,12 +37,12 @@ module Inferno
         tests[class_name] << test
       end
 
-      def generate_resource_read_test(key:, resource_type:, class_name:, interaction_test: false)
+      def generate_resource_read_test(test_key:, resource_type:, class_name:, interaction_test: false)
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'resource_read_unit_test.rb.erb')))
         resource_var_name = resource_type.underscore
 
         test = template.result_with_hash(
-          key: key,
+          test_key: test_key,
           resource_type: resource_type,
           resource_var_name: resource_var_name,
           interaction_test: interaction_test,

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -24,14 +24,25 @@ module Inferno
         File.write(file_name, unit_tests)
       end
 
-      def generate_authorization_test(key:, name:, resource_type:, search_params:, class_name:)
+      def generate_authorization_test(key:, resource_type:, search_params:, class_name:)
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'authorization_unit_test.rb.erb')))
         test = template.result_with_hash(
           key: key,
-          name: name,
           resource_type: resource_type,
           search_param_string: search_params_to_string(search_params),
           dynamic_search_params: dynamic_search_params(search_params)
+        )
+        tests[class_name] << test
+      end
+
+      def generate_resource_read_test(key:, resource_type:, class_name:)
+        template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'resource_read_unit_test.rb.erb')))
+        resource_var_name = resource_type.underscore
+
+        test = template.result_with_hash(
+          key: key,
+          resource_type: resource_type,
+          resource_var_name: resource_var_name
         )
         tests[class_name] << test
       end

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -14,7 +14,8 @@ module Inferno
 
         unit_tests = template.result_with_hash(
           class_name: class_name,
-          tests: tests[class_name]
+          tests: tests[class_name],
+          resource_type: sequence[:resource]
         )
 
         test_path = File.join(path, 'test')

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -7,7 +7,7 @@ module Inferno
         @tests ||= Hash.new { |hash, key| hash[key] = [] }
       end
 
-      def generate(sequence, path)
+      def generate(sequence, path, module_name)
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'unit_test.rb.erb')))
         class_name = sequence[:class_name]
         return if tests[class_name].blank?
@@ -15,7 +15,8 @@ module Inferno
         unit_tests = template.result_with_hash(
           class_name: class_name,
           tests: tests[class_name],
-          resource_type: sequence[:resource]
+          resource_type: sequence[:resource],
+          module_name: module_name
         )
 
         test_path = File.join(path, 'test')

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -27,7 +27,7 @@ module Inferno
         generate_search_validators(metadata)
         metadata[:sequences].each do |sequence|
           generate_sequence(sequence)
-          unit_test_generator.generate(sequence, sequence_out_path)
+          unit_test_generator.generate(sequence, sequence_out_path, metadata[:name])
         end
         generate_module(metadata)
       end

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -115,7 +115,10 @@ module Inferno
         read_test[:test_code] = %(
               #{sequence[:resource].downcase}_id = @instance.resource_references.find { |reference| reference.resource_type == '#{sequence[:resource]}' }&.resource_id
               skip 'No #{sequence[:resource]} references found from the prior searches' if #{sequence[:resource].downcase}_id.nil?
-              @#{sequence[:resource].downcase} = fetch_resource('#{sequence[:resource]}', #{sequence[:resource].downcase}_id)
+              @#{sequence[:resource].downcase} = validate_read_reply(
+                FHIR::#{sequence[:resource]}.new(id: #{sequence[:resource].downcase}_id),
+                FHIR::#{sequence[:resource]}
+              )
               @#{sequence[:resource].downcase}_ary = Array.wrap(@#{sequence[:resource].downcase})
               @resources_found = !@#{sequence[:resource].downcase}.nil?)
         sequence[:tests] << read_test

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -113,8 +113,11 @@ module Inferno
         }
 
         read_test[:test_code] = %(
+              skip_if_not_supported(:#{sequence[:resource]}, [:read])
+
               #{sequence[:resource].downcase}_id = @instance.resource_references.find { |reference| reference.resource_type == '#{sequence[:resource]}' }&.resource_id
               skip 'No #{sequence[:resource]} references found from the prior searches' if #{sequence[:resource].downcase}_id.nil?
+
               @#{sequence[:resource].downcase} = validate_read_reply(
                 FHIR::#{sequence[:resource]}.new(id: #{sequence[:resource].downcase}_id),
                 FHIR::#{sequence[:resource]}
@@ -143,8 +146,11 @@ module Inferno
         return if first_search.nil?
 
         authorization_test[:test_code] = %(
+              skip_if_not_supported(:#{sequence[:resource]}, [:search])
+
               @client.set_no_auth
               omit 'Do not test if no bearer token set' if @instance.token.blank?
+
               search_params = { patient: @instance.patient_id }
               reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
               @client.set_bearer_token(@instance.token)

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -104,10 +104,10 @@ module Inferno
       end
 
       def create_read_test(sequence)
-        key = :resource_read
+        test_key = :resource_read
         read_test = {
           tests_that: "Can read #{sequence[:resource]} from the server",
-          key: key,
+          key: test_key,
           index: sequence[:tests].length + 1,
           link: 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
         }
@@ -127,17 +127,17 @@ module Inferno
         sequence[:tests] << read_test
 
         unit_test_generator.generate_resource_read_test(
-          key: key,
+          test_key: test_key,
           resource_type: sequence[:resource],
           class_name: sequence[:class_name]
         )
       end
 
       def create_authorization_test(sequence)
-        key = :unauthorized_search
+        test_key = :unauthorized_search
         authorization_test = {
           tests_that: "Server rejects #{sequence[:resource]} search without authorization",
-          key: key,
+          key: test_key,
           index: sequence[:tests].length + 1,
           link: 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html#behavior'
         }
@@ -159,7 +159,7 @@ module Inferno
         sequence[:tests] << authorization_test
 
         unit_test_generator.generate_authorization_test(
-          key: key,
+          test_key: test_key,
           resource_type: sequence[:resource],
           search_params: { patient: '@instance.patient_id' },
           class_name: sequence[:class_name]
@@ -241,10 +241,10 @@ module Inferno
       end
 
       def create_interaction_test(sequence, interaction)
-        key = :"#{interaction[:code]}_interaction"
+        test_key = :"#{interaction[:code]}_interaction"
         interaction_test = {
           tests_that: "#{sequence[:resource]} #{interaction[:code]} interaction supported",
-          key: key,
+          key: test_key,
           index: sequence[:tests].length + 1,
           link: 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
         }
@@ -259,7 +259,7 @@ module Inferno
 
         if interaction[:code] == 'read' # rubocop:disable Style/GuardClause
           unit_test_generator.generate_resource_read_test(
-            key: key,
+            test_key: test_key,
             resource_type: sequence[:resource],
             class_name: sequence[:class_name],
             interaction_test: true

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -115,15 +115,15 @@ module Inferno
         read_test[:test_code] = %(
               skip_if_not_supported(:#{sequence[:resource]}, [:read])
 
-              #{sequence[:resource].downcase}_id = @instance.resource_references.find { |reference| reference.resource_type == '#{sequence[:resource]}' }&.resource_id
-              skip 'No #{sequence[:resource]} references found from the prior searches' if #{sequence[:resource].downcase}_id.nil?
+              #{sequence[:resource].underscore}_id = @instance.resource_references.find { |reference| reference.resource_type == '#{sequence[:resource]}' }&.resource_id
+              skip 'No #{sequence[:resource]} references found from the prior searches' if #{sequence[:resource].underscore}_id.nil?
 
-              @#{sequence[:resource].downcase} = validate_read_reply(
-                FHIR::#{sequence[:resource]}.new(id: #{sequence[:resource].downcase}_id),
+              @#{sequence[:resource].underscore} = validate_read_reply(
+                FHIR::#{sequence[:resource]}.new(id: #{sequence[:resource].underscore}_id),
                 FHIR::#{sequence[:resource]}
               )
-              @#{sequence[:resource].downcase}_ary = Array.wrap(@#{sequence[:resource].downcase}).compact
-              @resources_found = @#{sequence[:resource].downcase}.present?)
+              @#{sequence[:resource].underscore}_ary = Array.wrap(@#{sequence[:resource].underscore}).compact
+              @resources_found = @#{sequence[:resource].underscore}.present?)
         sequence[:tests] << read_test
 
         unit_test_generator.generate_resource_read_test(
@@ -230,7 +230,7 @@ module Inferno
           else
             %(
               skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-              assert !@#{sequence[:resource].downcase}.nil?, 'Expected valid #{sequence[:resource]} resource to be present'
+              assert !@#{sequence[:resource].underscore}.nil?, 'Expected valid #{sequence[:resource]} resource to be present'
       #{get_search_params(search_param[:names], sequence)}
               reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
@@ -241,19 +241,30 @@ module Inferno
       end
 
       def create_interaction_test(sequence, interaction)
+        key = :"#{interaction[:code]}_interaction"
         interaction_test = {
-          tests_that: "#{sequence[:resource]} #{interaction[:code]} resource supported",
+          tests_that: "#{sequence[:resource]} #{interaction[:code]} interaction supported",
+          key: key,
           index: sequence[:tests].length + 1,
           link: 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
         }
 
         interaction_test[:test_code] = %(
               skip_if_not_supported(:#{sequence[:resource]}, [:#{interaction[:code]}])
-              skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+              skip 'No #{sequence[:resource]} resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-              validate_#{interaction[:code]}_reply(@#{sequence[:resource].downcase}, versioned_resource_class('#{sequence[:resource]}')))
+              validate_#{interaction[:code]}_reply(@#{sequence[:resource].underscore}, versioned_resource_class('#{sequence[:resource]}')))
 
         sequence[:tests] << interaction_test
+
+        if interaction[:code] == 'read' # rubocop:disable Style/GuardClause
+          unit_test_generator.generate_resource_read_test(
+            key: key,
+            resource_type: sequence[:resource],
+            class_name: sequence[:class_name],
+            interaction_test: true
+          )
+        end
       end
 
       def create_must_support_test(sequence)
@@ -265,7 +276,7 @@ module Inferno
         }
 
         test[:test_code] += %(
-              skip 'No resources appear to be available for this patient. Please use patients with more information' unless @#{sequence[:resource].downcase}_ary&.any?)
+              skip 'No resources appear to be available for this patient. Please use patients with more information' unless @#{sequence[:resource].underscore}_ary&.any?)
 
         test[:test_code] += %(
               must_support_confirmed = {})
@@ -280,11 +291,11 @@ module Inferno
                 #{extensions_list.join(",\n          ")}
               }
               extensions_list.each do |id, url|
-                @#{sequence[:resource].downcase}_ary&.each do |resource|
+                @#{sequence[:resource].underscore}_ary&.each do |resource|
                   must_support_confirmed[id] = true if resource.extension.any? { |extension| extension.url == url }
                   break if must_support_confirmed[id]
                 end
-                skip_notification = "Could not find \#{id} in any of the \#{@#{sequence[:resource].downcase}_ary.length} provided #{sequence[:resource]} resource(s)"
+                skip_notification = "Could not find \#{id} in any of the \#{@#{sequence[:resource].underscore}_ary.length} provided #{sequence[:resource]} resource(s)"
                 skip skip_notification unless must_support_confirmed[id]
               end
       )
@@ -301,12 +312,12 @@ module Inferno
                 #{elements_list.join(",\n          ")}
               ]
               must_support_elements.each do |path|
-                @#{sequence[:resource].downcase}_ary&.each do |resource|
+                @#{sequence[:resource].underscore}_ary&.each do |resource|
                   truncated_path = path.gsub('#{sequence[:resource]}.', '')
                   must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
                   break if must_support_confirmed[path]
                 end
-                resource_count = @#{sequence[:resource].downcase}_ary.length
+                resource_count = @#{sequence[:resource].underscore}_ary.length
 
                 skip "Could not find \#{path} in any of the \#{resource_count} provided #{sequence[:resource]} resource(s)" unless must_support_confirmed[path]
               end)
@@ -342,7 +353,7 @@ module Inferno
               skip_if_not_supported(:#{sequence[:resource]}, [:search, :read])
               skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-              validate_reference_resolutions(@#{sequence[:resource].downcase}))
+              validate_reference_resolutions(@#{sequence[:resource].underscore}))
         sequence[:tests] << test
       end
 
@@ -406,10 +417,10 @@ module Inferno
 
           skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-          @#{sequence[:resource].downcase} = reply&.resource&.entry&.first&.resource
-          @#{sequence[:resource].downcase}_ary = fetch_all_bundled_resources(reply&.resource)
+          @#{sequence[:resource].underscore} = reply&.resource&.entry&.first&.resource
+          @#{sequence[:resource].underscore}_ary = fetch_all_bundled_resources(reply&.resource)
           save_resource_ids_in_bundle(#{save_resource_ids_in_bundle_arguments})
-          save_delayed_sequence_references(@#{sequence[:resource].downcase}_ary)
+          save_delayed_sequence_references(@#{sequence[:resource].underscore}_ary)
           validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
         )
       end
@@ -431,11 +442,11 @@ module Inferno
             @resources_found = true if resource_count.positive?
             next unless @resources_found
 
-            @#{sequence[:resource].downcase} = reply&.resource&.entry&.first&.resource
-            @#{sequence[:resource].downcase}_ary = fetch_all_bundled_resources(reply&.resource)
+            @#{sequence[:resource].underscore} = reply&.resource&.entry&.first&.resource
+            @#{sequence[:resource].underscore}_ary = fetch_all_bundled_resources(reply&.resource)
 
             save_resource_ids_in_bundle(#{save_resource_ids_in_bundle_arguments})
-            save_delayed_sequence_references(@#{sequence[:resource].downcase}_ary)
+            save_delayed_sequence_references(@#{sequence[:resource].underscore}_ary)
             validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
             break
           end

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -104,8 +104,10 @@ module Inferno
       end
 
       def create_read_test(sequence)
+        key = :resource_read
         read_test = {
           tests_that: "Can read #{sequence[:resource]} from the server",
+          key: key,
           index: sequence[:tests].length + 1,
           link: 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
         }

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -119,8 +119,8 @@ module Inferno
                 FHIR::#{sequence[:resource]}.new(id: #{sequence[:resource].downcase}_id),
                 FHIR::#{sequence[:resource]}
               )
-              @#{sequence[:resource].downcase}_ary = Array.wrap(@#{sequence[:resource].downcase})
-              @resources_found = !@#{sequence[:resource].downcase}.nil?)
+              @#{sequence[:resource].downcase}_ary = Array.wrap(@#{sequence[:resource].downcase}).compact
+              @resources_found = @#{sequence[:resource].downcase}.present?)
         sequence[:tests] << read_test
 
         unit_test_generator.generate_resource_read_test(

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -119,6 +119,12 @@ module Inferno
               @#{sequence[:resource].downcase}_ary = Array.wrap(@#{sequence[:resource].downcase})
               @resources_found = !@#{sequence[:resource].downcase}.nil?)
         sequence[:tests] << read_test
+
+        unit_test_generator.generate_resource_read_test(
+          key: key,
+          resource_type: sequence[:resource],
+          class_name: sequence[:class_name]
+        )
       end
 
       def create_authorization_test(sequence)
@@ -142,9 +148,9 @@ module Inferno
               assert_response_unauthorized reply)
 
         sequence[:tests] << authorization_test
+
         unit_test_generator.generate_authorization_test(
           key: key,
-          name: sequence[:name],
           resource_type: sequence[:resource],
           search_params: { patient: '@instance.patient_id' },
           class_name: sequence[:class_name]

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -515,18 +515,20 @@ module Inferno
       end
 
       def validate_read_reply(resource, klass)
-        assert !resource.nil?, "No #{klass.name.demodulize} resources available from search."
+        class_name = klass.name.demodulize
+        assert !resource.nil?, "No #{class_name} resources available from search."
         if resource.is_a? FHIR::DSTU2::Reference
           read_response = resource.read
         else
           id = resource.try(:id)
-          assert !id.nil?, "#{klass} id not returned"
+          assert !id.nil?, "#{class_name} id not returned"
           read_response = @client.read(klass, id)
           assert_response_ok read_response
           read_response = read_response.resource
         end
-        assert !read_response.nil?, "Expected valid #{klass} resource to be present"
-        assert read_response.is_a?(klass), "Expected resource to be valid #{klass}"
+        assert !read_response.nil?, "Expected #{class_name} resource to be present."
+        assert read_response.is_a?(klass), "Expected resource to be of type #{class_name}."
+        read_response
       end
 
       def validate_history_reply(resource, klass)

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -56,8 +56,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Observation, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -207,9 +210,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Observation read resource supported' do
+      test :read_interaction do
         metadata do
           id '07'
+          name 'Observation read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -217,14 +221,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '08'
+          name 'Observation vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -232,14 +237,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation history resource supported' do
+      test :history_interaction do
         metadata do
           id '09'
+          name 'Observation history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -247,7 +253,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -56,8 +56,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Observation, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -207,9 +210,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Observation read resource supported' do
+      test :read_interaction do
         metadata do
           id '07'
+          name 'Observation read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -217,14 +221,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '08'
+          name 'Observation vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -232,14 +237,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation history resource supported' do
+      test :history_interaction do
         metadata do
           id '09'
+          name 'Observation history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -247,7 +253,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Observation read test' do
     before do
       @observation_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Observation read test' do
     before do
       @observation_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'AllergyIntolerance')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the AllergyIntolerance search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support AllergyIntolerance search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @allergy_intolerance_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@allergy_intolerance', FHIR::AllergyIntolerance.new(id: @allergy_intolerance_id))
+    end
+
+    it 'skips if the AllergyIntolerance read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support AllergyIntolerance read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no AllergyIntolerance has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected AllergyIntolerance resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a AllergyIntolerance' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type AllergyIntolerance.', exception.message
+    end
+
+    it 'succeeds when a AllergyIntolerance resource is read successfully' do
+      allergy_intolerance = FHIR::AllergyIntolerance.new(
+        id: @allergy_intolerance_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: allergy_intolerance.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'AllergyIntolerance read test' do
     before do
       @allergy_intolerance_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'CarePlan')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the CarePlan search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support CarePlan search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @care_plan_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@care_plan', FHIR::CarePlan.new(id: @care_plan_id))
+    end
+
+    it 'skips if the CarePlan read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support CarePlan read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no CarePlan has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CarePlan resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected CarePlan resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a CarePlan' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type CarePlan.', exception.message
+    end
+
+    it 'succeeds when a CarePlan resource is read successfully' do
+      care_plan = FHIR::CarePlan.new(
+        id: @care_plan_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: care_plan.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'CarePlan read test' do
     before do
       @care_plan_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310CareteamSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'CareTeam read test' do
     before do
       @care_team_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310CareteamSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'CareTeam')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310CareteamSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the CareTeam search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support CareTeam search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310CareteamSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @care_team_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@care_team', FHIR::CareTeam.new(id: @care_team_id))
+    end
+
+    it 'skips if the CareTeam read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support CareTeam read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no CareTeam has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CareTeam resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected CareTeam resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a CareTeam' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type CareTeam.', exception.message
+    end
+
+    it 'succeeds when a CareTeam resource is read successfully' do
+      care_team = FHIR::CareTeam.new(
+        id: @care_team_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: care_team.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Condition')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Condition search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Condition search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @condition_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@condition', FHIR::Condition.new(id: @condition_id))
+    end
+
+    it 'skips if the Condition read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Condition read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Condition has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Condition resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Condition resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Condition' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Condition.', exception.message
+    end
+
+    it 'succeeds when a Condition resource is read successfully' do
+      condition = FHIR::Condition.new(
+        id: @condition_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: condition.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Condition read test' do
     before do
       @condition_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'DiagnosticReport')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the DiagnosticReport search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DiagnosticReport search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @diagnostic_report_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@diagnostic_report', FHIR::DiagnosticReport.new(id: @diagnostic_report_id))
+    end
+
+    it 'skips if the DiagnosticReport read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DiagnosticReport read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no DiagnosticReport has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected DiagnosticReport resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a DiagnosticReport' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type DiagnosticReport.', exception.message
+    end
+
+    it 'succeeds when a DiagnosticReport resource is read successfully' do
+      diagnostic_report = FHIR::DiagnosticReport.new(
+        id: @diagnostic_report_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: diagnostic_report.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'DiagnosticReport read test' do
     before do
       @diagnostic_report_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'DiagnosticReport')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the DiagnosticReport search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DiagnosticReport search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @diagnostic_report_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@diagnostic_report', FHIR::DiagnosticReport.new(id: @diagnostic_report_id))
+    end
+
+    it 'skips if the DiagnosticReport read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DiagnosticReport read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no DiagnosticReport has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected DiagnosticReport resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a DiagnosticReport' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type DiagnosticReport.', exception.message
+    end
+
+    it 'succeeds when a DiagnosticReport resource is read successfully' do
+      diagnostic_report = FHIR::DiagnosticReport.new(
+        id: @diagnostic_report_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: diagnostic_report.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'DiagnosticReport read test' do
     before do
       @diagnostic_report_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'DocumentReference')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the DocumentReference search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DocumentReference search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @document_reference_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@document_reference', FHIR::DocumentReference.new(id: @document_reference_id))
+    end
+
+    it 'skips if the DocumentReference read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DocumentReference read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no DocumentReference has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected DocumentReference resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a DocumentReference' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type DocumentReference.', exception.message
+    end
+
+    it 'succeeds when a DocumentReference resource is read successfully' do
+      document_reference = FHIR::DocumentReference.new(
+        id: @document_reference_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: document_reference.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'DocumentReference read test' do
     before do
       @document_reference_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Encounter')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Encounter search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Encounter search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @encounter_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@encounter', FHIR::Encounter.new(id: @encounter_id))
+    end
+
+    it 'skips if the Encounter read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Encounter read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Encounter has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Encounter resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Encounter' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Encounter.', exception.message
+    end
+
+    it 'succeeds when a Encounter resource is read successfully' do
+      encounter = FHIR::Encounter.new(
+        id: @encounter_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: encounter.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Encounter read test' do
     before do
       @encounter_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310GoalSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Goal')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310GoalSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Goal search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Goal search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310GoalSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @goal_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@goal', FHIR::Goal.new(id: @goal_id))
+    end
+
+    it 'skips if the Goal read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Goal read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Goal has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Goal resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Goal resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Goal' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Goal.', exception.message
+    end
+
+    it 'succeeds when a Goal resource is read successfully' do
+      goal = FHIR::Goal.new(
+        id: @goal_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: goal.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Goal read test' do
     before do
       @goal_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Immunization read test' do
     before do
       @immunization_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Immunization')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Immunization search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Immunization search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @immunization_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@immunization', FHIR::Immunization.new(id: @immunization_id))
+    end
+
+    it 'skips if the Immunization read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Immunization read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Immunization has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Immunization resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Immunization resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Immunization' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Immunization.', exception.message
+    end
+
+    it 'succeeds when a Immunization resource is read successfully' do
+      immunization = FHIR::Immunization.new(
+        id: @immunization_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: immunization.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Device')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Device search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Device search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @device_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@device', FHIR::Device.new(id: @device_id))
+    end
+
+    it 'skips if the Device read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Device read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Device has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Device resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Device resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Device' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Device.', exception.message
+    end
+
+    it 'succeeds when a Device resource is read successfully' do
+      device = FHIR::Device.new(
+        id: @device_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: device.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Device read test' do
     before do
       @device_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -11,10 +11,99 @@ describe Inferno::Sequence::USCore310LocationSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Location')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'resource read test' do
+    before do
+      @location_id = '456'
+      @test = @sequence_class[:resource_read]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips if the Location read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Location read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Location has been found' do
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Location references found from the prior searches', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Location',
+        resource_id: @location_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Location/#{@location_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Location',
+        resource_id: @location_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Location/#{@location_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Location resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Location' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Location',
+        resource_id: @location_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Location/#{@location_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Location.', exception.message
+    end
+
+    it 'succeeds when a Location resource is read successfully' do
+      location = FHIR::Location.new(
+        id: @location_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Location',
+        resource_id: @location_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Location/#{@location_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: location.to_json)
+
+      @sequence.run_test(@test)
+    end
   end
 
   describe 'unauthorized search test' do
@@ -25,6 +114,15 @@ describe Inferno::Sequence::USCore310LocationSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Location search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Location search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -18,7 +18,7 @@ describe Inferno::Sequence::USCore310LocationSequence do
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
-  describe 'resource read test' do
+  describe 'Location read test' do
     before do
       @location_id = '456'
       @test = @sequence_class[:resource_read]

--- a/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310MedicationSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310MedicationSequence
+    @base_url = 'http://www.example.com/fhir'
+    @client = FHIR::Client.new(@base_url)
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @patient_id = '123'
+    @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Medication')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'resource read test' do
+    before do
+      @medication_id = '456'
+      @test = @sequence_class[:resource_read]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips if the Medication read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Medication read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Medication has been found' do
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Medication references found from the prior searches', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Medication',
+        resource_id: @medication_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Medication/#{@medication_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Medication',
+        resource_id: @medication_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Medication/#{@medication_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Medication resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Medication' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Medication',
+        resource_id: @medication_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Medication/#{@medication_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Medication.', exception.message
+    end
+
+    it 'succeeds when a Medication resource is read successfully' do
+      medication = FHIR::Medication.new(
+        id: @medication_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Medication',
+        resource_id: @medication_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Medication/#{@medication_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: medication.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
@@ -18,7 +18,7 @@ describe Inferno::Sequence::USCore310MedicationSequence do
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
-  describe 'resource read test' do
+  describe 'Medication read test' do
     before do
       @medication_id = '456'
       @test = @sequence_class[:resource_read]

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'MedicationRequest read test' do
     before do
       @medication_request_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'MedicationRequest')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the MedicationRequest search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support MedicationRequest search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @medication_request_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@medication_request', FHIR::MedicationRequest.new(id: @medication_request_id))
+    end
+
+    it 'skips if the MedicationRequest read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support MedicationRequest read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no MedicationRequest has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No MedicationRequest resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected MedicationRequest resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a MedicationRequest' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type MedicationRequest.', exception.message
+    end
+
+    it 'succeeds when a MedicationRequest resource is read successfully' do
+      medication_request = FHIR::MedicationRequest.new(
+        id: @medication_request_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: medication_request.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Observation read test' do
     before do
       @observation_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -11,10 +11,99 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Organization')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'resource read test' do
+    before do
+      @organization_id = '456'
+      @test = @sequence_class[:resource_read]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips if the Organization read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Organization read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Organization has been found' do
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Organization references found from the prior searches', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Organization',
+        resource_id: @organization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Organization/#{@organization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Organization',
+        resource_id: @organization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Organization/#{@organization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Organization resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Organization' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Organization',
+        resource_id: @organization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Organization/#{@organization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Organization.', exception.message
+    end
+
+    it 'succeeds when a Organization resource is read successfully' do
+      organization = FHIR::Organization.new(
+        id: @organization_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Organization',
+        resource_id: @organization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Organization/#{@organization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: organization.to_json)
+
+      @sequence.run_test(@test)
+    end
   end
 
   describe 'unauthorized search test' do
@@ -25,6 +114,15 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Organization search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Organization search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -18,7 +18,7 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
-  describe 'resource read test' do
+  describe 'Organization read test' do
     before do
       @organization_id = '456'
       @test = @sequence_class[:resource_read]

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Patient read test' do
     before do
       @patient_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310PatientSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Patient')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Patient search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Patient search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310PatientSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @patient_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@patient', FHIR::Patient.new(id: @patient_id))
+    end
+
+    it 'skips if the Patient read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Patient read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Patient has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Patient resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Patient' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Patient.', exception.message
+    end
+
+    it 'succeeds when a Patient resource is read successfully' do
+      patient = FHIR::Patient.new(
+        id: @patient_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: patient.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -18,7 +18,7 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
-  describe 'resource read test' do
+  describe 'Practitioner read test' do
     before do
       @practitioner_id = '456'
       @test = @sequence_class[:resource_read]

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -11,10 +11,99 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Practitioner')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'resource read test' do
+    before do
+      @practitioner_id = '456'
+      @test = @sequence_class[:resource_read]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips if the Practitioner read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Practitioner read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Practitioner has been found' do
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Practitioner references found from the prior searches', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Practitioner',
+        resource_id: @practitioner_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Practitioner/#{@practitioner_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Practitioner',
+        resource_id: @practitioner_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Practitioner/#{@practitioner_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Practitioner resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Practitioner' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Practitioner',
+        resource_id: @practitioner_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Practitioner/#{@practitioner_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Practitioner.', exception.message
+    end
+
+    it 'succeeds when a Practitioner resource is read successfully' do
+      practitioner = FHIR::Practitioner.new(
+        id: @practitioner_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Practitioner',
+        resource_id: @practitioner_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Practitioner/#{@practitioner_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: practitioner.to_json)
+
+      @sequence.run_test(@test)
+    end
   end
 
   describe 'unauthorized search test' do
@@ -25,6 +114,15 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Practitioner search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Practitioner search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -18,7 +18,7 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
-  describe 'resource read test' do
+  describe 'PractitionerRole read test' do
     before do
       @practitioner_role_id = '456'
       @test = @sequence_class[:resource_read]

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -11,10 +11,99 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'PractitionerRole')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'resource read test' do
+    before do
+      @practitioner_role_id = '456'
+      @test = @sequence_class[:resource_read]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips if the PractitionerRole read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support PractitionerRole read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no PractitionerRole has been found' do
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No PractitionerRole references found from the prior searches', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'PractitionerRole',
+        resource_id: @practitioner_role_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/PractitionerRole/#{@practitioner_role_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'PractitionerRole',
+        resource_id: @practitioner_role_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/PractitionerRole/#{@practitioner_role_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected PractitionerRole resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a PractitionerRole' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'PractitionerRole',
+        resource_id: @practitioner_role_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/PractitionerRole/#{@practitioner_role_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type PractitionerRole.', exception.message
+    end
+
+    it 'succeeds when a PractitionerRole resource is read successfully' do
+      practitioner_role = FHIR::PractitionerRole.new(
+        id: @practitioner_role_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'PractitionerRole',
+        resource_id: @practitioner_role_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/PractitionerRole/#{@practitioner_role_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: practitioner_role.to_json)
+
+      @sequence.run_test(@test)
+    end
   end
 
   describe 'unauthorized search test' do
@@ -25,6 +114,15 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the PractitionerRole search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support PractitionerRole search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Procedure read test' do
     before do
       @procedure_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Procedure')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Procedure search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Procedure search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @procedure_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@procedure', FHIR::Procedure.new(id: @procedure_id))
+    end
+
+    it 'skips if the Procedure read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Procedure read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Procedure has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Procedure resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Procedure resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Procedure' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Procedure.', exception.message
+    end
+
+    it 'succeeds when a Procedure resource is read successfully' do
+      procedure = FHIR::Procedure.new(
+        id: @procedure_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: procedure.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
@@ -18,7 +18,7 @@ describe Inferno::Sequence::USCore310ProvenanceSequence do
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
-  describe 'resource read test' do
+  describe 'Provenance read test' do
     before do
       @provenance_id = '456'
       @test = @sequence_class[:resource_read]

--- a/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310ProvenanceSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310ProvenanceSequence
+    @base_url = 'http://www.example.com/fhir'
+    @client = FHIR::Client.new(@base_url)
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @patient_id = '123'
+    @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Provenance')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'resource read test' do
+    before do
+      @provenance_id = '456'
+      @test = @sequence_class[:resource_read]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips if the Provenance read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Provenance read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Provenance has been found' do
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Provenance references found from the prior searches', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Provenance',
+        resource_id: @provenance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Provenance/#{@provenance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Provenance',
+        resource_id: @provenance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Provenance/#{@provenance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Provenance resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Provenance' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Provenance',
+        resource_id: @provenance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Provenance/#{@provenance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Provenance.', exception.message
+    end
+
+    it 'succeeds when a Provenance resource is read successfully' do
+      provenance = FHIR::Provenance.new(
+        id: @provenance_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Provenance',
+        resource_id: @provenance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Provenance/#{@provenance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: provenance.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Observation read test' do
     before do
       @observation_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -11,9 +11,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token)
+    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = '123'
     @instance.patient_id = @patient_id
+    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -25,6 +26,15 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @query = {
         'patient': @instance.patient_id
       }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -51,6 +61,97 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
       assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'resource read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
     end
   end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -64,7 +64,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
   end
 
-  describe 'resource read test' do
+  describe 'Observation read test' do
     before do
       @observation_id = '456'
       @test = @sequence_class[:read_interaction]

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -42,8 +42,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:AllergyIntolerance, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -72,10 +75,10 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @allergyintolerance = reply&.resource&.entry&.first&.resource
-        @allergyintolerance_ary = fetch_all_bundled_resources(reply&.resource)
+        @allergy_intolerance = reply&.resource&.entry&.first&.resource
+        @allergy_intolerance_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
-        save_delayed_sequence_references(@allergyintolerance_ary)
+        save_delayed_sequence_references(@allergy_intolerance_ary)
         validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)
       end
 
@@ -90,7 +93,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@allergyintolerance.nil?, 'Expected valid AllergyIntolerance resource to be present'
+        assert !@allergy_intolerance.nil?, 'Expected valid AllergyIntolerance resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -103,9 +106,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'AllergyIntolerance read resource supported' do
+      test :read_interaction do
         metadata do
           id '04'
+          name 'AllergyIntolerance read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -113,14 +117,15 @@ module Inferno
         end
 
         skip_if_not_supported(:AllergyIntolerance, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@allergyintolerance, versioned_resource_class('AllergyIntolerance'))
+        validate_read_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'))
       end
 
-      test 'AllergyIntolerance vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '05'
+          name 'AllergyIntolerance vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -128,14 +133,15 @@ module Inferno
         end
 
         skip_if_not_supported(:AllergyIntolerance, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_vread_reply(@allergyintolerance, versioned_resource_class('AllergyIntolerance'))
+        validate_vread_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'))
       end
 
-      test 'AllergyIntolerance history resource supported' do
+      test :history_interaction do
         metadata do
           id '06'
+          name 'AllergyIntolerance history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -143,9 +149,9 @@ module Inferno
         end
 
         skip_if_not_supported(:AllergyIntolerance, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_history_reply(@allergyintolerance, versioned_resource_class('AllergyIntolerance'))
+        validate_history_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'))
       end
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
@@ -191,7 +197,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @allergyintolerance_ary&.any?
+        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @allergy_intolerance_ary&.any?
         must_support_confirmed = {}
         must_support_elements = [
           'AllergyIntolerance.clinicalStatus',
@@ -200,12 +206,12 @@ module Inferno
           'AllergyIntolerance.patient'
         ]
         must_support_elements.each do |path|
-          @allergyintolerance_ary&.each do |resource|
+          @allergy_intolerance_ary&.each do |resource|
             truncated_path = path.gsub('AllergyIntolerance.', '')
             must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
             break if must_support_confirmed[path]
           end
-          resource_count = @allergyintolerance_ary.length
+          resource_count = @allergy_intolerance_ary.length
 
           skip "Could not find #{path} in any of the #{resource_count} provided AllergyIntolerance resource(s)" unless must_support_confirmed[path]
         end
@@ -224,7 +230,7 @@ module Inferno
         skip_if_not_supported(:AllergyIntolerance, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_reference_resolutions(@allergyintolerance)
+        validate_reference_resolutions(@allergy_intolerance)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -52,8 +52,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:CarePlan, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -83,10 +86,10 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @careplan = reply&.resource&.entry&.first&.resource
-        @careplan_ary = fetch_all_bundled_resources(reply&.resource)
+        @care_plan = reply&.resource&.entry&.first&.resource
+        @care_plan_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
-        save_delayed_sequence_references(@careplan_ary)
+        save_delayed_sequence_references(@care_plan_ary)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
       end
 
@@ -101,7 +104,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@careplan.nil?, 'Expected valid CarePlan resource to be present'
+        assert !@care_plan.nil?, 'Expected valid CarePlan resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -134,7 +137,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@careplan.nil?, 'Expected valid CarePlan resource to be present'
+        assert !@care_plan.nil?, 'Expected valid CarePlan resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -168,7 +171,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@careplan.nil?, 'Expected valid CarePlan resource to be present'
+        assert !@care_plan.nil?, 'Expected valid CarePlan resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -182,9 +185,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'CarePlan read resource supported' do
+      test :read_interaction do
         metadata do
           id '06'
+          name 'CarePlan read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -192,14 +196,15 @@ module Inferno
         end
 
         skip_if_not_supported(:CarePlan, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@careplan, versioned_resource_class('CarePlan'))
+        validate_read_reply(@care_plan, versioned_resource_class('CarePlan'))
       end
 
-      test 'CarePlan vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '07'
+          name 'CarePlan vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -207,14 +212,15 @@ module Inferno
         end
 
         skip_if_not_supported(:CarePlan, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_vread_reply(@careplan, versioned_resource_class('CarePlan'))
+        validate_vread_reply(@care_plan, versioned_resource_class('CarePlan'))
       end
 
-      test 'CarePlan history resource supported' do
+      test :history_interaction do
         metadata do
           id '08'
+          name 'CarePlan history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -222,9 +228,9 @@ module Inferno
         end
 
         skip_if_not_supported(:CarePlan, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_history_reply(@careplan, versioned_resource_class('CarePlan'))
+        validate_history_reply(@care_plan, versioned_resource_class('CarePlan'))
       end
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
@@ -271,7 +277,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @careplan_ary&.any?
+        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @care_plan_ary&.any?
         must_support_confirmed = {}
         must_support_elements = [
           'CarePlan.text',
@@ -283,12 +289,12 @@ module Inferno
           'CarePlan.subject'
         ]
         must_support_elements.each do |path|
-          @careplan_ary&.each do |resource|
+          @care_plan_ary&.each do |resource|
             truncated_path = path.gsub('CarePlan.', '')
             must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
             break if must_support_confirmed[path]
           end
-          resource_count = @careplan_ary.length
+          resource_count = @care_plan_ary.length
 
           skip "Could not find #{path} in any of the #{resource_count} provided CarePlan resource(s)" unless must_support_confirmed[path]
         end
@@ -307,7 +313,7 @@ module Inferno
         skip_if_not_supported(:CarePlan, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_reference_resolutions(@careplan)
+        validate_reference_resolutions(@care_plan)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -42,8 +42,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:CareTeam, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -73,16 +76,17 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @careteam = reply&.resource&.entry&.first&.resource
-        @careteam_ary = fetch_all_bundled_resources(reply&.resource)
+        @care_team = reply&.resource&.entry&.first&.resource
+        @care_team_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
-        save_delayed_sequence_references(@careteam_ary)
+        save_delayed_sequence_references(@care_team_ary)
         validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)
       end
 
-      test 'CareTeam read resource supported' do
+      test :read_interaction do
         metadata do
           id '03'
+          name 'CareTeam read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -90,14 +94,15 @@ module Inferno
         end
 
         skip_if_not_supported(:CareTeam, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@careteam, versioned_resource_class('CareTeam'))
+        validate_read_reply(@care_team, versioned_resource_class('CareTeam'))
       end
 
-      test 'CareTeam vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '04'
+          name 'CareTeam vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -105,14 +110,15 @@ module Inferno
         end
 
         skip_if_not_supported(:CareTeam, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_vread_reply(@careteam, versioned_resource_class('CareTeam'))
+        validate_vread_reply(@care_team, versioned_resource_class('CareTeam'))
       end
 
-      test 'CareTeam history resource supported' do
+      test :history_interaction do
         metadata do
           id '05'
+          name 'CareTeam history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -120,9 +126,9 @@ module Inferno
         end
 
         skip_if_not_supported(:CareTeam, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_history_reply(@careteam, versioned_resource_class('CareTeam'))
+        validate_history_reply(@care_team, versioned_resource_class('CareTeam'))
       end
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
@@ -169,7 +175,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @careteam_ary&.any?
+        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @care_team_ary&.any?
         must_support_confirmed = {}
         must_support_elements = [
           'CareTeam.status',
@@ -179,12 +185,12 @@ module Inferno
           'CareTeam.participant.member'
         ]
         must_support_elements.each do |path|
-          @careteam_ary&.each do |resource|
+          @care_team_ary&.each do |resource|
             truncated_path = path.gsub('CareTeam.', '')
             must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
             break if must_support_confirmed[path]
           end
-          resource_count = @careteam_ary.length
+          resource_count = @care_team_ary.length
 
           skip "Could not find #{path} in any of the #{resource_count} provided CareTeam resource(s)" unless must_support_confirmed[path]
         end
@@ -203,7 +209,7 @@ module Inferno
         skip_if_not_supported(:CareTeam, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_reference_resolutions(@careteam)
+        validate_reference_resolutions(@care_team)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -56,8 +56,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Condition, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -197,9 +200,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Condition read resource supported' do
+      test :read_interaction do
         metadata do
           id '07'
+          name 'Condition read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -207,14 +211,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Condition, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@condition, versioned_resource_class('Condition'))
       end
 
-      test 'Condition vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '08'
+          name 'Condition vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -222,14 +227,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Condition, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@condition, versioned_resource_class('Condition'))
       end
 
-      test 'Condition history resource supported' do
+      test :history_interaction do
         metadata do
           id '09'
+          name 'Condition history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -237,7 +243,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Condition, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@condition, versioned_resource_class('Condition'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -56,8 +56,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:DiagnosticReport, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -86,10 +89,10 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = fetch_all_bundled_resources(reply&.resource)
+        @diagnostic_report = reply&.resource&.entry&.first&.resource
+        @diagnostic_report_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
-        save_delayed_sequence_references(@diagnosticreport_ary)
+        save_delayed_sequence_references(@diagnostic_report_ary)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
       end
 
@@ -103,7 +106,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -126,7 +129,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -158,7 +161,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -181,7 +184,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -205,7 +208,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -227,9 +230,10 @@ module Inferno
         end
       end
 
-      test 'DiagnosticReport create resource supported' do
+      test :create_interaction do
         metadata do
           id '08'
+          name 'DiagnosticReport create interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -237,14 +241,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DiagnosticReport, [:create])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_create_reply(@diagnosticreport, versioned_resource_class('DiagnosticReport'))
+        validate_create_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
 
-      test 'DiagnosticReport read resource supported' do
+      test :read_interaction do
         metadata do
           id '09'
+          name 'DiagnosticReport read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -252,14 +257,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DiagnosticReport, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@diagnosticreport, versioned_resource_class('DiagnosticReport'))
+        validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
 
-      test 'DiagnosticReport vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '10'
+          name 'DiagnosticReport vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -267,14 +273,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DiagnosticReport, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_vread_reply(@diagnosticreport, versioned_resource_class('DiagnosticReport'))
+        validate_vread_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
 
-      test 'DiagnosticReport history resource supported' do
+      test :history_interaction do
         metadata do
           id '11'
+          name 'DiagnosticReport history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -282,9 +289,9 @@ module Inferno
         end
 
         skip_if_not_supported(:DiagnosticReport, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_history_reply(@diagnosticreport, versioned_resource_class('DiagnosticReport'))
+        validate_history_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
@@ -330,7 +337,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @diagnosticreport_ary&.any?
+        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @diagnostic_report_ary&.any?
         must_support_confirmed = {}
         must_support_elements = [
           'DiagnosticReport.status',
@@ -345,12 +352,12 @@ module Inferno
           'DiagnosticReport.result'
         ]
         must_support_elements.each do |path|
-          @diagnosticreport_ary&.each do |resource|
+          @diagnostic_report_ary&.each do |resource|
             truncated_path = path.gsub('DiagnosticReport.', '')
             must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
             break if must_support_confirmed[path]
           end
-          resource_count = @diagnosticreport_ary.length
+          resource_count = @diagnostic_report_ary.length
 
           skip "Could not find #{path} in any of the #{resource_count} provided DiagnosticReport resource(s)" unless must_support_confirmed[path]
         end
@@ -369,7 +376,7 @@ module Inferno
         skip_if_not_supported(:DiagnosticReport, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_reference_resolutions(@diagnosticreport)
+        validate_reference_resolutions(@diagnostic_report)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -56,8 +56,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:DiagnosticReport, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -86,10 +89,10 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @diagnosticreport = reply&.resource&.entry&.first&.resource
-        @diagnosticreport_ary = fetch_all_bundled_resources(reply&.resource)
+        @diagnostic_report = reply&.resource&.entry&.first&.resource
+        @diagnostic_report_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
-        save_delayed_sequence_references(@diagnosticreport_ary)
+        save_delayed_sequence_references(@diagnostic_report_ary)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
       end
 
@@ -103,7 +106,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -126,7 +129,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -158,7 +161,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -181,7 +184,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -205,7 +208,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@diagnosticreport.nil?, 'Expected valid DiagnosticReport resource to be present'
+        assert !@diagnostic_report.nil?, 'Expected valid DiagnosticReport resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -227,9 +230,10 @@ module Inferno
         end
       end
 
-      test 'DiagnosticReport create resource supported' do
+      test :create_interaction do
         metadata do
           id '08'
+          name 'DiagnosticReport create interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -237,14 +241,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DiagnosticReport, [:create])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_create_reply(@diagnosticreport, versioned_resource_class('DiagnosticReport'))
+        validate_create_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
 
-      test 'DiagnosticReport read resource supported' do
+      test :read_interaction do
         metadata do
           id '09'
+          name 'DiagnosticReport read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -252,14 +257,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DiagnosticReport, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@diagnosticreport, versioned_resource_class('DiagnosticReport'))
+        validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
 
-      test 'DiagnosticReport vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '10'
+          name 'DiagnosticReport vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -267,14 +273,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DiagnosticReport, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_vread_reply(@diagnosticreport, versioned_resource_class('DiagnosticReport'))
+        validate_vread_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
 
-      test 'DiagnosticReport history resource supported' do
+      test :history_interaction do
         metadata do
           id '11'
+          name 'DiagnosticReport history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -282,9 +289,9 @@ module Inferno
         end
 
         skip_if_not_supported(:DiagnosticReport, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_history_reply(@diagnosticreport, versioned_resource_class('DiagnosticReport'))
+        validate_history_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
@@ -330,7 +337,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @diagnosticreport_ary&.any?
+        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @diagnostic_report_ary&.any?
         must_support_confirmed = {}
         must_support_elements = [
           'DiagnosticReport.status',
@@ -345,12 +352,12 @@ module Inferno
           'DiagnosticReport.presentedForm'
         ]
         must_support_elements.each do |path|
-          @diagnosticreport_ary&.each do |resource|
+          @diagnostic_report_ary&.each do |resource|
             truncated_path = path.gsub('DiagnosticReport.', '')
             must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
             break if must_support_confirmed[path]
           end
-          resource_count = @diagnosticreport_ary.length
+          resource_count = @diagnostic_report_ary.length
 
           skip "Could not find #{path} in any of the #{resource_count} provided DiagnosticReport resource(s)" unless must_support_confirmed[path]
         end
@@ -369,7 +376,7 @@ module Inferno
         skip_if_not_supported(:DiagnosticReport, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_reference_resolutions(@diagnosticreport)
+        validate_reference_resolutions(@diagnostic_report)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -64,8 +64,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:DocumentReference, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -94,10 +97,10 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @documentreference = reply&.resource&.entry&.first&.resource
-        @documentreference_ary = fetch_all_bundled_resources(reply&.resource)
+        @document_reference = reply&.resource&.entry&.first&.resource
+        @document_reference_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
-        save_delayed_sequence_references(@documentreference_ary)
+        save_delayed_sequence_references(@document_reference_ary)
         validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
       end
 
@@ -111,7 +114,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@documentreference.nil?, 'Expected valid DocumentReference resource to be present'
+        assert !@document_reference.nil?, 'Expected valid DocumentReference resource to be present'
 
         search_params = {
           '_id': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'id'))
@@ -133,7 +136,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@documentreference.nil?, 'Expected valid DocumentReference resource to be present'
+        assert !@document_reference.nil?, 'Expected valid DocumentReference resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -156,7 +159,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@documentreference.nil?, 'Expected valid DocumentReference resource to be present'
+        assert !@document_reference.nil?, 'Expected valid DocumentReference resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -180,7 +183,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@documentreference.nil?, 'Expected valid DocumentReference resource to be present'
+        assert !@document_reference.nil?, 'Expected valid DocumentReference resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -204,7 +207,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@documentreference.nil?, 'Expected valid DocumentReference resource to be present'
+        assert !@document_reference.nil?, 'Expected valid DocumentReference resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -237,7 +240,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@documentreference.nil?, 'Expected valid DocumentReference resource to be present'
+        assert !@document_reference.nil?, 'Expected valid DocumentReference resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -250,9 +253,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'DocumentReference create resource supported' do
+      test :create_interaction do
         metadata do
           id '09'
+          name 'DocumentReference create interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -260,14 +264,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DocumentReference, [:create])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_create_reply(@documentreference, versioned_resource_class('DocumentReference'))
+        validate_create_reply(@document_reference, versioned_resource_class('DocumentReference'))
       end
 
-      test 'DocumentReference read resource supported' do
+      test :read_interaction do
         metadata do
           id '10'
+          name 'DocumentReference read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -275,14 +280,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DocumentReference, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@documentreference, versioned_resource_class('DocumentReference'))
+        validate_read_reply(@document_reference, versioned_resource_class('DocumentReference'))
       end
 
-      test 'DocumentReference vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '11'
+          name 'DocumentReference vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -290,14 +296,15 @@ module Inferno
         end
 
         skip_if_not_supported(:DocumentReference, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_vread_reply(@documentreference, versioned_resource_class('DocumentReference'))
+        validate_vread_reply(@document_reference, versioned_resource_class('DocumentReference'))
       end
 
-      test 'DocumentReference history resource supported' do
+      test :history_interaction do
         metadata do
           id '12'
+          name 'DocumentReference history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -305,9 +312,9 @@ module Inferno
         end
 
         skip_if_not_supported(:DocumentReference, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_history_reply(@documentreference, versioned_resource_class('DocumentReference'))
+        validate_history_reply(@document_reference, versioned_resource_class('DocumentReference'))
       end
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
@@ -353,7 +360,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @documentreference_ary&.any?
+        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @document_reference_ary&.any?
         must_support_confirmed = {}
         must_support_elements = [
           'DocumentReference.identifier',
@@ -375,12 +382,12 @@ module Inferno
           'DocumentReference.context.period'
         ]
         must_support_elements.each do |path|
-          @documentreference_ary&.each do |resource|
+          @document_reference_ary&.each do |resource|
             truncated_path = path.gsub('DocumentReference.', '')
             must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
             break if must_support_confirmed[path]
           end
-          resource_count = @documentreference_ary.length
+          resource_count = @document_reference_ary.length
 
           skip "Could not find #{path} in any of the #{resource_count} provided DocumentReference resource(s)" unless must_support_confirmed[path]
         end
@@ -399,7 +406,7 @@ module Inferno
         skip_if_not_supported(:DocumentReference, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_reference_resolutions(@documentreference)
+        validate_reference_resolutions(@document_reference)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -64,8 +64,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Encounter, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Encounter'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -249,9 +252,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Encounter read resource supported' do
+      test :read_interaction do
         metadata do
           id '09'
+          name 'Encounter read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -259,14 +263,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Encounter, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@encounter, versioned_resource_class('Encounter'))
       end
 
-      test 'Encounter vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '10'
+          name 'Encounter vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -274,14 +279,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Encounter, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@encounter, versioned_resource_class('Encounter'))
       end
 
-      test 'Encounter history resource supported' do
+      test :history_interaction do
         metadata do
           id '11'
+          name 'Encounter history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -289,7 +295,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Encounter, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@encounter, versioned_resource_class('Encounter'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -48,8 +48,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Goal, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -141,9 +144,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Goal read resource supported' do
+      test :read_interaction do
         metadata do
           id '05'
+          name 'Goal read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -151,14 +155,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Goal, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@goal, versioned_resource_class('Goal'))
       end
 
-      test 'Goal vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '06'
+          name 'Goal vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -166,14 +171,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Goal, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@goal, versioned_resource_class('Goal'))
       end
 
-      test 'Goal history resource supported' do
+      test :history_interaction do
         metadata do
           id '07'
+          name 'Goal history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -181,7 +187,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Goal, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@goal, versioned_resource_class('Goal'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -48,8 +48,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Immunization, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -141,9 +144,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Immunization read resource supported' do
+      test :read_interaction do
         metadata do
           id '05'
+          name 'Immunization read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -151,14 +155,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Immunization, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@immunization, versioned_resource_class('Immunization'))
       end
 
-      test 'Immunization vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '06'
+          name 'Immunization vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -166,14 +171,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Immunization, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@immunization, versioned_resource_class('Immunization'))
       end
 
-      test 'Immunization history resource supported' do
+      test :history_interaction do
         metadata do
           id '07'
+          name 'Immunization history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -181,7 +187,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Immunization, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@immunization, versioned_resource_class('Immunization'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -42,8 +42,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Device, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -103,9 +106,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Device read resource supported' do
+      test :read_interaction do
         metadata do
           id '04'
+          name 'Device read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -113,14 +117,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Device, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Device resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@device, versioned_resource_class('Device'))
       end
 
-      test 'Device vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '05'
+          name 'Device vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -128,14 +133,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Device, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Device resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@device, versioned_resource_class('Device'))
       end
 
-      test 'Device history resource supported' do
+      test :history_interaction do
         metadata do
           id '06'
+          name 'Device history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -143,7 +149,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Device, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Device resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@device, versioned_resource_class('Device'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -51,9 +51,10 @@ module Inferno
 
       @resources_found = false
 
-      test 'Can read Location from the server' do
+      test :resource_read do
         metadata do
           id '01'
+          name 'Can read Location from the server'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )

--- a/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
@@ -29,16 +29,23 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Medication, [:read])
+
         medication_id = @instance.resource_references.find { |reference| reference.resource_type == 'Medication' }&.resource_id
         skip 'No Medication references found from the prior searches' if medication_id.nil?
-        @medication = fetch_resource('Medication', medication_id)
-        @medication_ary = Array.wrap(@medication)
-        @resources_found = !@medication.nil?
+
+        @medication = validate_read_reply(
+          FHIR::Medication.new(id: medication_id),
+          FHIR::Medication
+        )
+        @medication_ary = Array.wrap(@medication).compact
+        @resources_found = @medication.present?
       end
 
-      test 'Medication vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '02'
+          name 'Medication vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -46,14 +53,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Medication, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Medication resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@medication, versioned_resource_class('Medication'))
       end
 
-      test 'Medication history resource supported' do
+      test :history_interaction do
         metadata do
           id '03'
+          name 'Medication history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -61,7 +69,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Medication, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Medication resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@medication, versioned_resource_class('Medication'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
@@ -19,9 +19,10 @@ module Inferno
 
       @resources_found = false
 
-      test 'Can read Medication from the server' do
+      test :resource_read do
         metadata do
           id '01'
+          name 'Can read Medication from the server'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -54,8 +54,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:MedicationRequest, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -82,11 +85,11 @@ module Inferno
           @resources_found = true if resource_count.positive?
           next unless @resources_found
 
-          @medicationrequest = reply&.resource&.entry&.first&.resource
-          @medicationrequest_ary = fetch_all_bundled_resources(reply&.resource)
+          @medication_request = reply&.resource&.entry&.first&.resource
+          @medication_request_ary = fetch_all_bundled_resources(reply&.resource)
 
           save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
-          save_delayed_sequence_references(@medicationrequest_ary)
+          save_delayed_sequence_references(@medication_request_ary)
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
           break
         end
@@ -103,7 +106,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@medicationrequest.nil?, 'Expected valid MedicationRequest resource to be present'
+        assert !@medication_request.nil?, 'Expected valid MedicationRequest resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -128,7 +131,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@medicationrequest.nil?, 'Expected valid MedicationRequest resource to be present'
+        assert !@medication_request.nil?, 'Expected valid MedicationRequest resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -153,7 +156,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@medicationrequest.nil?, 'Expected valid MedicationRequest resource to be present'
+        assert !@medication_request.nil?, 'Expected valid MedicationRequest resource to be present'
 
         search_params = {
           'patient': @instance.patient_id,
@@ -167,9 +170,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'MedicationRequest read resource supported' do
+      test :read_interaction do
         metadata do
           id '06'
+          name 'MedicationRequest read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -177,14 +181,15 @@ module Inferno
         end
 
         skip_if_not_supported(:MedicationRequest, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@medicationrequest, versioned_resource_class('MedicationRequest'))
+        validate_read_reply(@medication_request, versioned_resource_class('MedicationRequest'))
       end
 
-      test 'MedicationRequest vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '07'
+          name 'MedicationRequest vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -192,14 +197,15 @@ module Inferno
         end
 
         skip_if_not_supported(:MedicationRequest, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_vread_reply(@medicationrequest, versioned_resource_class('MedicationRequest'))
+        validate_vread_reply(@medication_request, versioned_resource_class('MedicationRequest'))
       end
 
-      test 'MedicationRequest history resource supported' do
+      test :history_interaction do
         metadata do
           id '08'
+          name 'MedicationRequest history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -207,9 +213,9 @@ module Inferno
         end
 
         skip_if_not_supported(:MedicationRequest, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_history_reply(@medicationrequest, versioned_resource_class('MedicationRequest'))
+        validate_history_reply(@medication_request, versioned_resource_class('MedicationRequest'))
       end
 
       test 'Server returns the appropriate resource from the following _includes: MedicationRequest:medication' do
@@ -280,7 +286,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @medicationrequest_ary&.any?
+        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @medication_request_ary&.any?
         must_support_confirmed = {}
         must_support_elements = [
           'MedicationRequest.status',
@@ -297,12 +303,12 @@ module Inferno
           'MedicationRequest.dosageInstruction.text'
         ]
         must_support_elements.each do |path|
-          @medicationrequest_ary&.each do |resource|
+          @medication_request_ary&.each do |resource|
             truncated_path = path.gsub('MedicationRequest.', '')
             must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
             break if must_support_confirmed[path]
           end
-          resource_count = @medicationrequest_ary.length
+          resource_count = @medication_request_ary.length
 
           skip "Could not find #{path} in any of the #{resource_count} provided MedicationRequest resource(s)" unless must_support_confirmed[path]
         end
@@ -321,7 +327,7 @@ module Inferno
         skip_if_not_supported(:MedicationRequest, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_reference_resolutions(@medicationrequest)
+        validate_reference_resolutions(@medication_request)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -56,8 +56,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Observation, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -207,9 +210,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Observation read resource supported' do
+      test :read_interaction do
         metadata do
           id '07'
+          name 'Observation read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -217,14 +221,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '08'
+          name 'Observation vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -232,14 +237,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation history resource supported' do
+      test :history_interaction do
         metadata do
           id '09'
+          name 'Observation history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -247,7 +253,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -39,9 +39,10 @@ module Inferno
 
       @resources_found = false
 
-      test 'Can read Organization from the server' do
+      test :resource_read do
         metadata do
           id '01'
+          name 'Can read Organization from the server'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -71,8 +71,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Patient, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -246,9 +249,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Patient read resource supported' do
+      test :read_interaction do
         metadata do
           id '09'
+          name 'Patient read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -256,14 +260,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Patient, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@patient, versioned_resource_class('Patient'))
       end
 
-      test 'Patient vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '10'
+          name 'Patient vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -271,14 +276,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Patient, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@patient, versioned_resource_class('Patient'))
       end
 
-      test 'Patient history resource supported' do
+      test :history_interaction do
         metadata do
           id '11'
+          name 'Patient history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -286,7 +292,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Patient, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@patient, versioned_resource_class('Patient'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -40,9 +40,10 @@ module Inferno
 
       @resources_found = false
 
-      test 'Can read Practitioner from the server' do
+      test :resource_read do
         metadata do
           id '01'
+          name 'Can read Practitioner from the server'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -33,9 +33,10 @@ module Inferno
 
       @resources_found = false
 
-      test 'Can read PractitionerRole from the server' do
+      test :resource_read do
         metadata do
           id '01'
+          name 'Can read PractitionerRole from the server'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -43,11 +43,17 @@ module Inferno
           versions :r4
         end
 
-        practitionerrole_id = @instance.resource_references.find { |reference| reference.resource_type == 'PractitionerRole' }&.resource_id
-        skip 'No PractitionerRole references found from the prior searches' if practitionerrole_id.nil?
-        @practitionerrole = fetch_resource('PractitionerRole', practitionerrole_id)
-        @practitionerrole_ary = Array.wrap(@practitionerrole)
-        @resources_found = !@practitionerrole.nil?
+        skip_if_not_supported(:PractitionerRole, [:read])
+
+        practitioner_role_id = @instance.resource_references.find { |reference| reference.resource_type == 'PractitionerRole' }&.resource_id
+        skip 'No PractitionerRole references found from the prior searches' if practitioner_role_id.nil?
+
+        @practitioner_role = validate_read_reply(
+          FHIR::PractitionerRole.new(id: practitioner_role_id),
+          FHIR::PractitionerRole
+        )
+        @practitioner_role_ary = Array.wrap(@practitioner_role).compact
+        @resources_found = @practitioner_role.present?
       end
 
       test :unauthorized_search do
@@ -60,8 +66,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:PractitionerRole, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -91,10 +100,10 @@ module Inferno
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        @practitionerrole = reply&.resource&.entry&.first&.resource
-        @practitionerrole_ary = fetch_all_bundled_resources(reply&.resource)
+        @practitioner_role = reply&.resource&.entry&.first&.resource
+        @practitioner_role_ary = fetch_all_bundled_resources(reply&.resource)
         save_resource_ids_in_bundle(versioned_resource_class('PractitionerRole'), reply)
-        save_delayed_sequence_references(@practitionerrole_ary)
+        save_delayed_sequence_references(@practitioner_role_ary)
         validate_search_reply(versioned_resource_class('PractitionerRole'), reply, search_params)
       end
 
@@ -108,7 +117,7 @@ module Inferno
         end
 
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
-        assert !@practitionerrole.nil?, 'Expected valid PractitionerRole resource to be present'
+        assert !@practitioner_role.nil?, 'Expected valid PractitionerRole resource to be present'
 
         search_params = {
           'practitioner': get_value_for_search_param(resolve_element_from_path(@practitionerrole_ary, 'practitioner'))
@@ -120,9 +129,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'PractitionerRole vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '05'
+          name 'PractitionerRole vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -130,14 +140,15 @@ module Inferno
         end
 
         skip_if_not_supported(:PractitionerRole, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No PractitionerRole resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_vread_reply(@practitionerrole, versioned_resource_class('PractitionerRole'))
+        validate_vread_reply(@practitioner_role, versioned_resource_class('PractitionerRole'))
       end
 
-      test 'PractitionerRole history resource supported' do
+      test :history_interaction do
         metadata do
           id '06'
+          name 'PractitionerRole history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -145,9 +156,9 @@ module Inferno
         end
 
         skip_if_not_supported(:PractitionerRole, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No PractitionerRole resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_history_reply(@practitionerrole, versioned_resource_class('PractitionerRole'))
+        validate_history_reply(@practitioner_role, versioned_resource_class('PractitionerRole'))
       end
 
       test 'Server returns the appropriate resource from the following _includes: PractitionerRole:endpoint, PractitionerRole:practitioner' do
@@ -223,7 +234,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @practitionerrole_ary&.any?
+        skip 'No resources appear to be available for this patient. Please use patients with more information' unless @practitioner_role_ary&.any?
         must_support_confirmed = {}
         must_support_elements = [
           'PractitionerRole.practitioner',
@@ -237,12 +248,12 @@ module Inferno
           'PractitionerRole.endpoint'
         ]
         must_support_elements.each do |path|
-          @practitionerrole_ary&.each do |resource|
+          @practitioner_role_ary&.each do |resource|
             truncated_path = path.gsub('PractitionerRole.', '')
             must_support_confirmed[path] = true if can_resolve_path(resource, truncated_path)
             break if must_support_confirmed[path]
           end
-          resource_count = @practitionerrole_ary.length
+          resource_count = @practitioner_role_ary.length
 
           skip "Could not find #{path} in any of the #{resource_count} provided PractitionerRole resource(s)" unless must_support_confirmed[path]
         end
@@ -261,7 +272,7 @@ module Inferno
         skip_if_not_supported(:PractitionerRole, [:search, :read])
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_reference_resolutions(@practitionerrole)
+        validate_reference_resolutions(@practitioner_role)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -52,8 +52,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Procedure, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -177,9 +180,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Procedure read resource supported' do
+      test :read_interaction do
         metadata do
           id '06'
+          name 'Procedure read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -187,14 +191,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Procedure, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@procedure, versioned_resource_class('Procedure'))
       end
 
-      test 'Procedure vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '07'
+          name 'Procedure vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -202,14 +207,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Procedure, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@procedure, versioned_resource_class('Procedure'))
       end
 
-      test 'Procedure history resource supported' do
+      test :history_interaction do
         metadata do
           id '08'
+          name 'Procedure history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -217,7 +223,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Procedure, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@procedure, versioned_resource_class('Procedure'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -29,16 +29,23 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Provenance, [:read])
+
         provenance_id = @instance.resource_references.find { |reference| reference.resource_type == 'Provenance' }&.resource_id
         skip 'No Provenance references found from the prior searches' if provenance_id.nil?
-        @provenance = fetch_resource('Provenance', provenance_id)
-        @provenance_ary = Array.wrap(@provenance)
-        @resources_found = !@provenance.nil?
+
+        @provenance = validate_read_reply(
+          FHIR::Provenance.new(id: provenance_id),
+          FHIR::Provenance
+        )
+        @provenance_ary = Array.wrap(@provenance).compact
+        @resources_found = @provenance.present?
       end
 
-      test 'Provenance vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '02'
+          name 'Provenance vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -46,14 +53,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Provenance, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Provenance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@provenance, versioned_resource_class('Provenance'))
       end
 
-      test 'Provenance history resource supported' do
+      test :history_interaction do
         metadata do
           id '03'
+          name 'Provenance history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -61,7 +69,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Provenance, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Provenance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@provenance, versioned_resource_class('Provenance'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -19,9 +19,10 @@ module Inferno
 
       @resources_found = false
 
-      test 'Can read Provenance from the server' do
+      test :resource_read do
         metadata do
           id '01'
+          name 'Can read Provenance from the server'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -56,8 +56,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Observation, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -207,9 +210,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Observation read resource supported' do
+      test :read_interaction do
         metadata do
           id '07'
+          name 'Observation read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -217,14 +221,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '08'
+          name 'Observation vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -232,14 +237,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation history resource supported' do
+      test :history_interaction do
         metadata do
           id '09'
+          name 'Observation history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -247,7 +253,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -56,8 +56,11 @@ module Inferno
           versions :r4
         end
 
+        skip_if_not_supported(:Observation, [:search])
+
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
+
         search_params = { patient: @instance.patient_id }
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         @client.set_bearer_token(@instance.token)
@@ -207,9 +210,10 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test 'Observation read resource supported' do
+      test :read_interaction do
         metadata do
           id '07'
+          name 'Observation read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -217,14 +221,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:read])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation vread resource supported' do
+      test :vread_interaction do
         metadata do
           id '08'
+          name 'Observation vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -232,14 +237,15 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:vread])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
 
-      test 'Observation history resource supported' do
+      test :history_interaction do
         metadata do
           id '09'
+          name 'Observation history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
           )
@@ -247,7 +253,7 @@ module Inferno
         end
 
         skip_if_not_supported(:Observation, [:history])
-        skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
+        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end


### PR DESCRIPTION
This PR adds unit test generation for the generated US Core read tests. There are two types of read tests performed in the US Core sequences:
- For resources with no patient-based search, there is an initial read test which depends on a reference to one of these resources having been found in a previous sequence
- For resources with a patient-based search, there is a read test performed as part of the tests for required interactions
There are some minor differences in the unit tests generated for these two types of read tests because each expects to find the id to read in a different place.

While working on this branch, I also noticed that the authorization tests were being performed for every resource regardless of whether the server supported that resource. This PR also adds checks to the authorization tests so that they are only performed for resources supported by the server, and skipped for unsupported resources.

The unit test generator code is still fairly rough, and I am planning on doing some cleanup with the next set of unit tests.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-487
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
