### PR TITLE
FI-496 fix metadata errors

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -296,7 +296,7 @@ module Inferno
         metadata[:sequences].each do |sequence|
           sequence[:search_param_descriptions].each do |_param, description|
             param_comparators = description[:comparators]
-            param_comparators[:ge] = param_comparators[:le] if param_comparators.keys.include? :le
+            param_comparators[:ge] = param_comparators[:le] if param_comparators.key? :le
           end
         end
       end

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -37,7 +37,6 @@ module Inferno
         class_name:,
         sequence_name:
       )
-        return if resource_type == 'Procedure' && search_params.key?('date')
 
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'search_unit_test.rb.erb')))
 

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -616,14 +616,7 @@ module Inferno
           path_parts = path_parts.map { |part| part == 'class' ? 'local_class' : part }
           path_parts.shift
           case type
-          when 'Period'
-            search_validators += %(
-                value_found = can_resolve_path(resource, '#{path_parts.join('.')}') do |period|
-                  validate_period_search(value, period)
-                end
-                assert value_found, '#{element} on resource does not match #{element} requested'
-      )
-          when 'date'
+          when 'Period', 'date'
             search_validators += %(
                 value_found = can_resolve_path(resource, '#{path_parts.join('.')}') do |date|
                   validate_date_search(value, date)

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -738,7 +738,7 @@ module Inferno
       def get_value_for_search_param(element)
         case element
         when FHIR::Period
-          element.start || element.end
+          'gt' + element.start || 'lt' + element.end
         when FHIR::Reference
           element.reference
         when FHIR::CodeableConcept

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -738,7 +738,11 @@ module Inferno
       def get_value_for_search_param(element)
         case element
         when FHIR::Period
-          'gt' + element.start || 'lt' + element.end
+          if element.start.present?
+            'gt' + element.start
+          else
+            'lt' + element.end
+          end
         when FHIR::Reference
           element.reference
         when FHIR::CodeableConcept

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -709,7 +709,7 @@ module Inferno
         path_ary = path.split('.')
         el_as_array = Array.wrap(element)
         cur_path_part = path_ary.shift.to_sym
-        return false if el_as_array.none? { |el| el.try(cur_path_part).present? }
+        return false if el_as_array.none? { |el| el.send(cur_path_part).present? }
 
         if block_given?
           el_as_array.any? { |el| can_resolve_path(el.send(cur_path_part), path_ary.join('.')) { |value_found| yield(value_found) } }
@@ -725,7 +725,7 @@ module Inferno
         path_ary = path.split('.')
         cur_path_part = path_ary.shift.to_sym
 
-        found_subset = el_as_array.select { |el| el.try(cur_path_part).present? }
+        found_subset = el_as_array.select { |el| el.send(cur_path_part).present? }
         return nil if found_subset.empty?
 
         found_subset.each do |el|

--- a/lib/app/utils/search_validation.rb
+++ b/lib/app/utils/search_validation.rb
@@ -67,6 +67,14 @@ module Inferno
     end
 
     def validate_date_search(search_value, target_value)
+      if target_value.instance_of? FHIR::Period
+        validate_period_search(search_value, target_value)
+      else
+        validate_datetime_search(search_value, target_value)
+      end
+    end
+
+    def validate_datetime_search(search_value, target_value)
       comparator = search_value[0..1]
       if ['eq', 'ge', 'gt', 'le', 'lt', 'ne', 'sa', 'eb', 'ap'].include? comparator
         search_value = search_value[2..-1]

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -134,7 +134,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
@@ -194,7 +194,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'code': search_params[:code], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -28,7 +28,7 @@ module Inferno
           assert value_found, 'code on resource does not match code requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'effectiveDateTime') do |date|
+          value_found = can_resolve_path(resource, 'effective') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -127,7 +127,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'category': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -187,7 +187,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -117,7 +117,7 @@ module Inferno
 
             A server SHALL support searching by patient+category+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -177,7 +177,7 @@ module Inferno
 
             A server SHOULD support searching by patient+code+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -134,7 +134,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
@@ -194,7 +194,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'code': search_params[:code], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -28,7 +28,7 @@ module Inferno
           assert value_found, 'code on resource does not match code requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'effectiveDateTime') do |date|
+          value_found = can_resolve_path(resource, 'effective') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -127,7 +127,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'category': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -187,7 +187,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -117,7 +117,7 @@ module Inferno
 
             A server SHALL support searching by patient+category+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -177,7 +177,7 @@ module Inferno
 
             A server SHOULD support searching by patient+code+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -179,7 +179,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @query = {
         'patient': @instance.patient_id,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 
@@ -316,7 +316,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @query = {
         'patient': @instance.patient_id,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -179,7 +179,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @query = {
         'patient': @instance.patient_id,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 
@@ -316,7 +316,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @query = {
         'patient': @instance.patient_id,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -314,7 +314,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @query = {
         'patient': @instance.patient_id,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'effective'))
       }
     end
 
@@ -451,7 +451,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @query = {
         'patient': @instance.patient_id,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'effective'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -314,7 +314,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @query = {
         'patient': @instance.patient_id,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'effective'))
       }
     end
 
@@ -451,7 +451,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @query = {
         'patient': @instance.patient_id,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary, 'effective'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -140,7 +140,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
 
       @query = {
         'patient': @instance.patient_id,
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@immunization_ary, 'occurrenceDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@immunization_ary, 'occurrence'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -251,7 +251,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @query = {
         'patient': @instance.patient_id,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 
@@ -316,7 +316,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @query = {
         'patient': @instance.patient_id,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -127,6 +127,135 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
   end
 
+  describe 'Procedure search by patient+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
+      @procedure_ary = [@procedure]
+      @sequence.instance_variable_set(:'@procedure', @procedure)
+      @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': @instance.patient_id,
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary, 'performed'))
+      }
+    end
+
+    it 'skips if no Procedure resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No resources appear to be available for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@procedure_ary', [FHIR::Procedure.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve [\w-]+ in given resource/, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Procedure.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+  end
+
+  describe 'Procedure search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
+      @procedure_ary = [@procedure]
+      @sequence.instance_variable_set(:'@procedure', @procedure)
+      @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': @instance.patient_id,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary, 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary, 'performed'))
+      }
+    end
+
+    it 'skips if no Procedure resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No resources appear to be available for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@procedure_ary', [FHIR::Procedure.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve [\w-]+ in given resource/, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Procedure.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+  end
+
   describe 'Procedure search by patient+status test' do
     before do
       @test = @sequence_class[:search_by_patient_status]

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -179,7 +179,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @query = {
         'patient': @instance.patient_id,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 
@@ -316,7 +316,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @query = {
         'patient': @instance.patient_id,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -179,7 +179,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @query = {
         'patient': @instance.patient_id,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 
@@ -316,7 +316,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @query = {
         'patient': @instance.patient_id,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary, 'effective'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -114,7 +114,7 @@ module Inferno
 
             A server SHOULD support searching by patient+category+date on the CarePlan resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -149,7 +149,7 @@ module Inferno
 
             A server SHOULD support searching by patient+category+status+date on the CarePlan resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -20,8 +20,8 @@ module Inferno
           assert value_found, 'category on resource does not match category requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'period') do |period|
-            validate_period_search(value, period)
+          value_found = can_resolve_path(resource, 'period') do |date|
+            validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
 

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -131,7 +131,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('CarePlan'), comparator_search_params)
@@ -167,7 +167,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
         validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'status': search_params[:status], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('CarePlan'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -157,7 +157,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
         validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:'onset-date'])
           comparator_search_params = { 'patient': search_params[:patient], 'onset-date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Condition'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -141,7 +141,7 @@ module Inferno
 
             A server SHOULD support searching by patient+onset-date on the Condition resource
 
-              including support for these onset-date comparators: gt, lt, le
+              including support for these onset-date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -165,7 +165,7 @@ module Inferno
 
             A server SHALL support searching by patient+category+date on the DiagnosticReport resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -226,7 +226,7 @@ module Inferno
 
             A server SHOULD support searching by patient+code+date on the DiagnosticReport resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -32,7 +32,7 @@ module Inferno
           assert value_found, 'code on resource does not match code requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'effectiveDateTime') do |date|
+          value_found = can_resolve_path(resource, 'effective') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -175,7 +175,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -236,7 +236,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -182,7 +182,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
@@ -243,7 +243,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'code': search_params[:code], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -165,7 +165,7 @@ module Inferno
 
             A server SHALL support searching by patient+category+date on the DiagnosticReport resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -226,7 +226,7 @@ module Inferno
 
             A server SHOULD support searching by patient+code+date on the DiagnosticReport resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -32,7 +32,7 @@ module Inferno
           assert value_found, 'code on resource does not match code requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'effectiveDateTime') do |date|
+          value_found = can_resolve_path(resource, 'effective') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -175,7 +175,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -236,7 +236,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -182,7 +182,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
@@ -243,7 +243,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
         validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'code': search_params[:code], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -241,7 +241,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
         validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:period])
           comparator_search_params = { 'patient': search_params[:patient], 'type': search_params[:type], 'period': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('DocumentReference'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -40,8 +40,8 @@ module Inferno
           assert value_found, 'date on resource does not match date requested'
 
         when 'period'
-          value_found = can_resolve_path(resource, 'context.period') do |period|
-            validate_period_search(value, period)
+          value_found = can_resolve_path(resource, 'context.period') do |date|
+            validate_date_search(value, date)
           end
           assert value_found, 'period on resource does not match period requested'
 

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -171,7 +171,7 @@ module Inferno
 
             A server SHALL support searching by patient+category+date on the DocumentReference resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -224,7 +224,7 @@ module Inferno
 
             A server SHOULD support searching by patient+type+period on the DocumentReference resource
 
-              including support for these period comparators: gt, lt, le
+              including support for these period comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -146,7 +146,7 @@ module Inferno
 
             A server SHALL support searching by date+patient on the Encounter resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -24,8 +24,8 @@ module Inferno
           assert value_found, 'class on resource does not match class requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'period') do |period|
-            validate_period_search(value, period)
+          value_found = can_resolve_path(resource, 'period') do |date|
+            validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
 

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -162,7 +162,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Encounter'), search_params)
         validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'date': comparator_val, 'patient': search_params[:patient] }
           reply = get_resource_by_params(versioned_resource_class('Encounter'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -107,7 +107,7 @@ module Inferno
 
             A server SHOULD support searching by patient+target-date on the Goal resource
 
-              including support for these target-date comparators: gt, lt, le
+              including support for these target-date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -123,7 +123,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
         validate_search_reply(versioned_resource_class('Goal'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:'target-date'])
           comparator_search_params = { 'patient': search_params[:patient], 'target-date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Goal'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -123,7 +123,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
         validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Immunization'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -107,7 +107,7 @@ module Inferno
 
             A server SHOULD support searching by patient+date on the Immunization resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -24,7 +24,7 @@ module Inferno
           assert value_found, 'status on resource does not match status requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'occurrenceDateTime') do |date|
+          value_found = can_resolve_path(resource, 'occurrence') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -116,7 +116,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'date': get_value_for_search_param(resolve_element_from_path(@immunization_ary, 'occurrenceDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@immunization_ary, 'occurrence'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -169,7 +169,7 @@ module Inferno
 
             A server SHOULD support searching by patient+intent+authoredon on the MedicationRequest resource
 
-              including support for these authoredon comparators: gt, lt, le
+              including support for these authoredon comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -159,7 +159,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
@@ -194,7 +194,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'code': search_params[:code], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -28,7 +28,7 @@ module Inferno
           assert value_found, 'code on resource does not match code requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'effectiveDateTime') do |date|
+          value_found = can_resolve_path(resource, 'effective') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -152,7 +152,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'category': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -187,7 +187,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -142,7 +142,7 @@ module Inferno
 
             A server SHALL support searching by patient+category+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -177,7 +177,7 @@ module Inferno
 
             A server SHOULD support searching by patient+code+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -110,7 +110,7 @@ module Inferno
 
             A server SHALL support searching by patient+date on the Procedure resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -144,7 +144,7 @@ module Inferno
 
             A server SHOULD support searching by patient+code+date on the Procedure resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -24,7 +24,7 @@ module Inferno
           assert value_found, 'patient on resource does not match patient requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'occurrenceDateTime') do |date|
+          value_found = can_resolve_path(resource, 'performedDateTime') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -119,14 +119,14 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'occurrenceDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'performedDateTime'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
         validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Procedure'), comparator_search_params)
@@ -154,14 +154,14 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'occurrenceDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'performedDateTime'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
         validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'code': search_params[:code], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Procedure'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -24,7 +24,7 @@ module Inferno
           assert value_found, 'patient on resource does not match patient requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'performedDateTime') do |date|
+          value_found = can_resolve_path(resource, 'performed') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -119,7 +119,7 @@ module Inferno
 
         search_params = {
           'patient': @instance.patient_id,
-          'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'performedDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'performed'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -154,7 +154,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'performedDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary, 'performed'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -134,7 +134,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
@@ -194,7 +194,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'code': search_params[:code], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -28,7 +28,7 @@ module Inferno
           assert value_found, 'code on resource does not match code requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'effectiveDateTime') do |date|
+          value_found = can_resolve_path(resource, 'effective') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -127,7 +127,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'category': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -187,7 +187,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -117,7 +117,7 @@ module Inferno
 
             A server SHALL support searching by patient+category+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -177,7 +177,7 @@ module Inferno
 
             A server SHOULD support searching by patient+code+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -134,7 +134,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'category': search_params[:category], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
@@ -194,7 +194,7 @@ module Inferno
         reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
         validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-        ['gt', 'lt', 'le'].each do |comparator|
+        ['gt', 'lt', 'le', 'ge'].each do |comparator|
           comparator_val = date_comparator_value(comparator, search_params[:date])
           comparator_search_params = { 'patient': search_params[:patient], 'code': search_params[:code], 'date': comparator_val }
           reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -28,7 +28,7 @@ module Inferno
           assert value_found, 'code on resource does not match code requested'
 
         when 'date'
-          value_found = can_resolve_path(resource, 'effectiveDateTime') do |date|
+          value_found = can_resolve_path(resource, 'effective') do |date|
             validate_date_search(value, date)
           end
           assert value_found, 'date on resource does not match date requested'
@@ -127,7 +127,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'category': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'category')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 
@@ -187,7 +187,7 @@ module Inferno
         search_params = {
           'patient': @instance.patient_id,
           'code': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'code')),
-          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effectiveDateTime'))
+          'date': get_value_for_search_param(resolve_element_from_path(@observation_ary, 'effective'))
         }
         search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
 

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -117,7 +117,7 @@ module Inferno
 
             A server SHALL support searching by patient+category+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end
@@ -177,7 +177,7 @@ module Inferno
 
             A server SHOULD support searching by patient+code+date on the Observation resource
 
-              including support for these date comparators: gt, lt, le
+              including support for these date comparators: gt, lt, le, ge
           )
           versions :r4
         end

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -59,7 +59,12 @@ class SequenceBaseTest < MiniTest::Test
     it 'returns value from period' do
       { start: 'now', end: 'later' }.each do |key, value|
         element = FHIR::Period.new(key => value)
-        assert @sequence.get_value_for_search_param(element) == value
+        expected_value = if key == :start
+                           'gt' + value
+                         else
+                           'lt' + value
+                         end
+        assert @sequence.get_value_for_search_param(element) == expected_value
       end
     end
 


### PR DESCRIPTION
This PR fixes some of the problems in the tests that were caused by metadata errors. It adds the 'ge', comparator and changes Procedure.occurenceDateTime to Procedure.performedDateTime.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-496
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
