### PR TITLE
FI-503: Make resource instance variable names consistent

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -177,7 +177,7 @@ module Inferno
         include_test[:test_code] = search_params
         sequence[:include_params].each do |include|
           resource_name = include.split(':').last.capitalize
-          resource_variable = "#{resource_name.downcase}_results" # kind of a hack, but works for now - would have to otherwise figure out resource type of target profile
+          resource_variable = "#{resource_name.underscore}_results" # kind of a hack, but works for now - would have to otherwise figure out resource type of target profile
           include_test[:test_code] += %(
                 search_params['_include'] = '#{include}'
                 reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
@@ -201,7 +201,7 @@ module Inferno
         revinclude_test[:test_code] = search_params
         sequence[:revincludes].each do |revinclude|
           resource_name = revinclude.split(':').first
-          resource_variable = "#{resource_name.downcase}_results"
+          resource_variable = "#{resource_name.underscore}_results"
           revinclude_test[:test_code] += %(
                 search_params['_revinclude'] = '#{revinclude}'
                 reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
@@ -360,7 +360,7 @@ module Inferno
       def resolve_element_path(search_param_description)
         element_path = search_param_description[:path].gsub('.class', '.local_class') # match fhir_models because class is protected keyword in ruby
         path_parts = element_path.split('.')
-        resource_val = "@#{path_parts.shift.downcase}_ary"
+        resource_val = "@#{path_parts.shift.underscore}_ary"
         "get_value_for_search_param(resolve_element_from_path(#{resource_val}, '#{path_parts.join('.')}'))"
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -97,7 +97,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'clinical-status': get_value_for_search_param(resolve_element_from_path(@allergyintolerance_ary, 'clinicalStatus'))
+          'clinical-status': get_value_for_search_param(resolve_element_from_path(@allergy_intolerance_ary, 'clinicalStatus'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -108,8 +108,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'period'))
+          'category': get_value_for_search_param(resolve_element_from_path(@care_plan_ary, 'category')),
+          'date': get_value_for_search_param(resolve_element_from_path(@care_plan_ary, 'period'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -141,9 +141,9 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'category')),
-          'status': get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'status')),
-          'date': get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'period'))
+          'category': get_value_for_search_param(resolve_element_from_path(@care_plan_ary, 'category')),
+          'status': get_value_for_search_param(resolve_element_from_path(@care_plan_ary, 'status')),
+          'date': get_value_for_search_param(resolve_element_from_path(@care_plan_ary, 'period'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -175,8 +175,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'category')),
-          'status': get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'status'))
+          'category': get_value_for_search_param(resolve_element_from_path(@care_plan_ary, 'category')),
+          'status': get_value_for_search_param(resolve_element_from_path(@care_plan_ary, 'status'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -110,7 +110,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'code': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'code'))
+          'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'code'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -133,8 +133,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'effectiveDateTime'))
+          'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'category')),
+          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -188,7 +188,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'status': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'status'))
+          'status': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'status'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -212,8 +212,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'code': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'effectiveDateTime'))
+          'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'code')),
+          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -110,7 +110,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'code': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'code'))
+          'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'code'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -133,8 +133,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'effectiveDateTime'))
+          'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'category')),
+          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -188,7 +188,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'status': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'status'))
+          'status': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'status'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -212,8 +212,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'code': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@diagnosticreport_ary, 'effectiveDateTime'))
+          'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'code')),
+          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -117,7 +117,7 @@ module Inferno
         assert !@document_reference.nil?, 'Expected valid DocumentReference resource to be present'
 
         search_params = {
-          '_id': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'id'))
+          '_id': get_value_for_search_param(resolve_element_from_path(@document_reference_ary, 'id'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -140,7 +140,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'type': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'type'))
+          'type': get_value_for_search_param(resolve_element_from_path(@document_reference_ary, 'type'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -163,8 +163,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'date'))
+          'category': get_value_for_search_param(resolve_element_from_path(@document_reference_ary, 'category')),
+          'date': get_value_for_search_param(resolve_element_from_path(@document_reference_ary, 'date'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -187,7 +187,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'category': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'category'))
+          'category': get_value_for_search_param(resolve_element_from_path(@document_reference_ary, 'category'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -211,8 +211,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'type': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'type')),
-          'period': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'context.period'))
+          'type': get_value_for_search_param(resolve_element_from_path(@document_reference_ary, 'type')),
+          'period': get_value_for_search_param(resolve_element_from_path(@document_reference_ary, 'context.period'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -244,7 +244,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'status': get_value_for_search_param(resolve_element_from_path(@documentreference_ary, 'status'))
+          'status': get_value_for_search_param(resolve_element_from_path(@document_reference_ary, 'status'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -110,8 +110,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'intent': get_value_for_search_param(resolve_element_from_path(@medicationrequest_ary, 'intent')),
-          'status': get_value_for_search_param(resolve_element_from_path(@medicationrequest_ary, 'status'))
+          'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary, 'intent')),
+          'status': get_value_for_search_param(resolve_element_from_path(@medication_request_ary, 'status'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -135,8 +135,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'intent': get_value_for_search_param(resolve_element_from_path(@medicationrequest_ary, 'intent')),
-          'encounter': get_value_for_search_param(resolve_element_from_path(@medicationrequest_ary, 'encounter'))
+          'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary, 'intent')),
+          'encounter': get_value_for_search_param(resolve_element_from_path(@medication_request_ary, 'encounter'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -160,8 +160,8 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'intent': get_value_for_search_param(resolve_element_from_path(@medicationrequest_ary, 'intent')),
-          'authoredon': get_value_for_search_param(resolve_element_from_path(@medicationrequest_ary, 'authoredOn'))
+          'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary, 'intent')),
+          'authoredon': get_value_for_search_param(resolve_element_from_path(@medication_request_ary, 'authoredOn'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -229,7 +229,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'intent': get_value_for_search_param(resolve_element_from_path(@medicationrequest_ary, 'intent'))
+          'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary, 'intent'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -252,7 +252,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'intent': get_value_for_search_param(resolve_element_from_path(@medicationrequest_ary, 'intent'))
+          'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary, 'intent'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -87,7 +87,7 @@ module Inferno
         end
 
         search_params = {
-          'specialty': get_value_for_search_param(resolve_element_from_path(@practitionerrole_ary, 'specialty'))
+          'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -120,7 +120,7 @@ module Inferno
         assert !@practitioner_role.nil?, 'Expected valid PractitionerRole resource to be present'
 
         search_params = {
-          'practitioner': get_value_for_search_param(resolve_element_from_path(@practitionerrole_ary, 'practitioner'))
+          'practitioner': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'practitioner'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -171,7 +171,7 @@ module Inferno
         end
 
         search_params = {
-          'specialty': get_value_for_search_param(resolve_element_from_path(@practitionerrole_ary, 'specialty'))
+          'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -200,7 +200,7 @@ module Inferno
         end
 
         search_params = {
-          'specialty': get_value_for_search_param(resolve_element_from_path(@practitionerrole_ary, 'specialty'))
+          'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 


### PR DESCRIPTION
Resource instance variable names in the US Core sequences were updated recently from `@resourcename` to `@resource_name`, but I missed one spot in the generator. This PR makes all of the names consistent.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-503
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name: @okeefm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
