### PR TITLE
Fi 530 revinclude skip

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -220,7 +220,7 @@ module Inferno
                 assert_response_ok(reply)
                 assert_bundle_response(reply)
                 #{resource_variable} = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == '#{resource_name}' }
-                assert #{resource_variable}, 'No #{resource_name} resources were returned from this search'
+                skip 'No #{resource_name} resources were returned from this search' unless #{resource_variable}
           )
         end
         sequence[:tests] << revinclude_test

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -190,7 +190,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'AllergyIntolerance resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -279,7 +279,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'CarePlan resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -171,7 +171,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'CareTeam resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -291,7 +291,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Condition resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -330,7 +330,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'DiagnosticReport resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -330,7 +330,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'DiagnosticReport resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -351,7 +351,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'DocumentReference resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -349,7 +349,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Encounter resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -229,7 +229,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Goal resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -229,7 +229,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Immunization resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -190,7 +190,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Device resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -295,7 +295,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Location resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -291,7 +291,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'MedicationRequest resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Organization resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -346,7 +346,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Patient resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -206,7 +206,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Practitioner resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -230,7 +230,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'PractitionerRole resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -268,7 +268,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Procedure resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -307,7 +307,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         provenance_results = reply&.resource&.entry&.map(&:resource)&.any? { |resource| resource.resourceType == 'Provenance' }
-        assert provenance_results, 'No Provenance resources were returned from this search'
+        skip 'No Provenance resources were returned from this search' unless provenance_results
       end
 
       test 'Observation resources returned conform to US Core R4 profiles' do


### PR DESCRIPTION
If revinclude doesn't return anything, we should skip as it just means they have an incomplete record.  At the very least we should skip if there are no resources of the type you are revincluding against (e.g. if there are no AllergyIntolerances, there should not be any provenances either), but this update should handle both cases.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
