### PR TITLE
FI-573 Add reference to a dependent ruby file in token refresh sequence.

### DIFF
--- a/lib/modules/smart/token_refresh_sequence.rb
+++ b/lib/modules/smart/token_refresh_sequence.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './shared_launch_tests'
+
 module Inferno
   module Sequence
     class TokenRefreshSequence < SequenceBase


### PR DESCRIPTION
Fixes bug that causes inferno to crash depending on the order that a given environment loads ruby files.


**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR:
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
