### PR TITLE
Fi 581 do not skip on capability check when no capability statement loaded

### DIFF
--- a/generator/uscore/templates/module.yml.erb
+++ b/generator/uscore/templates/module.yml.erb
@@ -7,20 +7,18 @@ test_sets:
   ad_hoc_testing:
     view: default
     tests:
-      - name: Discovery
+      - name: SMART App Launch
         sequences:
-        - UsCoreR4CapabilityStatementSequence
         - SMARTDiscoverySequence
-        run_all: true
-      - name: Authorization and Authentication
-        sequences:
         - DynamicRegistrationSequence
         - ManualRegistrationSequence
         - StandaloneLaunchSequence
         - EHRLaunchSequence
-      - name: US Core R4 Patient Based Profiles
+      - name: US Core v3.1.0 Profiles
         run_all: true
-        sequences:<% non_delayed_sequences.each do |sequence| %>
+        sequences:
+        - UsCoreR4CapabilityStatementSequence
+        - USCore310PatientSequence<% non_delayed_sequences.each do |sequence| %>
         - <%=sequence[:class_name]%><% end %>
         - USCoreR4ClinicalNotesSequence<% delayed_sequences.each do |sequence| %>
         - <%=sequence[:class_name]%><% end %>

--- a/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
@@ -15,6 +15,10 @@ describe 'unauthorized search test' do
 
   it 'skips if the <%= resource_type %> search interaction is not supported' do
     @instance.server_capabilities.destroy
+    Inferno::Models::ServerCapabilities.create(
+      testing_instance_id: @instance.id,
+      capabilities: FHIR::CapabilityStatement.new.to_json
+    )
     @instance.reload
     exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -10,6 +10,10 @@ describe '<%= resource_type %> read test' do
 
   it 'skips if the <%= resource_type %> read interaction is not supported' do
     @instance.server_capabilities.destroy
+    Inferno::Models::ServerCapabilities.create(
+      testing_instance_id: @instance.id,
+      capabilities: FHIR::CapabilityStatement.new.to_json
+    )
     @instance.reload
     exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -121,7 +121,7 @@ module Inferno
         }
 
         read_test[:test_code] = %(
-              skip_if_not_supported(:#{sequence[:resource]}, [:read])
+              skip_if_known_not_supported(:#{sequence[:resource]}, [:read])
 
               #{sequence[:resource].underscore}_references = @instance.resource_references.select { |reference| reference.resource_type == '#{sequence[:resource]}' }
               skip 'No #{sequence[:resource]} references found from the prior searches' if #{sequence[:resource].underscore}_references.blank?
@@ -161,7 +161,7 @@ module Inferno
         unit_test_params = get_search_param_hash(search_parameters, sequence, true)
 
         authorization_test[:test_code] = %(
-              skip_if_not_supported(:#{sequence[:resource]}, [:search])
+              skip_if_known_not_supported(:#{sequence[:resource]}, [:search])
 
               @client.set_no_auth
               omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -190,7 +190,7 @@ module Inferno
         }
 
         docref_test[:test_code] = %(
-          skip_if_not_supported(:#{sequence[:resource]}, [], [:docref])
+          skip_if_known_not_supported(:#{sequence[:resource]}, [], [:docref])
           search_string = "/DocumentReference/$docref?patient=\#{@instance.patient_id}"
           reply = @client.get(search_string, @client.fhir_headers)
           assert_response_ok(reply)
@@ -320,7 +320,7 @@ module Inferno
         }
 
         interaction_test[:test_code] = %(
-              skip_if_not_supported(:#{sequence[:resource]}, [:#{interaction[:code]}])
+              skip_if_known_not_supported(:#{sequence[:resource]}, [:#{interaction[:code]}])
               skip 'No #{sequence[:resource]} resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
               validate_#{interaction[:code]}_reply(@#{sequence[:resource].underscore}, versioned_resource_class('#{sequence[:resource]}')))
@@ -481,7 +481,7 @@ module Inferno
         }
 
         test[:test_code] = %(
-              skip_if_not_supported(:#{sequence[:resource]}, [:search, :read])
+              skip_if_known_not_supported(:#{sequence[:resource]}, [:search, :read])
               #{skip_if_not_found(sequence)}
 
               validate_reference_resolutions(@#{sequence[:resource].underscore}))

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -92,7 +92,7 @@ module Inferno
           sequence[:delayed_sequence] = sequence[:resource] != 'Patient' && sequence[:searches].none? { |search| search[:names].include? 'patient' }
         end
         metadata[:delayed_sequences] = metadata[:sequences].select { |seq| seq[:delayed_sequence] }
-        metadata[:non_delayed_sequences] = metadata[:sequences].reject { |seq| seq[:delayed_sequence] }
+        metadata[:non_delayed_sequences] = metadata[:sequences].reject { |seq| seq[:resource] == 'Patient' || seq[:delayed_sequence] }
       end
 
       def find_first_search(sequence)

--- a/lib/app/utils/skip_helpers.rb
+++ b/lib/app/utils/skip_helpers.rb
@@ -3,9 +3,10 @@
 module Inferno
   module SkipHelpers
     def skip_if_known_not_supported(resource, methods = [], operations = [])
-      # In the case that the user has not run the any capability statement sequences, we 
+      # In the case that the user has not run the any capability statement sequences, we
       # will allow this to silently pass because we don't know if the server supports it or not.
       return if @instance.server_capabilities.nil?
+
       skip_if_not_supported(resource, methods, operations)
     end
 

--- a/lib/app/utils/skip_helpers.rb
+++ b/lib/app/utils/skip_helpers.rb
@@ -2,6 +2,13 @@
 
 module Inferno
   module SkipHelpers
+    def skip_if_known_not_supported(resource, methods = [], operations = [])
+      # In the case that the user has not run the any capability statement sequences, we 
+      # will allow this to silently pass because we don't know if the server supports it or not.
+      return if @instance.server_capabilities.nil?
+      skip_if_not_supported(resource, methods, operations)
+    end
+
     def skip_if_not_supported(resource, methods = [], operations = [])
       skip_message = "This server does not support #{resource} #{(methods + operations).join(',')} operation(s) according to conformance statement."
       skip skip_message unless @instance.conformance_supported?(resource, methods, operations)

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -462,7 +462,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -462,7 +462,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -462,7 +462,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -798,7 +798,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -462,7 +462,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -462,7 +462,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -456,7 +456,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -456,7 +456,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -462,7 +462,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310BodytempSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310BodytempSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310BpSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310BpSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310ResprateSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310ResprateSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
 
     it 'skips if the AllergyIntolerance search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -210,6 +214,10 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
 
     it 'skips if the AllergyIntolerance read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310CareplanSequence do
 
     it 'skips if the CarePlan search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -380,6 +384,10 @@ describe Inferno::Sequence::USCore310CareplanSequence do
 
     it 'skips if the CarePlan read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310CareteamSequence do
 
     it 'skips if the CareTeam search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -176,6 +180,10 @@ describe Inferno::Sequence::USCore310CareteamSequence do
 
     it 'skips if the CareTeam read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310ConditionSequence do
 
     it 'skips if the Condition search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -418,6 +422,10 @@ describe Inferno::Sequence::USCore310ConditionSequence do
 
     it 'skips if the Condition read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
 
     it 'skips if the DiagnosticReport search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -513,6 +517,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
 
     it 'skips if the DiagnosticReport read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
 
     it 'skips if the DiagnosticReport search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -513,6 +517,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
 
     it 'skips if the DiagnosticReport read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
 
     it 'skips if the DocumentReference search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -563,6 +567,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
 
     it 'skips if the DocumentReference read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310EncounterSequence do
 
     it 'skips if the Encounter search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -560,6 +564,10 @@ describe Inferno::Sequence::USCore310EncounterSequence do
 
     it 'skips if the Encounter read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310GoalSequence do
 
     it 'skips if the Goal search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -274,6 +278,10 @@ describe Inferno::Sequence::USCore310GoalSequence do
 
     it 'skips if the Goal read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
 
     it 'skips if the Immunization search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -274,6 +278,10 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
 
     it 'skips if the Immunization read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
 
     it 'skips if the Device search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -210,6 +214,10 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
 
     it 'skips if the Device read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -27,6 +27,10 @@ describe Inferno::Sequence::USCore310LocationSequence do
 
     it 'skips if the Location read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -121,6 +125,10 @@ describe Inferno::Sequence::USCore310LocationSequence do
 
     it 'skips if the Location search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
@@ -27,6 +27,10 @@ describe Inferno::Sequence::USCore310MedicationSequence do
 
     it 'skips if the Medication read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
 
     it 'skips if the MedicationRequest search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -395,6 +399,10 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
 
     it 'skips if the MedicationRequest read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -27,6 +27,10 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
 
     it 'skips if the Organization read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -121,6 +125,10 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
 
     it 'skips if the Organization search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310PatientSequence do
 
     it 'skips if the Patient search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -568,6 +572,10 @@ describe Inferno::Sequence::USCore310PatientSequence do
 
     it 'skips if the Patient read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -27,6 +27,10 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
 
     it 'skips if the Practitioner read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -121,6 +125,10 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
 
     it 'skips if the Practitioner search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -27,6 +27,10 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
 
     it 'skips if the PractitionerRole read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -121,6 +125,10 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
 
     it 'skips if the PractitionerRole search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -30,6 +30,10 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
 
     it 'skips if the Procedure search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -339,6 +343,10 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
 
     it 'skips if the Procedure read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
@@ -27,6 +27,10 @@ describe Inferno::Sequence::USCore310ProvenanceSequence do
 
     it 'skips if the Provenance read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -31,6 +31,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
 
     it 'skips if the Observation search interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -451,6 +455,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
 
     it 'skips if the Observation read interaction is not supported' do
       @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
       @instance.reload
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -43,7 +43,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:AllergyIntolerance, [:search])
+        skip_if_known_not_supported(:AllergyIntolerance, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -129,7 +129,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:AllergyIntolerance, [:read])
+        skip_if_known_not_supported(:AllergyIntolerance, [:read])
         skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'))
@@ -147,7 +147,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:AllergyIntolerance, [:vread])
+        skip_if_known_not_supported(:AllergyIntolerance, [:vread])
         skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'))
@@ -165,7 +165,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:AllergyIntolerance, [:history])
+        skip_if_known_not_supported(:AllergyIntolerance, [:history])
         skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'))
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:AllergyIntolerance, [:search, :read])
+        skip_if_known_not_supported(:AllergyIntolerance, [:search, :read])
         skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@allergy_intolerance)

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CarePlan, [:search])
+        skip_if_known_not_supported(:CarePlan, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -216,7 +216,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CarePlan, [:read])
+        skip_if_known_not_supported(:CarePlan, [:read])
         skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@care_plan, versioned_resource_class('CarePlan'))
@@ -234,7 +234,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CarePlan, [:vread])
+        skip_if_known_not_supported(:CarePlan, [:vread])
         skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@care_plan, versioned_resource_class('CarePlan'))
@@ -252,7 +252,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CarePlan, [:history])
+        skip_if_known_not_supported(:CarePlan, [:history])
         skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@care_plan, versioned_resource_class('CarePlan'))
@@ -362,7 +362,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CarePlan, [:search, :read])
+        skip_if_known_not_supported(:CarePlan, [:search, :read])
         skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@care_plan)

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -43,7 +43,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CareTeam, [:search])
+        skip_if_known_not_supported(:CareTeam, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -108,7 +108,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CareTeam, [:read])
+        skip_if_known_not_supported(:CareTeam, [:read])
         skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@care_team, versioned_resource_class('CareTeam'))
@@ -126,7 +126,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CareTeam, [:vread])
+        skip_if_known_not_supported(:CareTeam, [:vread])
         skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@care_team, versioned_resource_class('CareTeam'))
@@ -144,7 +144,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CareTeam, [:history])
+        skip_if_known_not_supported(:CareTeam, [:history])
         skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@care_team, versioned_resource_class('CareTeam'))
@@ -272,7 +272,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:CareTeam, [:search, :read])
+        skip_if_known_not_supported(:CareTeam, [:search, :read])
         skip 'No CareTeam resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@care_team)

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Condition, [:search])
+        skip_if_known_not_supported(:Condition, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -230,7 +230,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Condition, [:read])
+        skip_if_known_not_supported(:Condition, [:read])
         skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@condition, versioned_resource_class('Condition'))
@@ -248,7 +248,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Condition, [:vread])
+        skip_if_known_not_supported(:Condition, [:vread])
         skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@condition, versioned_resource_class('Condition'))
@@ -266,7 +266,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Condition, [:history])
+        skip_if_known_not_supported(:Condition, [:history])
         skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@condition, versioned_resource_class('Condition'))
@@ -368,7 +368,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Condition, [:search, :read])
+        skip_if_known_not_supported(:Condition, [:search, :read])
         skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@condition)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:search])
+        skip_if_known_not_supported(:DiagnosticReport, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -267,7 +267,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:read])
+        skip_if_known_not_supported(:DiagnosticReport, [:read])
         skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
@@ -285,7 +285,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:vread])
+        skip_if_known_not_supported(:DiagnosticReport, [:vread])
         skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
@@ -303,7 +303,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:history])
+        skip_if_known_not_supported(:DiagnosticReport, [:history])
         skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
@@ -422,7 +422,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:search, :read])
+        skip_if_known_not_supported(:DiagnosticReport, [:search, :read])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@diagnostic_report)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:search])
+        skip_if_known_not_supported(:DiagnosticReport, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -267,7 +267,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:read])
+        skip_if_known_not_supported(:DiagnosticReport, [:read])
         skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
@@ -285,7 +285,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:vread])
+        skip_if_known_not_supported(:DiagnosticReport, [:vread])
         skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
@@ -303,7 +303,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:history])
+        skip_if_known_not_supported(:DiagnosticReport, [:history])
         skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
@@ -422,7 +422,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DiagnosticReport, [:search, :read])
+        skip_if_known_not_supported(:DiagnosticReport, [:search, :read])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@diagnostic_report)

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -63,7 +63,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DocumentReference, [:search])
+        skip_if_known_not_supported(:DocumentReference, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -290,7 +290,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DocumentReference, [:read])
+        skip_if_known_not_supported(:DocumentReference, [:read])
         skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@document_reference, versioned_resource_class('DocumentReference'))
@@ -308,7 +308,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DocumentReference, [:vread])
+        skip_if_known_not_supported(:DocumentReference, [:vread])
         skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@document_reference, versioned_resource_class('DocumentReference'))
@@ -326,7 +326,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DocumentReference, [:history])
+        skip_if_known_not_supported(:DocumentReference, [:history])
         skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@document_reference, versioned_resource_class('DocumentReference'))
@@ -342,7 +342,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DocumentReference, [], [:docref])
+        skip_if_known_not_supported(:DocumentReference, [], [:docref])
         search_string = "/DocumentReference/$docref?patient=#{@instance.patient_id}"
         reply = @client.get(search_string, @client.fhir_headers)
         assert_response_ok(reply)
@@ -480,7 +480,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:DocumentReference, [:search, :read])
+        skip_if_known_not_supported(:DocumentReference, [:search, :read])
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@document_reference)

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -63,7 +63,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Encounter, [:search])
+        skip_if_known_not_supported(:Encounter, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -288,7 +288,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Encounter, [:read])
+        skip_if_known_not_supported(:Encounter, [:read])
         skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@encounter, versioned_resource_class('Encounter'))
@@ -306,7 +306,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Encounter, [:vread])
+        skip_if_known_not_supported(:Encounter, [:vread])
         skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@encounter, versioned_resource_class('Encounter'))
@@ -324,7 +324,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Encounter, [:history])
+        skip_if_known_not_supported(:Encounter, [:history])
         skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@encounter, versioned_resource_class('Encounter'))
@@ -462,7 +462,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Encounter, [:search, :read])
+        skip_if_known_not_supported(:Encounter, [:search, :read])
         skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@encounter)

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -47,7 +47,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Goal, [:search])
+        skip_if_known_not_supported(:Goal, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -168,7 +168,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Goal, [:read])
+        skip_if_known_not_supported(:Goal, [:read])
         skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@goal, versioned_resource_class('Goal'))
@@ -186,7 +186,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Goal, [:vread])
+        skip_if_known_not_supported(:Goal, [:vread])
         skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@goal, versioned_resource_class('Goal'))
@@ -204,7 +204,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Goal, [:history])
+        skip_if_known_not_supported(:Goal, [:history])
         skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@goal, versioned_resource_class('Goal'))
@@ -306,7 +306,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Goal, [:search, :read])
+        skip_if_known_not_supported(:Goal, [:search, :read])
         skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@goal)

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -47,7 +47,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Immunization, [:search])
+        skip_if_known_not_supported(:Immunization, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -168,7 +168,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Immunization, [:read])
+        skip_if_known_not_supported(:Immunization, [:read])
         skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@immunization, versioned_resource_class('Immunization'))
@@ -186,7 +186,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Immunization, [:vread])
+        skip_if_known_not_supported(:Immunization, [:vread])
         skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@immunization, versioned_resource_class('Immunization'))
@@ -204,7 +204,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Immunization, [:history])
+        skip_if_known_not_supported(:Immunization, [:history])
         skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@immunization, versioned_resource_class('Immunization'))
@@ -312,7 +312,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Immunization, [:search, :read])
+        skip_if_known_not_supported(:Immunization, [:search, :read])
         skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@immunization)

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -43,7 +43,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Device, [:search])
+        skip_if_known_not_supported(:Device, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -129,7 +129,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Device, [:read])
+        skip_if_known_not_supported(:Device, [:read])
         skip 'No Device resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@device, versioned_resource_class('Device'))
@@ -147,7 +147,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Device, [:vread])
+        skip_if_known_not_supported(:Device, [:vread])
         skip 'No Device resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@device, versioned_resource_class('Device'))
@@ -165,7 +165,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Device, [:history])
+        skip_if_known_not_supported(:Device, [:history])
         skip 'No Device resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@device, versioned_resource_class('Device'))
@@ -285,7 +285,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Device, [:search, :read])
+        skip_if_known_not_supported(:Device, [:search, :read])
         skip 'No Device resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@device)

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -62,7 +62,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Location, [:read])
+        skip_if_known_not_supported(:Location, [:read])
 
         location_references = @instance.resource_references.select { |reference| reference.resource_type == 'Location' }
         skip 'No Location references found from the prior searches' if location_references.blank?
@@ -88,7 +88,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Location, [:search])
+        skip_if_known_not_supported(:Location, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -253,7 +253,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Location, [:vread])
+        skip_if_known_not_supported(:Location, [:vread])
         skip 'No Location resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@location, versioned_resource_class('Location'))
@@ -271,7 +271,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Location, [:history])
+        skip_if_known_not_supported(:Location, [:history])
         skip 'No Location resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@location, versioned_resource_class('Location'))
@@ -386,7 +386,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Location, [:search, :read])
+        skip_if_known_not_supported(:Location, [:search, :read])
         skip 'No Location resources appear to be available.' unless @resources_found
 
         validate_reference_resolutions(@location)

--- a/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
@@ -30,7 +30,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Medication, [:read])
+        skip_if_known_not_supported(:Medication, [:read])
 
         medication_references = @instance.resource_references.select { |reference| reference.resource_type == 'Medication' }
         skip 'No Medication references found from the prior searches' if medication_references.blank?
@@ -57,7 +57,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Medication, [:vread])
+        skip_if_known_not_supported(:Medication, [:vread])
         skip 'No Medication resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@medication, versioned_resource_class('Medication'))
@@ -75,7 +75,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Medication, [:history])
+        skip_if_known_not_supported(:Medication, [:history])
         skip 'No Medication resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@medication, versioned_resource_class('Medication'))
@@ -142,7 +142,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Medication, [:search, :read])
+        skip_if_known_not_supported(:Medication, [:search, :read])
         skip 'No Medication resources appear to be available.' unless @resources_found
 
         validate_reference_resolutions(@medication)

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:MedicationRequest, [:search])
+        skip_if_known_not_supported(:MedicationRequest, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -203,7 +203,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:MedicationRequest, [:read])
+        skip_if_known_not_supported(:MedicationRequest, [:read])
         skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@medication_request, versioned_resource_class('MedicationRequest'))
@@ -221,7 +221,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:MedicationRequest, [:vread])
+        skip_if_known_not_supported(:MedicationRequest, [:vread])
         skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@medication_request, versioned_resource_class('MedicationRequest'))
@@ -239,7 +239,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:MedicationRequest, [:history])
+        skip_if_known_not_supported(:MedicationRequest, [:history])
         skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@medication_request, versioned_resource_class('MedicationRequest'))
@@ -414,7 +414,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:MedicationRequest, [:search, :read])
+        skip_if_known_not_supported(:MedicationRequest, [:search, :read])
         skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@medication_request)

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -426,7 +426,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Organization, [:read])
+        skip_if_known_not_supported(:Organization, [:read])
 
         organization_references = @instance.resource_references.select { |reference| reference.resource_type == 'Organization' }
         skip 'No Organization references found from the prior searches' if organization_references.blank?
@@ -76,7 +76,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Organization, [:search])
+        skip_if_known_not_supported(:Organization, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -163,7 +163,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Organization, [:vread])
+        skip_if_known_not_supported(:Organization, [:vread])
         skip 'No Organization resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@organization, versioned_resource_class('Organization'))
@@ -181,7 +181,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Organization, [:history])
+        skip_if_known_not_supported(:Organization, [:history])
         skip 'No Organization resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@organization, versioned_resource_class('Organization'))
@@ -311,7 +311,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Organization, [:search, :read])
+        skip_if_known_not_supported(:Organization, [:search, :read])
         skip 'No Organization resources appear to be available.' unless @resources_found
 
         validate_reference_resolutions(@organization)

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -70,7 +70,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Patient, [:search])
+        skip_if_known_not_supported(:Patient, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -285,7 +285,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Patient, [:read])
+        skip_if_known_not_supported(:Patient, [:read])
         skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@patient, versioned_resource_class('Patient'))
@@ -303,7 +303,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Patient, [:vread])
+        skip_if_known_not_supported(:Patient, [:vread])
         skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@patient, versioned_resource_class('Patient'))
@@ -321,7 +321,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Patient, [:history])
+        skip_if_known_not_supported(:Patient, [:history])
         skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@patient, versioned_resource_class('Patient'))
@@ -487,7 +487,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Patient, [:search, :read])
+        skip_if_known_not_supported(:Patient, [:search, :read])
         skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@patient)

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Practitioner, [:read])
+        skip_if_known_not_supported(:Practitioner, [:read])
 
         practitioner_references = @instance.resource_references.select { |reference| reference.resource_type == 'Practitioner' }
         skip 'No Practitioner references found from the prior searches' if practitioner_references.blank?
@@ -77,7 +77,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Practitioner, [:search])
+        skip_if_known_not_supported(:Practitioner, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -164,7 +164,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Practitioner, [:vread])
+        skip_if_known_not_supported(:Practitioner, [:vread])
         skip 'No Practitioner resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@practitioner, versioned_resource_class('Practitioner'))
@@ -182,7 +182,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Practitioner, [:history])
+        skip_if_known_not_supported(:Practitioner, [:history])
         skip 'No Practitioner resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@practitioner, versioned_resource_class('Practitioner'))
@@ -288,7 +288,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Practitioner, [:search, :read])
+        skip_if_known_not_supported(:Practitioner, [:search, :read])
         skip 'No Practitioner resources appear to be available.' unless @resources_found
 
         validate_reference_resolutions(@practitioner)

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -44,7 +44,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:PractitionerRole, [:read])
+        skip_if_known_not_supported(:PractitionerRole, [:read])
 
         practitioner_role_references = @instance.resource_references.select { |reference| reference.resource_type == 'PractitionerRole' }
         skip 'No PractitionerRole references found from the prior searches' if practitioner_role_references.blank?
@@ -70,7 +70,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:PractitionerRole, [:search])
+        skip_if_known_not_supported(:PractitionerRole, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -157,7 +157,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:PractitionerRole, [:vread])
+        skip_if_known_not_supported(:PractitionerRole, [:vread])
         skip 'No PractitionerRole resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@practitioner_role, versioned_resource_class('PractitionerRole'))
@@ -175,7 +175,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:PractitionerRole, [:history])
+        skip_if_known_not_supported(:PractitionerRole, [:history])
         skip 'No PractitionerRole resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@practitioner_role, versioned_resource_class('PractitionerRole'))
@@ -321,7 +321,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:PractitionerRole, [:search, :read])
+        skip_if_known_not_supported(:PractitionerRole, [:search, :read])
         skip 'No PractitionerRole resources appear to be available.' unless @resources_found
 
         validate_reference_resolutions(@practitioner_role)

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Procedure, [:search])
+        skip_if_known_not_supported(:Procedure, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -207,7 +207,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Procedure, [:read])
+        skip_if_known_not_supported(:Procedure, [:read])
         skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@procedure, versioned_resource_class('Procedure'))
@@ -225,7 +225,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Procedure, [:vread])
+        skip_if_known_not_supported(:Procedure, [:vread])
         skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@procedure, versioned_resource_class('Procedure'))
@@ -243,7 +243,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Procedure, [:history])
+        skip_if_known_not_supported(:Procedure, [:history])
         skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@procedure, versioned_resource_class('Procedure'))
@@ -345,7 +345,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Procedure, [:search, :read])
+        skip_if_known_not_supported(:Procedure, [:search, :read])
         skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@procedure)

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -30,7 +30,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Provenance, [:read])
+        skip_if_known_not_supported(:Provenance, [:read])
 
         provenance_references = @instance.resource_references.select { |reference| reference.resource_type == 'Provenance' }
         skip 'No Provenance references found from the prior searches' if provenance_references.blank?
@@ -57,7 +57,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Provenance, [:vread])
+        skip_if_known_not_supported(:Provenance, [:vread])
         skip 'No Provenance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@provenance, versioned_resource_class('Provenance'))
@@ -75,7 +75,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Provenance, [:history])
+        skip_if_known_not_supported(:Provenance, [:history])
         skip 'No Provenance resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@provenance, versioned_resource_class('Provenance'))
@@ -169,7 +169,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Provenance, [:search, :read])
+        skip_if_known_not_supported(:Provenance, [:search, :read])
         skip 'No Provenance resources appear to be available.' unless @resources_found
 
         validate_reference_resolutions(@provenance)

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -822,7 +822,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search])
+        skip_if_known_not_supported(:Observation, [:search])
 
         @client.set_no_auth
         omit 'Do not test if no bearer token set' if @instance.token.blank?
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:read])
+        skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_read_reply(@observation, versioned_resource_class('Observation'))
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:vread])
+        skip_if_known_not_supported(:Observation, [:vread])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
@@ -280,7 +280,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:history])
+        skip_if_known_not_supported(:Observation, [:history])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
@@ -384,7 +384,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_not_supported(:Observation, [:search, :read])
+        skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         validate_reference_resolutions(@observation)

--- a/lib/modules/uscore_v3.1.0_module.yml
+++ b/lib/modules/uscore_v3.1.0_module.yml
@@ -7,20 +7,18 @@ test_sets:
   ad_hoc_testing:
     view: default
     tests:
-      - name: Discovery
+      - name: SMART App Launch
         sequences:
-        - UsCoreR4CapabilityStatementSequence
         - SMARTDiscoverySequence
-        run_all: true
-      - name: Authorization and Authentication
-        sequences:
         - DynamicRegistrationSequence
         - ManualRegistrationSequence
         - StandaloneLaunchSequence
         - EHRLaunchSequence
-      - name: US Core R4 Patient Based Profiles
+      - name: US Core v3.1.0 Profiles
         run_all: true
         sequences:
+        - UsCoreR4CapabilityStatementSequence
+        - USCore310PatientSequence
         - USCore310AllergyintoleranceSequence
         - USCore310CareplanSequence
         - USCore310CareteamSequence
@@ -45,7 +43,6 @@ test_sets:
         - USCore310HeadcircumSequence
         - USCore310HeartrateSequence
         - USCore310ResprateSequence
-        - USCore310PatientSequence
         - USCore310ProcedureSequence
         - USCoreR4ClinicalNotesSequence
         - USCore310LocationSequence


### PR DESCRIPTION
When in community edition, running the profile tests will skip if you haven't first run the capability sequence.  This doesn't make sense in the context of the community edition.  Change so that if no capability statement is loaded, we do not skip, because we do not know if they support or do not support a capability.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR:
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
