### PR TITLE
FI-507: Automatic token refresh

### DIFF
--- a/lib/app/ext/fhir_client.rb
+++ b/lib/app/ext/fhir_client.rb
@@ -4,7 +4,7 @@ module FHIR
   VERSIONS = [:dstu2, :stu3, :r4].freeze
 
   class Client
-    attr_accessor :requests
+    attr_accessor :requests, :testing_instance
 
     def record_requests(reply)
       @requests ||= []
@@ -19,6 +19,7 @@ module FHIR
         class_eval <<~RUBY, __FILE__, __LINE__ + 1
           alias #{method}_original #{method}
           def #{method}(*args, &block)
+            refresh_token_if_needed
             reply = #{method}_original(*args, &block)
             record_requests(reply)
             return reply
@@ -27,8 +28,67 @@ module FHIR
       end
     end
 
+    def refresh_token_if_needed
+      return if testing_instance&.refresh_token.blank?
+
+      perform_refresh if time_to_refresh?
+    end
+
+    def time_to_refresh?
+      return true if testing_instance.token_expires_in.blank?
+
+      testing_instance.token_expiration_time.to_i - DateTime.now.to_i < 60
+    end
+
+    def perform_refresh
+      oauth2_params = {
+        'grant_type' => 'refresh_token',
+        'refresh_token' => testing_instance.refresh_token
+      }
+      oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+
+      if testing_instance.confidential_client
+        oauth2_headers['Authorization'] = encoded_secret(testing_instance.client_id, testing_instance.client_secret)
+      else
+        oauth2_params['client_id'] = testing_instance.client_id
+      end
+
+      begin
+        token_response = Inferno::LoggedRestClient.post(
+          testing_instance.oauth_token_endpoint,
+          oauth2_params,
+          oauth2_headers
+        )
+
+        return if token_response.code != 200
+
+        token_response_body = JSON.parse(token_response.body)
+
+        expires_in = token_response_body['expires_in'].is_a?(Numeric) ? token_response_body['expires_in'] : nil
+
+        update_params = {
+          token: token_response_body['access_token'],
+          token_retrieved_at: DateTime.now,
+          token_expires_in: expires_in
+        }
+
+        update_params[:refresh_token] = token_response_body['refresh_token'] if token_response_body['refresh_token'].present?
+        testing_instance.save
+        testing_instance.update(update_params)
+
+        set_bearer_token(token_response_body['access_token'])
+      rescue StandardError => e
+        Inferno.logger.error "Unable to refresh token: #{e.message}"
+      end
+    end
+
+    def encoded_secret(client_id, client_secret)
+      "Basic #{Base64.strict_encode64(client_id + ':' + client_secret)}"
+    end
+
     def self.for_testing_instance(instance)
       new(instance.url).tap do |client|
+        client.testing_instance = instance
         case instance.fhir_version
         when 'stu3'
           client.use_stu3

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -36,6 +36,7 @@ module Inferno
 
       property :token, String
       property :token_retrieved_at, DateTime
+      property :token_expires_in, Integer
       property :id_token, String
       property :refresh_token, String
       property :created_at, DateTime, default: proc { DateTime.now }
@@ -249,6 +250,10 @@ module Inferno
         else
           FHIR::CapabilityStatement
         end
+      end
+
+      def token_expiration_time
+        token_retrieved_at + token_expires_in.seconds
       end
 
       private

--- a/lib/modules/smart/shared_launch_tests.rb
+++ b/lib/modules/smart/shared_launch_tests.rb
@@ -55,7 +55,11 @@ module Inferno
         @instance.update(encounter_id: token_response_body['encounter']) if token_response_body['encounter'].present?
 
         required_keys = ['token_type', 'scope']
-        required_keys << 'expires_in' if require_expires_in
+        if require_expires_in
+          required_keys << 'expires_in'
+        else
+          warning { assert expires_in.present?, 'Token exchange response did not contain the recommended `expires_in` field' }
+        end
 
         required_keys.each do |key|
           assert token_response_body[key].present?, "Token response did not contain #{key} as required"

--- a/lib/modules/smart/shared_launch_tests.rb
+++ b/lib/modules/smart/shared_launch_tests.rb
@@ -40,7 +40,16 @@ module Inferno
 
         assert token_response_body['access_token'].present?, 'Token response did not contain access_token as required'
 
-        @instance.update(token: token_response_body['access_token'], token_retrieved_at: DateTime.now)
+        expires_in = token_response_body['expires_in']
+        if expires_in.present? # rubocop:disable Style/IfUnlessModifier
+          assert expires_in.is_a?(Numeric), "`expires_in` field is not a number: #{expires_in.inspect}"
+        end
+
+        @instance.update(
+          token: token_response_body['access_token'],
+          token_retrieved_at: DateTime.now,
+          token_expires_in: expires_in
+        )
 
         @instance.patient_id = token_response_body['patient'] if token_response_body['patient'].present?
         @instance.update(encounter_id: token_response_body['encounter']) if token_response_body['encounter'].present?

--- a/lib/modules/smart/shared_launch_tests.rb
+++ b/lib/modules/smart/shared_launch_tests.rb
@@ -42,13 +42,13 @@ module Inferno
 
         expires_in = token_response_body['expires_in']
         if expires_in.present? # rubocop:disable Style/IfUnlessModifier
-          assert expires_in.is_a?(Numeric), "`expires_in` field is not a number: #{expires_in.inspect}"
+          warning { assert expires_in.is_a?(Numeric), "`expires_in` field is not a number: #{expires_in.inspect}" }
         end
 
         @instance.update(
           token: token_response_body['access_token'],
           token_retrieved_at: DateTime.now,
-          token_expires_in: expires_in
+          token_expires_in: expires_in.to_i
         )
 
         @instance.patient_id = token_response_body['patient'] if token_response_body['patient'].present?

--- a/lib/modules/smart/test/shared_launch_tests_test.rb
+++ b/lib/modules/smart/test/shared_launch_tests_test.rb
@@ -437,6 +437,22 @@ describe Inferno::Sequence::SharedLaunchTests do
       assert warnings.include?('`expires_in` field is not a number: "DEF"')
     end
 
+    it 'generates a warning if no expires_in provided but still successfully saves patient id' do
+      @instance.scopes = 'GHI'
+      response = {
+        access_token: 'ABC',
+        token_type: 'Bearer',
+        scope: 'GHI',
+        patient: '5'
+      }
+      @sequence.instance_variable_set(:@token_response, OpenStruct.new(body: response.to_json))
+      @sequence.run_test(@test)
+
+      warnings = @sequence.instance_variable_get(:@test_warnings)
+      assert warnings.include?('Token exchange response did not contain the recommended `expires_in` field')
+      assert @instance.patient_id == '5', 'patient_id not saved when expires_in empty'
+    end
+
     it 'succeeds if the token_type is "bearer" and an access token and scope are included' do
       @instance.scopes = 'GHI'
       response = {

--- a/lib/modules/smart/test/shared_launch_tests_test.rb
+++ b/lib/modules/smart/test/shared_launch_tests_test.rb
@@ -380,6 +380,14 @@ describe Inferno::Sequence::SharedLaunchTests do
       assert_equal 'Token response did not contain access_token as required', exception.message
     end
 
+    it 'fails if the response contains a non-numeric value for expires_in' do
+      response = { access_token: 'ABC', expires_in: 'DEF' }
+      @sequence.instance_variable_set(:@token_response, OpenStruct.new(body: response.to_json))
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal '`expires_in` field is not a number: "DEF"', exception.message
+    end
+
     it 'fails if the token response does not contain the token_type' do
       response = { access_token: 'ABC' }
       @sequence.instance_variable_set(:@token_response, OpenStruct.new(body: response.to_json))
@@ -427,7 +435,8 @@ describe Inferno::Sequence::SharedLaunchTests do
       response = {
         access_token: 'ABC',
         token_type: 'Bearer',
-        scope: 'GHI'
+        scope: 'GHI',
+        expires_in: 300
       }
       @sequence.instance_variable_set(:@token_response, OpenStruct.new(body: response.to_json))
 

--- a/lib/modules/smart/test/token_refresh_sequence_test.rb
+++ b/lib/modules/smart/test/token_refresh_sequence_test.rb
@@ -6,7 +6,7 @@ describe Inferno::Sequence::TokenRefreshSequence do
   let(:full_body) do
     {
       'access_token' => 'abc',
-      'expires_in' => 'def',
+      'expires_in' => 300,
       'token_type' => 'Bearer',
       'scope' => 'jkl'
     }

--- a/test/unit/fhir_client_test.rb
+++ b/test/unit/fhir_client_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require File.expand_path '../test_helper.rb', __dir__
+
+describe FHIR::Client do
+  before do
+    @client = FHIR::Client.new('http://www.example.com/fhir')
+    @instance = Inferno::Models::TestingInstance.create(
+      oauth_token_endpoint: 'http://www.example.com/token',
+      client_id: 'CLIENT_ID'
+    )
+    @client.instance_variable_set(:@testing_instance, @instance)
+  end
+
+  describe '#time_to_refresh?' do
+    it 'returns true if the token expiration time is unknown' do
+      assert_equal true, @client.time_to_refresh?
+    end
+
+    it 'returns false if the token expiration time is more than a minute in the future' do
+      now = DateTime.now
+      @instance.update(token_retrieved_at: now)
+      [now + 65.seconds, now + 1.hour, now + 1.year].each do |time|
+        expires_in = time.to_i - now.to_i
+        @instance.update(token_expires_in: expires_in)
+
+        assert_equal false, @client.time_to_refresh?
+      end
+    end
+
+    it 'returns trueif the token has expired or is about to expire' do
+      now = DateTime.now
+      @instance.update(token_retrieved_at: now)
+      [now + 55.seconds, now - 1.hour, now - 1.year].each do |time|
+        expires_in = time.to_i - now.to_i
+        @instance.update(token_expires_in: expires_in)
+
+        assert_equal true, @client.time_to_refresh?
+      end
+    end
+  end
+
+  describe '#perform_refresh' do
+    before do
+      @refresh_token = 'OLD_REFRESH_TOKEN'
+      @access_token = 'OLD_ACCESS_TOKEN'
+      @expires_in = 123
+      @instance.update(
+        refresh_token: @refresh_token,
+        token: @access_token,
+        token_expires_in: @expires_in
+      )
+
+      @new_refresh_token = 'NEW_REFRESH_TOKEN'
+      @new_access_token = 'NEW_ACCESS_TOKEN'
+      @new_expires_in = 456
+      @token_response = {
+        refresh_token: @new_refresh_token,
+        access_token: @new_access_token,
+        expires_in: @new_expires_in
+      }
+    end
+
+    it 'does not update the token if the refresh is unsuccessful' do
+      stub_request(:post, @instance.oauth_token_endpoint)
+        .with(body: {
+                grant_type: 'refresh_token',
+                refresh_token: @instance.refresh_token,
+                client_id: @instance.client_id
+              })
+        .to_return(status: 500)
+
+      @client.perform_refresh
+      assert_equal @refresh_token, @instance.refresh_token
+      assert_equal @access_token, @instance.token
+      assert_equal @expires_in, @instance.token_expires_in
+    end
+
+    it 'updates the token if the refresh is successful for public clients' do
+      stub_request(:post, @instance.oauth_token_endpoint)
+        .with(body: {
+                grant_type: 'refresh_token',
+                refresh_token: @instance.refresh_token,
+                client_id: @instance.client_id
+              })
+        .to_return(status: 200, body: @token_response.to_json)
+
+      @client.perform_refresh
+
+      assert_equal @new_refresh_token, @instance.refresh_token
+      assert_equal @new_access_token, @instance.token
+      assert_equal @new_expires_in, @instance.token_expires_in
+    end
+
+    it 'updates the token if the refresh is successful for confidential clients' do
+      @instance.update(
+        client_secret: 'CLIENT_SECRET',
+        confidential_client: true
+      )
+      stub_request(:post, @instance.oauth_token_endpoint)
+        .with(
+          body: {
+            grant_type: 'refresh_token',
+            refresh_token: @instance.refresh_token
+          },
+          headers: { 'Authorization': @client.encoded_secret(@instance.client_id, @instance.client_secret) }
+        )
+        .to_return(status: 200, body: @token_response.to_json)
+
+      @client.perform_refresh
+
+      assert_equal @new_refresh_token, @instance.refresh_token
+      assert_equal @new_access_token, @instance.token
+      assert_equal @new_expires_in, @instance.token_expires_in
+    end
+
+    it 'sets expires_in to nil if it is non-numeric' do
+      @token_response[:expires_in] = 'abc'
+      stub_request(:post, @instance.oauth_token_endpoint)
+        .with(body: {
+                grant_type: 'refresh_token',
+                refresh_token: @instance.refresh_token,
+                client_id: @instance.client_id
+              })
+        .to_return(status: 200, body: @token_response.to_json)
+
+      @client.perform_refresh
+
+      assert_equal @new_refresh_token, @instance.refresh_token
+      assert_equal @new_access_token, @instance.token
+      assert_nil @instance.token_expires_in
+    end
+  end
+end


### PR DESCRIPTION
Inferno's tests can take some time, so Inferno needs to be able to automatically refresh access tokens before they expire.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-507
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
