### PR TITLE
FI-445 Removing create tests

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -241,6 +241,8 @@ module Inferno
       end
 
       def create_interaction_test(sequence, interaction)
+        return if interaction[:code] == 'create'
+
         test_key = :"#{interaction[:code]}_interaction"
         interaction_test = {
           tests_that: "#{sequence[:resource]} #{interaction[:code]} interaction supported",

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -230,25 +230,9 @@ module Inferno
         end
       end
 
-      test :create_interaction do
-        metadata do
-          id '08'
-          name 'DiagnosticReport create interaction supported'
-          link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
-          description %(
-          )
-          versions :r4
-        end
-
-        skip_if_not_supported(:DiagnosticReport, [:create])
-        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
-
-        validate_create_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
-      end
-
       test :read_interaction do
         metadata do
-          id '09'
+          id '08'
           name 'DiagnosticReport read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -264,7 +248,7 @@ module Inferno
 
       test :vread_interaction do
         metadata do
-          id '10'
+          id '09'
           name 'DiagnosticReport vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -280,7 +264,7 @@ module Inferno
 
       test :history_interaction do
         metadata do
-          id '11'
+          id '10'
           name 'DiagnosticReport history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -296,7 +280,7 @@ module Inferno
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
         metadata do
-          id '12'
+          id '11'
           link 'https://www.hl7.org/fhir/search.html#revinclude'
           description %(
           )
@@ -317,7 +301,7 @@ module Inferno
 
       test 'DiagnosticReport resources associated with Patient conform to US Core R4 profiles' do
         metadata do
-          id '13'
+          id '12'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab'
           description %(
           )
@@ -330,7 +314,7 @@ module Inferno
 
       test 'At least one of every must support element is provided in any DiagnosticReport for this patient.' do
         metadata do
-          id '14'
+          id '13'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/general-guidance.html/#must-support'
           description %(
           )
@@ -366,7 +350,7 @@ module Inferno
 
       test 'All references can be resolved' do
         metadata do
-          id '15'
+          id '14'
           link 'https://www.hl7.org/fhir/DSTU2/references.html'
           description %(
           )

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -230,25 +230,9 @@ module Inferno
         end
       end
 
-      test :create_interaction do
-        metadata do
-          id '08'
-          name 'DiagnosticReport create interaction supported'
-          link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
-          description %(
-          )
-          versions :r4
-        end
-
-        skip_if_not_supported(:DiagnosticReport, [:create])
-        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
-
-        validate_create_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
-      end
-
       test :read_interaction do
         metadata do
-          id '09'
+          id '08'
           name 'DiagnosticReport read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -264,7 +248,7 @@ module Inferno
 
       test :vread_interaction do
         metadata do
-          id '10'
+          id '09'
           name 'DiagnosticReport vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -280,7 +264,7 @@ module Inferno
 
       test :history_interaction do
         metadata do
-          id '11'
+          id '10'
           name 'DiagnosticReport history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -296,7 +280,7 @@ module Inferno
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
         metadata do
-          id '12'
+          id '11'
           link 'https://www.hl7.org/fhir/search.html#revinclude'
           description %(
           )
@@ -317,7 +301,7 @@ module Inferno
 
       test 'DiagnosticReport resources associated with Patient conform to US Core R4 profiles' do
         metadata do
-          id '13'
+          id '12'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note'
           description %(
           )
@@ -330,7 +314,7 @@ module Inferno
 
       test 'At least one of every must support element is provided in any DiagnosticReport for this patient.' do
         metadata do
-          id '14'
+          id '13'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/general-guidance.html/#must-support'
           description %(
           )
@@ -366,7 +350,7 @@ module Inferno
 
       test 'All references can be resolved' do
         metadata do
-          id '15'
+          id '14'
           link 'https://www.hl7.org/fhir/DSTU2/references.html'
           description %(
           )

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -253,25 +253,9 @@ module Inferno
         assert_response_ok(reply)
       end
 
-      test :create_interaction do
-        metadata do
-          id '09'
-          name 'DocumentReference create interaction supported'
-          link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
-          description %(
-          )
-          versions :r4
-        end
-
-        skip_if_not_supported(:DocumentReference, [:create])
-        skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
-
-        validate_create_reply(@document_reference, versioned_resource_class('DocumentReference'))
-      end
-
       test :read_interaction do
         metadata do
-          id '10'
+          id '09'
           name 'DocumentReference read interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -287,7 +271,7 @@ module Inferno
 
       test :vread_interaction do
         metadata do
-          id '11'
+          id '10'
           name 'DocumentReference vread interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -303,7 +287,7 @@ module Inferno
 
       test :history_interaction do
         metadata do
-          id '12'
+          id '11'
           name 'DocumentReference history interaction supported'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/CapabilityStatement-us-core-server.html'
           description %(
@@ -319,7 +303,7 @@ module Inferno
 
       test 'Server returns the appropriate resources from the following _revincludes: Provenance:target' do
         metadata do
-          id '13'
+          id '12'
           link 'https://www.hl7.org/fhir/search.html#revinclude'
           description %(
           )
@@ -340,7 +324,7 @@ module Inferno
 
       test 'DocumentReference resources associated with Patient conform to US Core R4 profiles' do
         metadata do
-          id '14'
+          id '13'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'
           description %(
           )
@@ -353,7 +337,7 @@ module Inferno
 
       test 'At least one of every must support element is provided in any DocumentReference for this patient.' do
         metadata do
-          id '15'
+          id '14'
           link 'https://build.fhir.org/ig/HL7/US-Core-R4/general-guidance.html/#must-support'
           description %(
           )
@@ -396,7 +380,7 @@ module Inferno
 
       test 'All references can be resolved' do
         metadata do
-          id '16'
+          id '15'
           link 'https://www.hl7.org/fhir/DSTU2/references.html'
           description %(
           )


### PR DESCRIPTION
Removing CREATE interaction tests because they're not read-only. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-445
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
