### PR TITLE
FI-300: Fix cancel link during OAuth tests

### DIFF
--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -93,9 +93,16 @@ module Inferno
                   total + sequence_test_count
                 end
 
-                sequence_result = sequence.resume(request, headers, request.params, @error_message) do |result|
+                sequence_result = sequence.resume(request, headers, request.params, @error_message) do
                   count += 1
-                  out << js_update_result(sequence, test_set, result, count, sequence.test_count, count, total_tests)
+                  out << js_update_result(
+                    instance: @instance,
+                    sequence: sequence,
+                    test_set: test_set,
+                    set_count: count,
+                    count: count,
+                    total: total_tests
+                  )
                   @instance.save!
                 end
                 all_test_cases << test_case.id
@@ -134,10 +141,17 @@ module Inferno
                   @instance.reload # ensure that we have all the latest data
                   sequence = test_case.sequence.new(@instance, client, settings.disable_tls_tests)
                   count = 0
-                  sequence_result = sequence.start do |result|
+                  sequence_result = sequence.start do
                     test_count += 1
                     count += 1
-                    out << js_update_result(sequence, test_set, result, count, sequence.test_count, test_count, total_tests)
+                    out << js_update_result(
+                      instance: @instance,
+                      sequence: sequence,
+                      test_set: test_set,
+                      set_count: count,
+                      count: test_count,
+                      total: total_tests
+                    )
                   end
                   all_test_cases << test_case.id
                   failed_test_cases << test_case.id if sequence_result.fail?

--- a/lib/app/endpoint/test_set_endpoints.rb
+++ b/lib/app/endpoint/test_set_endpoints.rb
@@ -178,10 +178,17 @@ module Inferno
                 instance.reload # ensure that we have all the latest data
                 sequence = test_case.sequence.new(instance, client, settings.disable_tls_tests)
                 count = 0
-                sequence_result = sequence.start(test_set.id, test_case.id) do |result|
+                sequence_result = sequence.start(test_set.id, test_case.id) do
                   count += 1
                   test_count += 1
-                  out << js_update_result(sequence, test_set, result, count, sequence.test_count, test_count, total_tests)
+                  out << js_update_result(
+                    instance: instance,
+                    sequence: sequence,
+                    test_set: test_set,
+                    set_count: count,
+                    count: test_count,
+                    total: total_tests
+                  )
                 end
 
                 sequence_result.next_test_cases = ([next_test_case] + submitted_test_cases).join(',')

--- a/lib/app/helpers/browser_logic.rb
+++ b/lib/app/helpers/browser_logic.rb
@@ -16,17 +16,18 @@ module Inferno
           "<script>console.log('Time running: ' + #{time})</script>"
         end
 
-        def js_update_result(sequence, _test_set, _result, set_count, set_total, count, total)
+        def js_update_result(instance:, sequence:, test_set:, set_count:, count:, total:)
           cancel_button =
             if sequence.sequence_result
-              "<a href=\"sequence_result/#{sequence.sequence_result.id}/cancel\" class=\"btn btn-secondary\">Cancel Sequence</a>"
+              cancel_link = "#{instance.base_url}#{base_path}/#{instance.id}/test_sets/#{test_set.id}/sequence_result/#{sequence.sequence_result.id}/cancel"
+              "<a href=\"#{cancel_link}\" class=\"btn btn-secondary\">Cancel Sequence</a>"
             else
               ''
             end
 
           %(
             <script>
-              $('#testsRunningModal').find('.number-complete:last').html('(#{set_count} of #{set_total} #{sequence.class.title} tests complete)');
+              $('#testsRunningModal').find('.number-complete:last').html('(#{set_count} of #{sequence.test_count} #{sequence.class.title} tests complete)');
               $('#testsRunningModal .modal-footer').html('#{cancel_button}');
               var progress = Math.round((#{count}/#{total}) * 100);
               console.log('js_update_result (' + progress + ')');


### PR DESCRIPTION
This PR fixes the issue where during the launch sequences, clicking the cancel button would result in a 404.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-300
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
