### PR TITLE
Fi 526 config env

### DIFF
--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -10,7 +10,7 @@ module Inferno
     class Endpoint < Sinatra::Base
       register Sinatra::ConfigFile
 
-      config_file '../../config.yml'
+      config_file "../../#{ENV['INFERNO_CONFIG_FILE'] || 'config.yml'}"
 
       OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if settings.disable_verify_peer
       Inferno::BASE_PATH = "/#{settings.base_path.gsub(/[^0-9a-z_-]/i, '')}"

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -10,7 +10,7 @@ module Inferno
     class Endpoint < Sinatra::Base
       register Sinatra::ConfigFile
 
-      config_file "../../#{ENV['INFERNO_CONFIG_FILE'] || 'config.yml'}"
+      config_file File.join('..', '..', ENV['INFERNO_CONFIG_FILE'] || 'config.yml')
 
       OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if settings.disable_verify_peer
       Inferno::BASE_PATH = "/#{settings.base_path.gsub(/[^0-9a-z_-]/i, '')}"


### PR DESCRIPTION
Allow specifying alternate config file location with `INFERNO_CONFIG_FILE`.  This allows us to have downstream forks have fewer merge conficts.

```
cp config.yml config_other.yml
INFERNO_CONFIG_FILE=config_other.yml bundle exec rackup
```

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
