### PR TITLE
FI-509 Add optional group prefixes to ensure unique test ids.

### DIFF
--- a/lib/app/models/module/test_case.rb
+++ b/lib/app/models/module/test_case.rb
@@ -4,15 +4,17 @@ module Inferno
   class Module
     class TestCase
       attr_accessor :id
+      attr_accessor :prefix
       attr_accessor :test_group
       attr_accessor :sequence
       attr_accessor :parameters
 
-      def initialize(id, test_group, sequence, parameters)
+      def initialize(id, test_group, sequence, index, parameters)
         @id = id
         @sequence = sequence
         @test_group = test_group
         @parameters = parameters
+        @prefix = "#{test_group.prefix}#{index}-" unless test_group.prefix.nil?
       end
 
       def title

--- a/lib/app/models/module/test_case.rb
+++ b/lib/app/models/module/test_case.rb
@@ -20,7 +20,8 @@ module Inferno
       end
 
       def prefix
-        return unless parameters.has_key?(:prefix)
+        return unless parameters.key?(:prefix)
+
         "#{parameters[:prefix]}-"
       end
 

--- a/lib/app/models/module/test_case.rb
+++ b/lib/app/models/module/test_case.rb
@@ -15,10 +15,11 @@ module Inferno
         @test_group = test_group
         @parameters = parameters
 
-        number_to_string = {}
-        ('A'..'ZZZ').each_with_index { |string, string_index| number_to_string[string_index + 1] = string }
-        index_as_string = number_to_string[index]
-        @prefix = "#{test_group.prefix}#{index_as_string}-" unless test_group.prefix.nil?
+        if test_group.prefix.present?
+          index_as_string = 'A'.dup
+          index.times { index_as_string.next! }
+          @prefix = "#{test_group.prefix}#{index_as_string}-"
+        end
       end
 
       def title

--- a/lib/app/models/module/test_case.rb
+++ b/lib/app/models/module/test_case.rb
@@ -15,11 +15,11 @@ module Inferno
         @test_group = test_group
         @parameters = parameters
 
-        if test_group.prefix.present?
-          index_as_string = 'A'.dup
-          index.times { index_as_string.next! }
-          @prefix = "#{test_group.prefix}#{index_as_string}-"
-        end
+        return unless test_group.prefix.present?
+
+        index_as_string = 'A'.dup
+        index.times { index_as_string.next! }
+        @prefix = "#{test_group.prefix}#{index_as_string}-"
       end
 
       def title

--- a/lib/app/models/module/test_case.rb
+++ b/lib/app/models/module/test_case.rb
@@ -14,7 +14,11 @@ module Inferno
         @sequence = sequence
         @test_group = test_group
         @parameters = parameters
-        @prefix = "#{test_group.prefix}#{index}-" unless test_group.prefix.nil?
+
+        number_to_string = {}
+        ('A'..'ZZZ').each_with_index { |string, string_index| number_to_string[string_index + 1] = string }
+        index_as_string = number_to_string[index]
+        @prefix = "#{test_group.prefix}#{index_as_string}-" unless test_group.prefix.nil?
       end
 
       def title

--- a/lib/app/models/module/test_case.rb
+++ b/lib/app/models/module/test_case.rb
@@ -4,30 +4,28 @@ module Inferno
   class Module
     class TestCase
       attr_accessor :id
-      attr_accessor :prefix
-      attr_accessor :test_group
-      attr_accessor :sequence
       attr_accessor :parameters
+      attr_accessor :sequence
+      attr_accessor :test_group
 
-      def initialize(id, test_group, sequence, index, parameters)
+      def initialize(id, test_group, sequence, parameters)
         @id = id
         @sequence = sequence
-        @test_group = test_group
         @parameters = parameters
-
-        return unless test_group.prefix.present?
-
-        index_as_string = 'A'.dup
-        index.times { index_as_string.next! }
-        @prefix = "#{test_group.prefix}#{index_as_string}-"
-      end
-
-      def title
-        parameters[:title] || sequence.title
+        @test_group = test_group
       end
 
       def description
         parameters[:description] || sequence.description
+      end
+
+      def prefix
+        return unless parameters.has_key?(:prefix)
+        "#{parameters[:prefix]}-"
+      end
+
+      def title
+        parameters[:title] || sequence.title
       end
 
       def variable_defaults

--- a/lib/app/models/module/test_group.rb
+++ b/lib/app/models/module/test_group.rb
@@ -10,11 +10,12 @@ module Inferno
       attr_accessor :lock_variables
       attr_accessor :name
       attr_accessor :overview
-      attr_accessor :test_cases
-      attr_accessor :test_set
+      attr_accessor :prefix
       attr_accessor :run_all
       attr_accessor :run_skipped
       attr_accessor :test_case_names
+      attr_accessor :test_cases
+      attr_accessor :test_set
       attr_accessor :tags
 
       def initialize(test_set, group)
@@ -28,26 +29,27 @@ module Inferno
         @input_instructions = group[:input_instructions]
         @lock_variables = group[:lock_variables] || []
         @run_skipped = group[:run_skipped] || false
+        @prefix = group[:prefix]
         @tags = group[:tags]&.map do |tag|
           Tag.new(tag[:name], tag[:description], tag[:url])
         end || []
 
-        group[:sequences].each do |sequence|
+        group[:sequences].each_with_index do |sequence, index|
           if sequence.instance_of?(String)
-            add_test_case(sequence)
+            add_test_case(sequence, index + 1)
           else
-            add_test_case(sequence[:sequence], sequence)
+            add_test_case(sequence[:sequence], index + 1, sequence)
           end
         end
       end
 
-      def add_test_case(sequence_name, parameters = {})
+      def add_test_case(sequence_name, index, parameters = {})
         current_name = "#{test_set.id}_#{id}_#{sequence_name}"
-        index = 1
+        count = 1
         while test_case_names.include? current_name
-          index += 1
-          current_name = "#{test_set.id}_#{id}_#{sequence_name}_#{index}"
-          raise 'Too many test cases using the same scenario' if index > 99
+          count += 1
+          current_name = "#{test_set.id}_#{id}_#{sequence_name}_#{count}"
+          raise 'Too many test cases using the same scenario' if count > 99
         end
 
         test_case_names << current_name
@@ -56,7 +58,7 @@ module Inferno
 
         raise "No such sequence: #{sequence_name}" if sequence.nil?
 
-        new_test_case = TestCase.new(current_name, self, sequence, parameters)
+        new_test_case = TestCase.new(current_name, self, sequence, index, parameters)
 
         test_cases << new_test_case
 

--- a/lib/app/models/module/test_group.rb
+++ b/lib/app/models/module/test_group.rb
@@ -10,12 +10,11 @@ module Inferno
       attr_accessor :lock_variables
       attr_accessor :name
       attr_accessor :overview
-      attr_accessor :prefix
+      attr_accessor :test_cases
+      attr_accessor :test_set
       attr_accessor :run_all
       attr_accessor :run_skipped
       attr_accessor :test_case_names
-      attr_accessor :test_cases
-      attr_accessor :test_set
       attr_accessor :tags
 
       def initialize(test_set, group)
@@ -29,27 +28,26 @@ module Inferno
         @input_instructions = group[:input_instructions]
         @lock_variables = group[:lock_variables] || []
         @run_skipped = group[:run_skipped] || false
-        @prefix = group[:prefix]
         @tags = group[:tags]&.map do |tag|
           Tag.new(tag[:name], tag[:description], tag[:url])
         end || []
 
-        group[:sequences].each_with_index do |sequence, index|
+        group[:sequences].each do |sequence|
           if sequence.instance_of?(String)
-            add_test_case(sequence, index + 1)
+            add_test_case(sequence)
           else
-            add_test_case(sequence[:sequence], index + 1, sequence)
+            add_test_case(sequence[:sequence], sequence)
           end
         end
       end
 
-      def add_test_case(sequence_name, index, parameters = {})
+      def add_test_case(sequence_name, parameters = {})
         current_name = "#{test_set.id}_#{id}_#{sequence_name}"
-        count = 1
+        index = 1
         while test_case_names.include? current_name
-          count += 1
-          current_name = "#{test_set.id}_#{id}_#{sequence_name}_#{count}"
-          raise 'Too many test cases using the same scenario' if count > 99
+          index += 1
+          current_name = "#{test_set.id}_#{id}_#{sequence_name}_#{index}"
+          raise 'Too many test cases using the same scenario' if index > 99
         end
 
         test_case_names << current_name
@@ -58,7 +56,7 @@ module Inferno
 
         raise "No such sequence: #{sequence_name}" if sequence.nil?
 
-        new_test_case = TestCase.new(current_name, self, sequence, index, parameters)
+        new_test_case = TestCase.new(current_name, self, sequence, parameters)
 
         test_cases << new_test_case
 

--- a/lib/app/views/report.erb
+++ b/lib/app/views/report.erb
@@ -145,7 +145,7 @@
                         </span> - 
                         <div class="sequence-out-of">
                           <% if sequence_results[test_case.id].nil? %>
-                            <%= test_case.sequence.test_count %> <% 'test'.pluralize(test_case.sequence.test_count) %>
+                            <%= test_case.sequence.test_count %> <%= 'test'.pluralize(test_case.sequence.test_count) %>
                           <% else %>
                             <%= sequence_results[test_case.id].required_passed %>/<%= sequence_results[test_case.id].total_required_tests_except_omitted%> Required Tests Passed
                             <% if sequence_results[test_case.id].optional_total > 0%> -
@@ -169,7 +169,7 @@
           </div>
         <div class="report-result-details">
           
-            <%= erb(:test_list,{},{instance: instance, sequence_class: test_case.sequence, sequence_result: sequence_results[test_case.id] }) %>
+            <%= erb(:test_list,{},{instance: instance, test_case_prefix: test_case.prefix, sequence_class: test_case.sequence, sequence_result: sequence_results[test_case.id] }) %>
           
         </div>
         </div>

--- a/lib/app/views/test_case.erb
+++ b/lib/app/views/test_case.erb
@@ -155,7 +155,7 @@
       </ul>
       <div class="tab-content" id="<%=test_case.id%>_tabs">
         <div class="tab-pane fade show active" id="<%=test_case.id%>_test_list" role="tabpanel" aria-labelledby="<%=test_case.id%>_test_list-tab">
-          <%= erb(:test_list,{},{instance: instance, sequence_class: test_case.sequence, sequence_result: sequence_results[test_case.id] }) %>
+          <%= erb(:test_list,{},{instance: instance, test_case_prefix: test_case.prefix, sequence_class: test_case.sequence, sequence_result: sequence_results[test_case.id] }) %>
         </div>
         <% if show_inputs %>
           <div class="tab-pane fade" id="<%=test_case.id%>_inputs" role="tabpanel" aria-labelledby="<%=test_case.id%>_inputs-tab">
@@ -179,7 +179,7 @@
         <% end %>
       </div>
     <% else %>
-      <%= erb(:test_list,{},{instance: instance, sequence_class: test_case.sequence, sequence_result: sequence_results[test_case.id] }) %>
+      <%= erb(:test_list,{},{instance: instance, test_case_prefix: test_case.prefix, sequence_class: test_case.sequence, sequence_result: sequence_results[test_case.id] }) %>
     <% end %>
   </div>
 </div>

--- a/lib/app/views/test_list.erb
+++ b/lib/app/views/test_list.erb
@@ -60,7 +60,7 @@
       <% end %>
 
       <% if result.result == 'todo' %> TODO: <% end %>
-      <strong><%= result.test_id %></strong>:
+      <strong><%= test_case_prefix %><%= result.test_id %></strong>:
       <% unless result.required %> OPTIONAL |  <% end %>
       <%=result.name %>
       <button class="test-results-more" data-testing-instance-id="<%=sequence_result.testing_instance.id%>" data-test-result-id="<%=result.id%>">results...</button>
@@ -77,7 +77,7 @@
   <% start_at = [sequence_result.test_results.length, sequence_class.tests.length].min unless sequence_result.nil? %>
   <% sequence_class.tests[start_at..-1].each_with_index do |test, index| %>
     <li>
-      <strong><%= test.id %></strong>:
+      <strong><%= test_case_prefix %><%= test.id %></strong>:
         <% if test.optional? %> OPTIONAL |  <% end %>
         <%= test.name %>
         <button class="test-list-more"

--- a/lib/modules/onc_program_module.yml
+++ b/lib/modules/onc_program_module.yml
@@ -34,7 +34,6 @@ test_sets:
           - ArgonautConformanceSequence
           - ONCSMARTDiscoverySequence
       - name: Standalone Patient App
-        prefix: SA
         overview: |
           Demonstrate the ability to perform a Patient Standalone Launch to a [SMART on FHIR](http://www.hl7.org/fhir/smart-app-launch/) client with a patient context,
           refresh token, and [OpenID Connect (OIDC)](https://openid.net/specs/openid-connect-core-1_0.html) identity token.  After launch, a simple Patient resource read is performed
@@ -52,21 +51,25 @@ test_sets:
           - redirect_uris
         sequences:
           - sequence: OncStandaloneLaunchSequence
+            prefix: SAA
             title: Standalone Launch with Patient Scope
             description: Perform Standalone SMART launch sequence and test OpenID Connect and token refresh functionality.
             variable_defaults:
               scopes: launch/patient patient/*.read openid fhirUser offline_access
           - sequence: ArgonautPatientReadOnlySequence
+            prefix: SAB
             title: Read Patient Resource
             description: Demonstrate successful authorization by reading Patient resource.
           - sequence: OpenIDConnectSequence
+            prefix: SAC
             description: Use OpenID Connect ID token provided during launch sequence to authenticate user.
-          - TokenRefreshSequence
+          - sequence: TokenRefreshSequence
+            prefix: SAD
           - sequence: ArgonautPatientReadOnlySequence
+            prefix: SAE
             title: Read Patient Resource
             description: Ensure new token is functional by performing a simple read of the Patient resource.
       - name: EHR Practitioner App
-        prefix: EHR
         overview: |
           Demonstrate the ability to perform an EHR launch to a [SMART on FHIR](http://www.hl7.org/fhir/smart-app-launch/) client with a patient context,
           refresh token, and [OpenID Connect (OIDC)](https://openid.net/specs/openid-connect-core-1_0.html) identity token.  After launch, a simple Patient resource read is performed
@@ -74,17 +77,22 @@ test_sets:
           access token to ensure that the refresh was successful.  Finally, the authentication information provided by OpenID Connect is decoded and validated.
         sequences:
           - sequence: OncEHRLaunchSequence
+            prefix: EHA
             title: EHR Launch with Practitioner Scope
             description: Perform EHR SMART launch sequence and test OpenID Connect and token refresh functionality.
             variable_defaults:
               scopes: launch user/*.read openid fhirUser offline_access
           - sequence: ArgonautPatientReadOnlySequence
+            prefix: EHB
             title: Read Patient Resource
             description: Demonstrate successful authorization by reading Patient resource.
           - sequence: OpenIDConnectSequence
+            prefix: EHC
             description: Use OpenID Connect ID token provided during launch sequence to authenticate user.
-          - TokenRefreshSequence
+          - sequence: TokenRefreshSequence
+            prefix: EHD
           - sequence: ArgonautPatientReadOnlySequence
+            prefix: EHE
             title: Read Patient Resource
             description: Ensure new token is functional by performing a simple read of the Patient resource.
         input_instructions: |

--- a/lib/modules/onc_program_module.yml
+++ b/lib/modules/onc_program_module.yml
@@ -34,6 +34,7 @@ test_sets:
           - ArgonautConformanceSequence
           - ONCSMARTDiscoverySequence
       - name: Standalone Patient App
+        prefix: SA
         overview: |
           Demonstrate the ability to perform a Patient Standalone Launch to a [SMART on FHIR](http://www.hl7.org/fhir/smart-app-launch/) client with a patient context,
           refresh token, and [OpenID Connect (OIDC)](https://openid.net/specs/openid-connect-core-1_0.html) identity token.  After launch, a simple Patient resource read is performed
@@ -65,6 +66,7 @@ test_sets:
             title: Read Patient Resource
             description: Ensure new token is functional by performing a simple read of the Patient resource.
       - name: EHR Practitioner App
+        prefix: EHR
         overview: |
           Demonstrate the ability to perform an EHR launch to a [SMART on FHIR](http://www.hl7.org/fhir/smart-app-launch/) client with a patient context,
           refresh token, and [OpenID Connect (OIDC)](https://openid.net/specs/openid-connect-core-1_0.html) identity token.  After launch, a simple Patient resource read is performed


### PR DESCRIPTION
The problem:  In our test procedure view, you can string together multiple sequences executed against different contexts.  However, their TESTIDs remain the same, which is problematic because they are different tests because they have different inputs.

This addresses the issue by adding an optional 'prefix' field on groups in the module.yml files.  If a prefix exists, the UI (and soon the XLS outputter) appends it to the test.

![Screen Shot 2019-11-27 at 11 59 53 AM](https://user-images.githubusercontent.com/412901/69744286-edcb6b80-110d-11ea-95cc-c38c699bd61e.png)

This is starting to get a little more complicated than I'm comfortable with -- you need to know to append the group id in different views.  Also, I didn't add a test to ensure this is used for uniqueness, as it is just an option.  But we may consider adding this.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
