### PR TITLE
FI 541 - Fix fatal error with comparator search

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -749,6 +749,8 @@ module Inferno
       end
 
       def date_comparator_value(comparator, date)
+        date = date.slice(2..-1) if ['gt', 'ge', 'lt', 'le'].include? date[0, 2]
+
         case comparator
         when 'lt', 'le'
           comparator + (DateTime.xmlschema(date) + 1).xmlschema


### PR DESCRIPTION
This PR fixes a fatal error when performing a comparator search when trying to resolve from a period type. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR:
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
