### PR TITLE
FI-538: Allow omission of optional tests

### DIFF
--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -74,12 +74,17 @@ module Inferno
         # Returns test details for a specific test including any applicable requests and responses.
         #   This route is typically used for retrieving test metadata before the test has been run
         get '/test_details/:module/:sequence_name/:test_index?' do
-          sequence = Inferno::Module.get(params[:module]).sequences.find do |x|
+          inferno_module = Inferno::Module.get(params[:module])
+          sequence = inferno_module.sequences.find do |x|
             x.sequence_name == params[:sequence_name]
           end
+
           halt 404 unless sequence
-          @test = sequence.tests[params[:test_index].to_i]
+
+          @test = sequence.tests(inferno_module)[params[:test_index].to_i]
+
           halt 404 unless @test.present?
+
           erb :test_details, layout: false
         end
 

--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -89,7 +89,7 @@ module Inferno
 
                 submitted_test_cases_count = sequence_result.next_test_cases.split(',')
                 total_tests = submitted_test_cases_count.reduce(first_test_count) do |total, set|
-                  sequence_test_count = test_set.test_case_by_id(set).sequence.test_count
+                  sequence_test_count = test_set.test_case_by_id(set).sequence.test_count(@instance.module)
                   total + sequence_test_count
                 end
 

--- a/lib/app/endpoint/test_set_endpoints.rb
+++ b/lib/app/endpoint/test_set_endpoints.rb
@@ -64,8 +64,9 @@ module Inferno
           # Cancels the currently running test
           get '/:id/test_sets/:test_set_id/sequence_result/:sequence_result_id/cancel' do
             sequence_result = Inferno::Models::SequenceResult.get(params[:sequence_result_id])
-            halt 404 if sequence_result.testing_instance.id != params[:id]
-            test_set = sequence_result.testing_instance.module.test_sets[params[:test_set_id].to_sym]
+            instance = sequence_result.testing_instance
+            halt 404 if instance.id != params[:id]
+            test_set = instance.module.test_sets[params[:test_set_id].to_sym]
             halt 404 if test_set.nil?
 
             sequence_result.result = 'cancel'
@@ -77,13 +78,13 @@ module Inferno
               last_result.message = cancel_message
             end
 
-            sequence = sequence_result.testing_instance.module.sequences.find do |x|
+            sequence = instance.module.sequences.find do |x|
               x.sequence_name == sequence_result.name
             end
 
             current_test_count = sequence_result.result_count
 
-            sequence.tests.each_with_index do |test, index|
+            sequence.tests(instance.module).each_with_index do |test, index|
               next if index < current_test_count
 
               sequence_result.test_results << Inferno::Models::TestResult.new(test_id: test.id,
@@ -131,7 +132,7 @@ module Inferno
             instance.reload # ensure that we have all the latest data
 
             total_tests = submitted_test_cases.reduce(0) do |total, set|
-              sequence_test_count = test_set.test_case_by_id(set).sequence.test_count
+              sequence_test_count = test_set.test_case_by_id(set).sequence.test_count(instance.module)
               total + sequence_test_count
             end
 

--- a/lib/app/views/report.erb
+++ b/lib/app/views/report.erb
@@ -145,7 +145,7 @@
                         </span> - 
                         <div class="sequence-out-of">
                           <% if sequence_results[test_case.id].nil? %>
-                            <%= test_case.sequence.test_count %> <%= 'test'.pluralize(test_case.sequence.test_count) %>
+                            <%= test_case.sequence.test_count(instance.module) %> <%= 'test'.pluralize(test_case.sequence.test_count(instance.module)) %>
                           <% else %>
                             <%= sequence_results[test_case.id].required_passed %>/<%= sequence_results[test_case.id].total_required_tests_except_omitted%> Required Tests Passed
                             <% if sequence_results[test_case.id].optional_total > 0%> -

--- a/lib/app/views/test_case.erb
+++ b/lib/app/views/test_case.erb
@@ -68,7 +68,7 @@
                 </span> - 
                 <div class="sequence-out-of">
                   <% if sequence_results[test_case.id].nil? %>
-                    <%= test_case.sequence.test_count %> <%= 'test'.pluralize(test_case.sequence.test_count) %>
+                    <%= test_case.sequence.test_count(instance.module) %> <%= 'test'.pluralize(test_case.sequence.test_count(instance.module)) %>
                   <% else %>
                     <%= sequence_results[test_case.id].required_passed %>/<%= sequence_results[test_case.id].total_required_tests_except_omitted %> Required Tests Passed
 

--- a/lib/app/views/test_list.erb
+++ b/lib/app/views/test_list.erb
@@ -74,8 +74,8 @@
     </li>
   <% end %>
   <% start_at = 0%>
-  <% start_at = [sequence_result.test_results.length, sequence_class.tests.length].min unless sequence_result.nil? %>
-  <% sequence_class.tests[start_at..-1].each_with_index do |test, index| %>
+  <% start_at = [sequence_result.test_results.length, sequence_class.tests(instance.module).length].min unless sequence_result.nil? %>
+  <% sequence_class.tests(instance.module)[start_at..-1].each_with_index do |test, index| %>
     <li>
       <strong><%= test_case_prefix %><%= test.id %></strong>:
         <% if test.optional? %> OPTIONAL |  <% end %>

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -180,14 +180,15 @@ namespace :inferno do |_argv|
     Inferno.logger.warn 'Please use :tests_to_xls, which will replace this task'
     args.with_defaults(module: 'argonaut', group: 'active')
     args.with_defaults(filename: "#{args.module}_testlist.csv")
-    sequences = Inferno::Module.get(args.module)&.sequences
+    inferno_module = Inferno::Module.get(args.module)
+    sequences = inferno_module&.sequences
     if sequences.nil?
       puts "No sequence found for module: #{args.module}"
       exit
     end
 
     flat_tests = sequences.map do |klass|
-      klass.tests.map do |test|
+      klass.tests(inferno_module).map do |test|
         test.metadata_hash.merge(
           sequence: klass.to_s,
           sequence_required: !klass.optional?
@@ -257,7 +258,7 @@ namespace :inferno do |_argv|
 
     test_set.groups.each do |group|
       group.test_cases.each do |test_case|
-        test_case.sequence.tests.each do |test|
+        test_case.sequence.tests(test_module).each do |test|
           [group.name,
            group.overview,
            '',


### PR DESCRIPTION
This PR allows modules to set `hide_optional: true` and not display or run any optional tests. This option already existed, but was not actually implemented.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-538
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
