### PR TITLE
Fi 481 create docref test

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -77,6 +77,7 @@ module Inferno
           profile: profile,
           title: profile_title,
           interactions: [],
+          operations: [],
           searches: [],
           search_param_descriptions: {},
           element_descriptions: {},
@@ -98,6 +99,7 @@ module Inferno
             add_basic_searches(resource, new_sequence)
             add_combo_searches(resource, new_sequence)
             add_interactions(resource, new_sequence)
+            add_operations(resource, new_sequence)
             add_include_search(resource, new_sequence)
             add_revinclude_targets(resource, new_sequence)
 
@@ -153,6 +155,17 @@ module Inferno
             expectation: interaction['extension'][0]['valueCode']
           }
           sequence[:interactions] << new_interaction
+        end
+      end
+
+      def add_operations(resource, sequence)
+        operations = resource['operation']
+        operations&.each do |operation|
+          new_operation = {
+            operation: operation['name'],
+            expectation: operation['extension'][0]['valueCode']
+          }
+          sequence[:operations] << new_operation
         end
       end
 

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -72,6 +72,12 @@ module Inferno
               create_interaction_test(sequence, interaction)
             end
 
+          sequence[:operations]
+            .select { |operation| operation[:expectation] == 'SHALL' }
+            .each do |operation|
+              create_docref_test(sequence) if operation[:operation] == 'docref'
+            end
+
           create_include_test(sequence) if sequence[:include_params].any?
           create_revinclude_test(sequence) if sequence[:revincludes].any?
           create_resource_profile_test(sequence)
@@ -173,6 +179,24 @@ module Inferno
           class_name: sequence[:class_name],
           sequence_name: sequence[:name]
         )
+      end
+
+      def create_docref_test(sequence)
+        docref_test = {
+          tests_that: 'The server is capable of returning a reference to a generated CDA document in response to the $docref operation',
+          index: sequence[:tests].length + 1,
+          link: 'http://hl7.org/fhir/us/core/2019Sep/CapabilityStatement-us-core-server.html#documentreference',
+          description: 'A server SHALL be capable of responding to a $docref operation and capable of returning at least a reference to a generated CCD document, if available.'
+        }
+
+        docref_test[:test_code] = %(
+          skip_if_not_supported(:#{sequence[:resource]}, [], [:docref])
+          search_string = "/DocumentRefernce/$docref?patient=\#{@instance.patient_id}"
+          reply = @client.get(search_string, @client.fhir_headers)
+          assert_response_ok(reply)
+        )
+
+        sequence[:tests] << docref_test
       end
 
       def create_include_test(sequence)

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -191,7 +191,7 @@ module Inferno
 
         docref_test[:test_code] = %(
           skip_if_not_supported(:#{sequence[:resource]}, [], [:docref])
-          search_string = "/DocumentRefernce/$docref?patient=\#{@instance.patient_id}"
+          search_string = "/DocumentReference/$docref?patient=\#{@instance.patient_id}"
           reply = @client.get(search_string, @client.fhir_headers)
           assert_response_ok(reply)
         )

--- a/lib/app/models/server_capabilities.rb
+++ b/lib/app/models/server_capabilities.rb
@@ -24,7 +24,8 @@ module Inferno
           rest.resource.map do |resource|
             {
               resource_type: resource.type,
-              interactions: resource_interactions(resource).sort
+              interactions: resource_interactions(resource).sort,
+              operations: resource_operations(resource).sort
             }
           end
         end
@@ -74,6 +75,10 @@ module Inferno
 
       def resource_interactions(resource)
         resource.interaction.map { |interaction| interaction_display(interaction) }
+      end
+
+      def resource_operations(resource)
+        resource.operation.map(&:name)
       end
     end
   end

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -200,7 +200,7 @@ module Inferno
         end
       end
 
-      def conformance_supported?(resource, methods = [])
+      def conformance_supported?(resource, methods = [], operations = [])
         resource_support = supported_resource_interactions.find do |interactions|
           interactions[:resource_type] == resource.to_s
         end
@@ -211,6 +211,10 @@ module Inferno
           method = method == :history ? 'history-instance' : method.to_s
 
           resource_support[:interactions].include? method
+        end
+
+        operations.all? do |operation|
+          resource_support[:operations].include? operation.to_s
         end
       end
 

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -207,15 +207,17 @@ module Inferno
 
         return false if resource_support.blank?
 
-        methods.all? do |method|
+        methods_supported = methods.all? do |method|
           method = method == :history ? 'history-instance' : method.to_s
 
           resource_support[:interactions].include? method
         end
 
-        operations.all? do |operation|
+        operations_supported = operations.all? do |operation|
           resource_support[:operations].include? operation.to_s
         end
+
+        methods_supported && operations_supported
       end
 
       def save_resource_reference(type, id, profile = nil)

--- a/lib/app/utils/skip_helpers.rb
+++ b/lib/app/utils/skip_helpers.rb
@@ -2,9 +2,9 @@
 
 module Inferno
   module SkipHelpers
-    def skip_if_not_supported(resource, methods)
-      skip_message = "This server does not support #{resource} #{methods.join(',')} operation(s) according to conformance statement."
-      skip skip_message unless @instance.conformance_supported?(resource, methods)
+    def skip_if_not_supported(resource, methods = [], operations = [])
+      skip_message = "This server does not support #{resource} #{(methods + operations).join(',')} operation(s) according to conformance statement."
+      skip skip_message unless @instance.conformance_supported?(resource, methods, operations)
     end
 
     def omit_if_tls_disabled

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -332,9 +332,25 @@ module Inferno
         validate_history_reply(@document_reference, versioned_resource_class('DocumentReference'))
       end
 
-      test 'Server returns Provenance resources from DocumentReference search by patient + _revIncludes: Provenance:target' do
+      test 'The server is capable of returning a reference to a generated CDA document in response to the $docref operation' do
         metadata do
           id '12'
+          link 'http://hl7.org/fhir/us/core/2019Sep/CapabilityStatement-us-core-server.html#documentreference'
+          description %(
+            A server SHALL be capable of responding to a $docref operation and capable of returning at least a reference to a generated CCD document, if available.
+          )
+          versions :r4
+        end
+
+        skip_if_not_supported(:DocumentReference, [], [:docref])
+        search_string = "/DocumentRefernce/$docref?patient=#{@instance.patient_id}"
+        reply = @client.get(search_string, @client.fhir_headers)
+        assert_response_ok(reply)
+      end
+
+      test 'Server returns Provenance resources from DocumentReference search by patient + _revIncludes: Provenance:target' do
+        metadata do
+          id '13'
           link 'https://www.hl7.org/fhir/search.html#revinclude'
           description %(
             A Server SHALL be capable of supporting the following _revincludes: Provenance:target
@@ -357,7 +373,7 @@ module Inferno
 
       test 'DocumentReference resources returned conform to US Core R4 profiles' do
         metadata do
-          id '13'
+          id '14'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'
           description %(
 
@@ -374,7 +390,7 @@ module Inferno
 
       test 'All must support elements are provided in the DocumentReference resources returned.' do
         metadata do
-          id '14'
+          id '15'
           link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
           description %(
 
@@ -456,7 +472,7 @@ module Inferno
 
       test 'Every reference within DocumentReference resource is valid and can be read.' do
         metadata do
-          id '15'
+          id '16'
           link 'http://hl7.org/fhir/references.html'
           description %(
             This test checks if references found in resources from prior searches can be resolved.

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -343,7 +343,7 @@ module Inferno
         end
 
         skip_if_not_supported(:DocumentReference, [], [:docref])
-        search_string = "/DocumentRefernce/$docref?patient=#{@instance.patient_id}"
+        search_string = "/DocumentReference/$docref?patient=#{@instance.patient_id}"
         reply = @client.get(search_string, @client.fhir_headers)
         assert_response_ok(reply)
       end

--- a/test/unit/server_capabilities_test.rb
+++ b/test/unit/server_capabilities_test.rb
@@ -79,15 +79,18 @@ class ServerCapabilitiesTest < MiniTest::Test
     expected_interactions = [
       {
         resource_type: 'Patient',
-        interactions: ['history-instance', 'read', 'search', 'vread']
+        interactions: ['history-instance', 'read', 'search', 'vread'],
+        operations: []
       },
       {
         resource_type: 'Condition',
-        interactions: ['delete', 'update']
+        interactions: ['delete', 'update'],
+        operations: []
       },
       {
         resource_type: 'Observation',
-        interactions: []
+        interactions: [],
+        operations: []
       }
     ]
 


### PR DESCRIPTION
This PR adds a test for the docref operation. It also adds the ability to check the server capabilities for resource operation support. The test itself skips if docref is not supported in the capability statement. It performs the GET request and asserts it's 200 response. I don't check if anything is returned because returning an empty bundle is valid when the server can't generate the CCD. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR:
- [X] Internal ticket links to this PR
- [x ] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
