### PR TITLE
FI-402: Fix missing well known errors

### DIFF
--- a/lib/modules/smart/smart_discovery_sequence.rb
+++ b/lib/modules/smart/smart_discovery_sequence.rb
@@ -117,6 +117,8 @@ module Inferno
           )
         end
 
+        skip_if @well_known_configuration.blank?, 'No well-known SMART configuration found.'
+
         missing_fields = REQUIRED_WELL_KNOWN_FIELDS - @well_known_configuration.keys
         assert missing_fields.empty?, "The following required fields are missing: #{missing_fields.join(', ')}"
       end
@@ -134,6 +136,8 @@ module Inferno
             This test is optional because these fields are recommended, not required.
           )
         end
+
+        skip_if @well_known_configuration.blank?, 'No well-known SMART configuration found.'
 
         missing_fields = RECOMMENDED_WELL_KNOWN_FIELDS - @well_known_configuration.keys
         assert missing_fields.empty?, "The following recommended fields are missing: #{missing_fields.join(', ')}"

--- a/lib/modules/smart/smart_discovery_sequence.rb
+++ b/lib/modules/smart/smart_discovery_sequence.rb
@@ -106,9 +106,10 @@ module Inferno
         assert @well_known_configuration.present?, 'No .well-known/smart-configuration body'
       end
 
-      test 'Configuration from well-known endpoint contains required fields' do
+      test :required_well_known_fields do
         metadata do
           id '02'
+          name 'Configuration from well-known endpoint contains required fields'
           link 'http://hl7.org/fhir/smart-app-launch/conformance/index.html#metadata'
           description %(
             The JSON from .well-known/smart-configuration contains the following
@@ -120,9 +121,10 @@ module Inferno
         assert missing_fields.empty?, "The following required fields are missing: #{missing_fields.join(', ')}"
       end
 
-      test 'Configuration from well-known endpoint contains recommended fields' do
+      test :recommended_well_known_fields do
         metadata do
           id '03'
+          name 'Configuration from well-known endpoint contains recommended fields'
           link 'http://hl7.org/fhir/smart-app-launch/conformance/index.html#metadata'
           optional
           description %(

--- a/lib/modules/smart/test/smart_discovery_sequence_test.rb
+++ b/lib/modules/smart/test/smart_discovery_sequence_test.rb
@@ -15,7 +15,9 @@ describe Inferno::Sequence::SMARTDiscoverySequence do
     end
 
     it 'skips when no well-known configuration has been found' do
-      assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No well-known SMART configuration found.', exception.message
     end
   end
 
@@ -26,7 +28,9 @@ describe Inferno::Sequence::SMARTDiscoverySequence do
     end
 
     it 'skips when no well-known configuration has been found' do
-      assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No well-known SMART configuration found.', exception.message
     end
   end
 end

--- a/lib/modules/smart/test/smart_discovery_sequence_test.rb
+++ b/lib/modules/smart/test/smart_discovery_sequence_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::SMARTDiscoverySequence do
+  before do
+    @sequence_class = Inferno::Sequence::SMARTDiscoverySequence
+    @instance = Inferno::Models::TestingInstance.new
+  end
+
+  describe 'required well-known configuration fields' do
+    before do
+      @test = @sequence_class[:required_well_known_fields]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips when no well-known configuration has been found' do
+      assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+    end
+  end
+
+  describe 'recommended well-known configuration fields' do
+    before do
+      @test = @sequence_class[:recommended_well_known_fields]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips when no well-known configuration has been found' do
+      assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+    end
+  end
+end


### PR DESCRIPTION
Some tests in the SMART Discovery Sequence assume that the SMART well-known endpoint returned valid JSON configuration and fail if no configuration was returned.

![Screen Shot 2019-10-08 at 2 31 26 PM](https://user-images.githubusercontent.com/15969967/69668516-1b58dc00-105e-11ea-8a39-c6aacf9b1f2b.png)

This PR makes them skip if no well-known configuration was found.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-402
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
