### PR TITLE
FI-511 Apply bulk_access_token to Group export

### DIFF
--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -293,6 +293,12 @@
               value: instance.bulk_token_endpoint,
               })%>   
 
+        <%= erb(:prerequisite_field,{},{prerequisite: :bulk_access_token,
+              label: 'Bulk Bearer Token',
+              instance: instance,
+              value: instance.bulk_access_token,
+              })%>
+
         <%= erb(:prerequisite_field,{},{prerequisite: :bulk_client_id,
               instance: instance,
               label: 'Bulk Client ID',

--- a/lib/modules/bulk_data/bulk_data_group_export_sequence.rb
+++ b/lib/modules/bulk_data/bulk_data_group_export_sequence.rb
@@ -15,7 +15,7 @@ module Inferno
 
       test_id_prefix 'Group'
 
-      requires :group_id, :token
+      requires :group_id, :bulk_access_token
 
       def endpoint
         'Group'

--- a/lib/modules/bulk_data/bulk_data_patient_export_sequence.rb
+++ b/lib/modules/bulk_data/bulk_data_patient_export_sequence.rb
@@ -15,7 +15,7 @@ module Inferno
 
       test_id_prefix 'Patient'
 
-      requires :token
+      requires :bulk_access_token
       conformance_supports :Patient
 
       def endpoint

--- a/lib/modules/bulk_data/test/patient_export_sequence_test.rb
+++ b/lib/modules/bulk_data/test/patient_export_sequence_test.rb
@@ -25,22 +25,22 @@ class BulkDataPatientExportSequenceTest < MiniTest::Test
       oauth_authorize_endpoint: 'http://oauth_reg.example.com/authorize',
       oauth_token_endpoint: 'http://oauth_reg.example.com/token',
       scopes: 'launch openid patient/*.* profile',
-      token: 99_897_979
+      bulk_access_token: 99_897_979
     )
 
     @instance.save!
 
     @export_request_headers = { accept: 'application/fhir+json',
                                 prefer: 'respond-async',
-                                authorization: "Bearer #{@instance.token}" }
+                                authorization: "Bearer #{@instance.bulk_access_token}" }
 
     @export_request_headers_no_token = { accept: 'application/fhir+json', prefer: 'respond-async' }
 
     @status_request_headers = { accept: 'application/json',
-                                authorization: "Bearer #{@instance.token}" }
+                                authorization: "Bearer #{@instance.bulk_access_token}" }
 
     @file_request_headers = { accept: 'application/fhir+ndjson',
-                              authorization: "Bearer #{@instance.token}" }
+                              authorization: "Bearer #{@instance.bulk_access_token}" }
 
     @patient_export = load_fixture_with_extension('bulk_data_patient.ndjson')
 


### PR DESCRIPTION
This pull request contains changes for FI-511. Bulk data export sequence can use bulk_access_token if available.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
https://oncprojectracking.healthit.gov/support/browse/FI-511
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
