### PR TITLE
FI-569: Add chained search tests

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -238,8 +238,20 @@ module Inferno
             expectation = expectation_extension[index]['extension'].first['valueCode'] unless expectation_extension.nil?
             param_metadata[:comparators][comparator.to_sym] = expectation
           end
+
           multiple_or_expectation = search_param_definition['_multipleOr']['extension'].first['valueCode']
           param_metadata[:multiple_or] = multiple_or_expectation
+
+          if search_param_definition['chain'].present?
+            binding.pry
+            expectations =
+              search_param_definition['_chain']
+                .map { |expectation| expectation['extension'].first['valueCode'] }
+            param_metadata[:chain] =
+              search_param_definition['chain'].zip(expectations)
+                .map { |chain, expectation| { chain: chain, expectation: expectation }  }
+          end
+
           sequence[:search_param_descriptions][param] = param_metadata
         end
       end

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -243,13 +243,12 @@ module Inferno
           param_metadata[:multiple_or] = multiple_or_expectation
 
           if search_param_definition['chain'].present?
-            binding.pry
             expectations =
               search_param_definition['_chain']
                 .map { |expectation| expectation['extension'].first['valueCode'] }
             param_metadata[:chain] =
               search_param_definition['chain'].zip(expectations)
-                .map { |chain, expectation| { chain: chain, expectation: expectation }  }
+                .map { |chain, expectation| { chain: chain, expectation: expectation } }
           end
 
           sequence[:search_param_descriptions][param] = param_metadata

--- a/generator/uscore/templates/unit_tests/chained_search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/chained_search_unit_test.rb.erb
@@ -1,0 +1,182 @@
+describe 'PractitionerRole chained search by practitioner test' do
+  before do
+    @test = @sequence_class[:chained_search_by_practitioner]
+    @sequence = @sequence_class.new(@instance, @client)
+    @practitioner = FHIR::Practitioner.new(name: [{ family: 'FAMILY_NAME' }])
+    identifier_system = 'http://www.example.com/system'
+    identifier_value = 'IDENTIFIER'
+    @practitioner_with_identifier = FHIR::Practitioner.new(
+      identifier: [{ system: identifier_system, value: identifier_value }],
+      name: [{ family: 'FAMILY_NAME' }]
+    )
+    @identifier_string = "#{identifier_system}|#{identifier_value}"
+    @practitioner_role = FHIR::PractitionerRole.new(
+      id: '123',
+      practitioner: { reference: 'Practitioner/practitioner1' }
+    )
+
+    @sequence.instance_variable_set(:'@practitioner_role_ary', [@practitioner_role])
+    @sequence.instance_variable_set(:'@resources_found', true)
+  end
+
+  it 'skips if no PractitionerRole resources have been found' do
+    @sequence.instance_variable_set(:'@resources_found', false)
+
+    exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+    assert_equal 'No PractitionerRole resources appear to be available.', exception.message
+  end
+
+  it 'skips if no PractitionerRoles contain a Practitioner reference' do
+    @sequence.instance_variable_set(:'@practitioner_role_ary', [FHIR::PractitionerRole.new])
+
+    exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+    assert_equal 'No PractitionerRoles containing a Practitioner reference were found', exception.message
+  end
+
+  it 'fails if the Practitioner can not be fetched' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 400)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_match(/Unable to resolve Practitioner reference:/, exception.message)
+  end
+
+  it 'fails if a Practitioner resource in not received' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal 'Expected FHIR Practitioner but found: Patient', exception.message
+  end
+
+  it 'skips if the Practitioner has no family name' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: FHIR::Practitioner.new.to_json)
+
+    exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+    assert_equal 'Practitioner has no family name', exception.message
+  end
+
+  it 'fails if searching by practitioner.name returns a non-success response' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 400)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal 'Bad response code: expected 200, 201, but found 400. ', exception.message
+  end
+
+  it 'fails if searching by practitioner.name does not return a Bundle' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 200, body: @practitioner_role.to_json)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal 'Expected FHIR Bundle but found: PractitionerRole', exception.message
+  end
+
+  it 'fails if searching by practitioner.name does not return the expected PractitionerRole' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::PractitionerRole.new]).to_json)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal 'PractitionerRole with id 123 not found in search results for practitioner.name = FAMILY_NAME', exception.message
+  end
+
+  it 'skips if the Practitioner has no identifier' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+
+    exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+    assert_equal 'Practitioner has no identifier', exception.message
+  end
+
+  it 'fails if searching by practitioner.identifier returns a non-success response' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
+      .to_return(status: 400)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal 'Bad response code: expected 200, 201, but found 400. ', exception.message
+  end
+
+  it 'fails if searching by practitioner.identifier does not return a Bundle' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
+      .to_return(status: 200, body: FHIR::PractitionerRole.new.to_json)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal 'Expected FHIR Bundle but found: PractitionerRole', exception.message
+  end
+
+  it 'fails if searching by practitioner.identifier does not return the expected PractitionerRole' do
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
+      .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::PractitionerRole.new]).to_json)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal "PractitionerRole with id 123 not found in search results for practitioner.identifier = #{@identifier_string}", exception.message
+  end
+
+  it 'succeeds if the PractitionerRole is found in both chained searches' do
+    bundle = wrap_resources_in_bundle([@practitioner_role])
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 200, body: bundle.to_json)
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
+      .to_return(status: 200, body: bundle.to_json)
+
+    @sequence.run_test(@test)
+  end
+end

--- a/generator/uscore/templates/unit_tests/chained_search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/chained_search_unit_test.rb.erb
@@ -19,6 +19,24 @@ describe 'PractitionerRole chained search by practitioner test' do
     @sequence.instance_variable_set(:'@resources_found', true)
   end
 
+  def stub_name_search
+    stub_request(:get, "#{@base_url}/PractitionerRole")
+      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+  end
+
+  def stub_practitioner_read
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+  end
+
+  def stub_practitioner_read_without_identifier
+    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @practitioner.to_json)
+  end
+
   it 'skips if no PractitionerRole resources have been found' do
     @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -66,9 +84,7 @@ describe 'PractitionerRole chained search by practitioner test' do
   end
 
   it 'fails if searching by practitioner.name returns a non-success response' do
-    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-      .with(headers: @auth_header)
-      .to_return(status: 200, body: @practitioner.to_json)
+    stub_practitioner_read_without_identifier
     stub_request(:get, "#{@base_url}/PractitionerRole")
       .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
       .to_return(status: 400)
@@ -79,9 +95,7 @@ describe 'PractitionerRole chained search by practitioner test' do
   end
 
   it 'fails if searching by practitioner.name does not return a Bundle' do
-    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-      .with(headers: @auth_header)
-      .to_return(status: 200, body: @practitioner.to_json)
+    stub_practitioner_read_without_identifier
     stub_request(:get, "#{@base_url}/PractitionerRole")
       .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
       .to_return(status: 200, body: @practitioner_role.to_json)
@@ -92,9 +106,7 @@ describe 'PractitionerRole chained search by practitioner test' do
   end
 
   it 'fails if searching by practitioner.name does not return the expected PractitionerRole' do
-    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-      .with(headers: @auth_header)
-      .to_return(status: 200, body: @practitioner.to_json)
+    stub_practitioner_read_without_identifier
     stub_request(:get, "#{@base_url}/PractitionerRole")
       .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
       .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::PractitionerRole.new]).to_json)
@@ -105,12 +117,8 @@ describe 'PractitionerRole chained search by practitioner test' do
   end
 
   it 'skips if the Practitioner has no identifier' do
-    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-      .with(headers: @auth_header)
-      .to_return(status: 200, body: @practitioner.to_json)
-    stub_request(:get, "#{@base_url}/PractitionerRole")
-      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+    stub_practitioner_read_without_identifier
+    stub_name_search
 
     exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -118,12 +126,8 @@ describe 'PractitionerRole chained search by practitioner test' do
   end
 
   it 'fails if searching by practitioner.identifier returns a non-success response' do
-    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-      .with(headers: @auth_header)
-      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
-    stub_request(:get, "#{@base_url}/PractitionerRole")
-      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+    stub_practitioner_read
+    stub_name_search
     stub_request(:get, "#{@base_url}/PractitionerRole")
       .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
       .to_return(status: 400)
@@ -134,12 +138,8 @@ describe 'PractitionerRole chained search by practitioner test' do
   end
 
   it 'fails if searching by practitioner.identifier does not return a Bundle' do
-    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-      .with(headers: @auth_header)
-      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
-    stub_request(:get, "#{@base_url}/PractitionerRole")
-      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+    stub_practitioner_read
+    stub_name_search
     stub_request(:get, "#{@base_url}/PractitionerRole")
       .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
       .to_return(status: 200, body: FHIR::PractitionerRole.new.to_json)
@@ -150,12 +150,8 @@ describe 'PractitionerRole chained search by practitioner test' do
   end
 
   it 'fails if searching by practitioner.identifier does not return the expected PractitionerRole' do
-    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-      .with(headers: @auth_header)
-      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
-    stub_request(:get, "#{@base_url}/PractitionerRole")
-      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+    stub_practitioner_read
+    stub_name_search
     stub_request(:get, "#{@base_url}/PractitionerRole")
       .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
       .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::PractitionerRole.new]).to_json)
@@ -166,16 +162,11 @@ describe 'PractitionerRole chained search by practitioner test' do
   end
 
   it 'succeeds if the PractitionerRole is found in both chained searches' do
-    bundle = wrap_resources_in_bundle([@practitioner_role])
-    stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-      .with(headers: @auth_header)
-      .to_return(status: 200, body: @practitioner_with_identifier.to_json)
-    stub_request(:get, "#{@base_url}/PractitionerRole")
-      .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-      .to_return(status: 200, body: bundle.to_json)
+    stub_practitioner_read
+    stub_name_search
     stub_request(:get, "#{@base_url}/PractitionerRole")
       .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
-      .to_return(status: 200, body: bundle.to_json)
+      .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
 
     @sequence.run_test(@test)
   end

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -99,6 +99,12 @@ module Inferno
         tests[class_name] << test
       end
 
+      def generate_chained_search_test(class_name:)
+        template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'chained_search_unit_test.rb.erb')))
+
+        tests[class_name] << template.result
+      end
+
       def no_resources_found_message(interaction_test, resource_type)
         if interaction_test
           "No #{resource_type} resources could be found for this patient. Please use patients with more information."

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -321,6 +321,8 @@ module Inferno
       def create_chained_search_test(sequence, search_param)
         # NOTE: This test is currently hard-coded because chained searches are
         # only required for PractitionerRole
+        raise StandardError, 'Chained search tests only supported for PractitionerRole' if sequence[:resource] != 'PractitionerRole'
+
         chained_param_string = sequence[:search_param_descriptions][search_param][:chain]
           .map { |param| "#{search_param}.#{param[:chain]}" }
           .join(' and ')

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -60,6 +60,10 @@ module Inferno
             .select { |search_param| search_param[:expectation] == 'SHOULD' }
             .each { |search_param| create_search_test(sequence, search_param) }
 
+          sequence[:search_param_descriptions]
+            .select { |_, description| description[:chain].present? }
+            .each { |search_param, _| create_chained_search_test(sequence, search_param) }
+
           # make tests for each SHALL and SHOULD interaction
           sequence[:interactions]
             .select { |interaction| ['SHALL', 'SHOULD'].include? interaction[:expectation] }
@@ -312,6 +316,71 @@ module Inferno
           sequence_name: sequence[:name],
           delayed_sequence: sequence[:delayed_sequence]
         )
+      end
+
+      def create_chained_search_test(sequence, search_param)
+        # NOTE: This test is currently hard-coded because chained searches are
+        # only required for PractitionerRole
+        chained_param_string = sequence[:search_param_descriptions][search_param][:chain]
+          .map { |param| "#{search_param}.#{param[:chain]}" }
+          .join(' and ')
+        search_test = {
+          tests_that: "Server returns expected results from #{sequence[:resource]} chained search by #{chained_param_string}",
+          key: :"chained_search_by_#{search_param}",
+          index: sequence[:tests].length + 1,
+          link: 'https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-practitionerrole.html#mandatory-search-parameters',
+          optional: false,
+          description: %(
+            A server SHALL support searching the #{sequence[:resource]} resource
+            with the chained parameters #{chained_param_string}
+          )
+        }
+
+        search_test[:test_code] = %(
+          #{skip_if_not_found(sequence)}
+
+          practitioner_role = @practitioner_role_ary.find { |role| role.practitioner&.reference.present? }
+          skip_if practitioner_role.blank?, 'No PractitionerRoles containing a Practitioner reference were found'
+
+          begin
+            practitioner = practitioner_role.practitioner.read
+          rescue ClientException => e
+            assert false, "Unable to resolve Practitioner reference: \#{e}"
+          end
+
+          assert practitioner.resourceType == 'Practitioner', "Expected FHIR Practitioner but found: \#{practitioner.resourceType}"
+
+          name = practitioner.name&.first&.family
+          skip_if name.blank?, 'Practitioner has no family name'
+
+          name_search_response = @client.search(FHIR::PractitionerRole, search: { parameters: { 'practitioner.name': name }})
+          assert_response_ok(name_search_response)
+          assert_bundle_response(name_search_response)
+
+          name_bundle_entries = fetch_all_bundled_resources(name_search_response.resource)
+
+          practitioner_role_found = name_bundle_entries.any? { |entry| entry.id == practitioner_role.id }
+          assert practitioner_role_found, "PractitionerRole with id \#{practitioner_role.id} not found in search results for practitioner.name = \#{name}"
+
+          identifier = practitioner.identifier.first
+          skip_if identifier.blank?, 'Practitioner has no identifier'
+          identifier_string = "\#{identifier.system}|\#{identifier.value}"
+
+          identifier_search_response = @client.search(
+            FHIR::PractitionerRole,
+            search: { parameters: { 'practitioner.identifier': identifier_string } }
+          )
+          assert_response_ok(identifier_search_response)
+          assert_bundle_response(identifier_search_response)
+
+          identifier_bundle_entries = fetch_all_bundled_resources(identifier_search_response.resource)
+
+          practitioner_role_found = identifier_bundle_entries.any? { |entry| entry.id == practitioner_role.id }
+          assert practitioner_role_found, "PractitionerRole with id \#{practitioner_role.id} not found in search results for practitioner.identifier = \#{identifier_string}"
+        )
+
+        sequence[:tests] << search_test
+        unit_test_generator.generate_chained_search_test(class_name: sequence[:class_name])
       end
 
       def create_interaction_test(sequence, interaction)

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -296,4 +296,187 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
       @sequence.run_test(@test)
     end
   end
+
+  describe 'PractitionerRole chained search by practitioner test' do
+    before do
+      @test = @sequence_class[:chained_search_by_practitioner]
+      @sequence = @sequence_class.new(@instance, @client)
+      @practitioner = FHIR::Practitioner.new(name: [{ family: 'FAMILY_NAME' }])
+      identifier_system = 'http://www.example.com/system'
+      identifier_value = 'IDENTIFIER'
+      @practitioner_with_identifier = FHIR::Practitioner.new(
+        identifier: [{ system: identifier_system, value: identifier_value }],
+        name: [{ family: 'FAMILY_NAME' }]
+      )
+      @identifier_string = "#{identifier_system}|#{identifier_value}"
+      @practitioner_role = FHIR::PractitionerRole.new(
+        id: '123',
+        practitioner: { reference: 'Practitioner/practitioner1' }
+      )
+
+      @sequence.instance_variable_set(:'@practitioner_role_ary', [@practitioner_role])
+      @sequence.instance_variable_set(:'@resources_found', true)
+    end
+
+    it 'skips if no PractitionerRole resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No PractitionerRole resources appear to be available.', exception.message
+    end
+
+    it 'skips if no PractitionerRoles contain a Practitioner reference' do
+      @sequence.instance_variable_set(:'@practitioner_role_ary', [FHIR::PractitionerRole.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No PractitionerRoles containing a Practitioner reference were found', exception.message
+    end
+
+    it 'fails if the Practitioner can not be fetched' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 400)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Unable to resolve Practitioner reference:/, exception.message)
+    end
+
+    it 'fails if a Practitioner resource in not received' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Practitioner but found: Patient', exception.message
+    end
+
+    it 'skips if the Practitioner has no family name' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Practitioner.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'Practitioner has no family name', exception.message
+    end
+
+    it 'fails if searching by practitioner.name returns a non-success response' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 400)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 400. ', exception.message
+    end
+
+    it 'fails if searching by practitioner.name does not return a Bundle' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 200, body: @practitioner_role.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: PractitionerRole', exception.message
+    end
+
+    it 'fails if searching by practitioner.name does not return the expected PractitionerRole' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::PractitionerRole.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'PractitionerRole with id 123 not found in search results for practitioner.name = FAMILY_NAME', exception.message
+    end
+
+    it 'skips if the Practitioner has no identifier' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'Practitioner has no identifier', exception.message
+    end
+
+    it 'fails if searching by practitioner.identifier returns a non-success response' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
+        .to_return(status: 400)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 400. ', exception.message
+    end
+
+    it 'fails if searching by practitioner.identifier does not return a Bundle' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
+        .to_return(status: 200, body: FHIR::PractitionerRole.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: PractitionerRole', exception.message
+    end
+
+    it 'fails if searching by practitioner.identifier does not return the expected PractitionerRole' do
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::PractitionerRole.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal "PractitionerRole with id 123 not found in search results for practitioner.identifier = #{@identifier_string}", exception.message
+    end
+
+    it 'succeeds if the PractitionerRole is found in both chained searches' do
+      bundle = wrap_resources_in_bundle([@practitioner_role])
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 200, body: bundle.to_json)
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
+        .to_return(status: 200, body: bundle.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -318,6 +318,24 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
       @sequence.instance_variable_set(:'@resources_found', true)
     end
 
+    def stub_name_search
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
+        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+    end
+
+    def stub_practitioner_read
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
+    end
+
+    def stub_practitioner_read_without_identifier
+      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @practitioner.to_json)
+    end
+
     it 'skips if no PractitionerRole resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -365,9 +383,7 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'fails if searching by practitioner.name returns a non-success response' do
-      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-        .with(headers: @auth_header)
-        .to_return(status: 200, body: @practitioner.to_json)
+      stub_practitioner_read_without_identifier
       stub_request(:get, "#{@base_url}/PractitionerRole")
         .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
         .to_return(status: 400)
@@ -378,9 +394,7 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'fails if searching by practitioner.name does not return a Bundle' do
-      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-        .with(headers: @auth_header)
-        .to_return(status: 200, body: @practitioner.to_json)
+      stub_practitioner_read_without_identifier
       stub_request(:get, "#{@base_url}/PractitionerRole")
         .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
         .to_return(status: 200, body: @practitioner_role.to_json)
@@ -391,9 +405,7 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'fails if searching by practitioner.name does not return the expected PractitionerRole' do
-      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-        .with(headers: @auth_header)
-        .to_return(status: 200, body: @practitioner.to_json)
+      stub_practitioner_read_without_identifier
       stub_request(:get, "#{@base_url}/PractitionerRole")
         .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
         .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::PractitionerRole.new]).to_json)
@@ -404,12 +416,8 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'skips if the Practitioner has no identifier' do
-      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-        .with(headers: @auth_header)
-        .to_return(status: 200, body: @practitioner.to_json)
-      stub_request(:get, "#{@base_url}/PractitionerRole")
-        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+      stub_practitioner_read_without_identifier
+      stub_name_search
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -417,12 +425,8 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'fails if searching by practitioner.identifier returns a non-success response' do
-      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-        .with(headers: @auth_header)
-        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
-      stub_request(:get, "#{@base_url}/PractitionerRole")
-        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+      stub_practitioner_read
+      stub_name_search
       stub_request(:get, "#{@base_url}/PractitionerRole")
         .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
         .to_return(status: 400)
@@ -433,12 +437,8 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'fails if searching by practitioner.identifier does not return a Bundle' do
-      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-        .with(headers: @auth_header)
-        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
-      stub_request(:get, "#{@base_url}/PractitionerRole")
-        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+      stub_practitioner_read
+      stub_name_search
       stub_request(:get, "#{@base_url}/PractitionerRole")
         .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
         .to_return(status: 200, body: FHIR::PractitionerRole.new.to_json)
@@ -449,12 +449,8 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'fails if searching by practitioner.identifier does not return the expected PractitionerRole' do
-      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-        .with(headers: @auth_header)
-        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
-      stub_request(:get, "#{@base_url}/PractitionerRole")
-        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
+      stub_practitioner_read
+      stub_name_search
       stub_request(:get, "#{@base_url}/PractitionerRole")
         .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
         .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::PractitionerRole.new]).to_json)
@@ -465,16 +461,11 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'succeeds if the PractitionerRole is found in both chained searches' do
-      bundle = wrap_resources_in_bundle([@practitioner_role])
-      stub_request(:get, "#{@base_url}/#{@practitioner_role.practitioner.reference}")
-        .with(headers: @auth_header)
-        .to_return(status: 200, body: @practitioner_with_identifier.to_json)
-      stub_request(:get, "#{@base_url}/PractitionerRole")
-        .with(headers: @auth_header, query: { 'practitioner.name': @practitioner.name.first.family })
-        .to_return(status: 200, body: bundle.to_json)
+      stub_practitioner_read
+      stub_name_search
       stub_request(:get, "#{@base_url}/PractitionerRole")
         .with(headers: @auth_header, query: { 'practitioner.identifier': @identifier_string })
-        .to_return(status: 200, body: bundle.to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([@practitioner_role]).to_json)
 
       @sequence.run_test(@test)
     end


### PR DESCRIPTION
This branch adds a test for the chained search parameters US Core requires for PractitionerRole (practitioner.name and practitioner.identifier). Although this test was added to the US Core generator, the test itself and its unit test are hard coded. Implementing chained search tests in a generic manner would require a much larger amount of effort and isn't necessary to support these two chained parameters.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-569
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
