### PR TITLE
FI-564: Require code in CodeableConcepts with required bindings

### DIFF
--- a/generator/uscore/templates/unit_tests/resource_validation_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_validation_unit_test.rb.erb
@@ -1,0 +1,37 @@
+describe 'resource validation test' do
+  before do
+    @<%= resource_var_name %>= FHIR::<%= resource_type %>.new(load_json_fixture(:<%= sequence_name %>))
+    @test = @sequence_class[:validate_resources]
+    @sequence = @sequence_class.new(@instance, @client)
+    @sequence.instance_variable_set(:'@resources_found', true)
+
+    Inferno::Models::ResourceReference.create(
+      resource_type: '<%= resource_type %>',
+      resource_id: @<%= resource_var_name %>.id,
+      testing_instance: @instance<% if profile_uri.present? %>,
+      profile: <%= profile_uri %><% end %>
+    )
+  end
+
+  it 'fails if a resource does not contain a code for a CodeableConcept with a required binding' do
+    [<%= concept_paths %>].each do |path|
+      @sequence.resolve_path(@<%= resource_var_name %>, path).each do |concept|
+        concept&.coding&.each do |coding|
+          coding&.code = nil
+          coding&.system = nil
+        end
+        concept&.text = 'abc'
+      end
+    end
+
+    stub_request(:get, "#{@base_url}/<%= resource_type %>/#{@<%= resource_var_name %>.id}")
+      .with(headers: @auth_header)
+      .to_return(status: 200, body: @<%= resource_var_name %>.to_json)
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    [<%= concept_paths %>].each do |path|
+      assert_match(%r{<%= resource_type %>/#{@<%= resource_var_name %>.id}: The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes\.}, exception.message)
+    end
+  end
+end

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -105,6 +105,22 @@ module Inferno
         tests[class_name] << template.result
       end
 
+      def generate_resource_validation_test(test_key:, resource_type:, class_name:, sequence_name:, required_concepts:, profile_uri:)
+        template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'resource_validation_unit_test.rb.erb')))
+        resource_var_name = resource_type.underscore
+
+        test = template.result_with_hash(
+          test_key: test_key,
+          resource_type: resource_type,
+          resource_var_name: resource_var_name,
+          concept_paths: path_array_string(required_concepts),
+          sequence_name: sequence_name,
+          profile_uri: profile_uri
+        )
+
+        tests[class_name] << test
+      end
+
       def no_resources_found_message(interaction_test, resource_type)
         if interaction_test
           "No #{resource_type} resources could be found for this patient. Please use patients with more information."
@@ -151,6 +167,10 @@ module Inferno
           variable_name: match[1],
           resource_path: match[2]
         }
+      end
+
+      def path_array_string(paths)
+        paths.map { |path| "'#{path}'" }.join ', '
       end
     end
   end

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -569,7 +569,10 @@ module Inferno
 
       def validate_resource(resource_type, resource, profile)
         resource_validation_errors = Inferno::RESOURCE_VALIDATOR.validate(resource, versioned_resource_class, profile.url)
+
         errors = resource_validation_errors[:errors]
+        errors.concat(yield resource) if block_given?
+
         @test_warnings.concat resource_validation_errors[:warnings]
         @information_messages.concat resource_validation_errors[:information]
 
@@ -586,7 +589,7 @@ module Inferno
         resource
       end
 
-      def test_resources(resource_type)
+      def test_resources(resource_type, &block)
         references = @instance.resource_references.all(resource_type: resource_type)
         skip_if(
           references.empty?,
@@ -594,27 +597,27 @@ module Inferno
         )
 
         errors = references.map(&:resource_id).flat_map do |resource_id|
+          # binding.pry if resource_type == 'AllergyIntolerance'
           resource = fetch_resource(resource_type, resource_id)
           p = Inferno::ValidationUtil.guess_profile(resource, @instance.fhir_version.to_sym)
           if p
             @profiles_encountered << p.url
-            validate_resource(resource_type, resource, p)
+            validate_resource(resource_type, resource, p, &block)
           else
             warn { assert false, 'No profiles found for this Resource' }
             issues = Inferno::RESOURCE_VALIDATOR.validate(resource, versioned_resource_class)
             issues[:errors]
           end
         end
-        # TODO
-        # bundle = client.next_bundle
+
         assert(errors.empty?, errors.join("<br/>\n"))
       end
 
-      def test_resources_against_profile(resource_type, specified_profile = nil)
+      def test_resources_against_profile(resource_type, specified_profile = nil, &block)
         @profiles_encountered ||= Set.new
         @profiles_failed ||= Hash.new { |hash, key| hash[key] = [] }
 
-        return test_resources(resource_type) if specified_profile.blank?
+        return test_resources(resource_type, &block) if specified_profile.blank?
 
         profile = Inferno::ValidationUtil::DEFINITIONS[specified_profile]
         skip_if(
@@ -643,10 +646,9 @@ module Inferno
         @profiles_encountered << profile.url
 
         errors = resources.flat_map do |resource|
-          validate_resource(resource_type, resource, profile)
+          validate_resource(resource_type, resource, profile, &block)
         end
-        # TODO
-        # bundle = client.next_bundle
+
         assert(errors.empty?, errors.join("<br/>\n"))
       end
 
@@ -711,6 +713,17 @@ module Inferno
           errors = resource_validation_errors[:errors]
         end
         assert(errors.empty?, errors.join("<br/>\n"))
+      end
+
+      def resolve_path(elements, path)
+        elements = Array.wrap(elements)
+        return elements if path.blank?
+
+        paths = path.split('.')
+
+        elements.flat_map do |element|
+          resolve_path(element&.send(paths.first), paths.drop(1).join('.'))
+        end.compact
       end
 
       def resolve_element_from_path(element, path)

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -597,7 +597,6 @@ module Inferno
         )
 
         errors = references.map(&:resource_id).flat_map do |resource_id|
-          # binding.pry if resource_type == 'AllergyIntolerance'
           resource = fetch_resource(resource_type, resource_id)
           p = Inferno::ValidationUtil.guess_profile(resource, @instance.fhir_version.to_sym)
           if p

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/StructureDefinition/bodyheight'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/StructureDefinition/bodytemp'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/StructureDefinition/bodyweight'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/StructureDefinition/bp'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/StructureDefinition/headcircum'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/StructureDefinition/heartrate'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/StructureDefinition/resprate'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -297,4 +297,41 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       @sequence.run_test(@test)
     end
   end
+
+  describe 'resource validation test' do
+    before do
+      @allergy_intolerance = FHIR::AllergyIntolerance.new(load_json_fixture(:us_core_allergyintolerance))
+      @test = @sequence_class[:validate_resources]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance.id,
+        testing_instance: @instance
+      )
+    end
+
+    it 'fails if a resource does not contain a code for a CodeableConcept with a required binding' do
+      ['clinicalStatus', 'verificationStatus'].each do |path|
+        @sequence.resolve_path(@allergy_intolerance, path).each do |concept|
+          concept&.coding&.each do |coding|
+            coding&.code = nil
+            coding&.system = nil
+          end
+          concept&.text = 'abc'
+        end
+      end
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance.id}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @allergy_intolerance.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      ['clinicalStatus', 'verificationStatus'].each do |path|
+        assert_match(%r{AllergyIntolerance/#{@allergy_intolerance.id}: The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes\.}, exception.message)
+      end
+    end
+  end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -505,4 +505,41 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @sequence.run_test(@test)
     end
   end
+
+  describe 'resource validation test' do
+    before do
+      @condition = FHIR::Condition.new(load_json_fixture(:us_core_condition))
+      @test = @sequence_class[:validate_resources]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition.id,
+        testing_instance: @instance
+      )
+    end
+
+    it 'fails if a resource does not contain a code for a CodeableConcept with a required binding' do
+      ['clinicalStatus', 'verificationStatus'].each do |path|
+        @sequence.resolve_path(@condition, path).each do |concept|
+          concept&.coding&.each do |coding|
+            coding&.code = nil
+            coding&.system = nil
+          end
+          concept&.text = 'abc'
+        end
+      end
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition.id}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @condition.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      ['clinicalStatus', 'verificationStatus'].each do |path|
+        assert_match(%r{Condition/#{@condition.id}: The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes\.}, exception.message)
+      end
+    end
+  end
 end

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -650,4 +650,41 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @sequence.run_test(@test)
     end
   end
+
+  describe 'resource validation test' do
+    before do
+      @document_reference = FHIR::DocumentReference.new(load_json_fixture(:us_core_documentreference))
+      @test = @sequence_class[:validate_resources]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference.id,
+        testing_instance: @instance
+      )
+    end
+
+    it 'fails if a resource does not contain a code for a CodeableConcept with a required binding' do
+      ['type'].each do |path|
+        @sequence.resolve_path(@document_reference, path).each do |concept|
+          concept&.coding&.each do |coding|
+            coding&.code = nil
+            coding&.system = nil
+          end
+          concept&.text = 'abc'
+        end
+      end
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference.id}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @document_reference.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      ['type'].each do |path|
+        assert_match(%r{DocumentReference/#{@document_reference.id}: The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes\.}, exception.message)
+      end
+    end
+  end
 end

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -193,21 +193,37 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'AllergyIntolerance resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '08'
+          name 'AllergyIntolerance resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance'
           description %(
 
             This test checks if the resources returned from prior searches conform to the US Core profiles.
             This includes checking for missing data elements and valueset verification.
 
+            This test also checks that the following CodeableConcepts with
+            required ValueSet bindings include a code rather than just text:
+            'clinicalStatus' and 'verificationStatus'
+
           )
           versions :r4
         end
 
         skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
-        test_resources_against_profile('AllergyIntolerance')
+        test_resources_against_profile('AllergyIntolerance') do |resource|
+          ['clinicalStatus', 'verificationStatus'].flat_map do |path|
+            concepts = resolve_path(resource, path)
+            next if concepts.blank?
+
+            code_present = concepts.any? { |concept| concept.coding.any? { |coding| coding.code.present? } }
+
+            unless code_present # rubocop:disable Style/IfUnlessModifier
+              "The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes."
+            end
+          end.compact
+        end
       end
 
       test 'All must support elements are provided in the AllergyIntolerance resources returned.' do

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -281,9 +281,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'CarePlan resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '10'
+          name 'CarePlan resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -176,9 +176,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'CareTeam resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '07'
+          name 'CareTeam resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -330,9 +330,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'DiagnosticReport resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '12'
+          name 'DiagnosticReport resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -330,9 +330,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'DiagnosticReport resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '12'
+          name 'DiagnosticReport resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -365,21 +365,37 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'DocumentReference resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '14'
+          name 'DocumentReference resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'
           description %(
 
             This test checks if the resources returned from prior searches conform to the US Core profiles.
             This includes checking for missing data elements and valueset verification.
 
+            This test also checks that the following CodeableConcepts with
+            required ValueSet bindings include a code rather than just text:
+            'type'
+
           )
           versions :r4
         end
 
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
-        test_resources_against_profile('DocumentReference')
+        test_resources_against_profile('DocumentReference') do |resource|
+          ['type'].flat_map do |path|
+            concepts = resolve_path(resource, path)
+            next if concepts.blank?
+
+            code_present = concepts.any? { |concept| concept.coding.any? { |coding| coding.code.present? } }
+
+            unless code_present # rubocop:disable Style/IfUnlessModifier
+              "The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes."
+            end
+          end.compact
+        end
       end
 
       test 'All must support elements are provided in the DocumentReference resources returned.' do

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -347,9 +347,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Encounter resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '13'
+          name 'Encounter resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -231,9 +231,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Goal resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '09'
+          name 'Goal resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -231,9 +231,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Immunization resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '09'
+          name 'Immunization resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -193,9 +193,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Device resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '08'
+          name 'Device resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -297,9 +297,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Location resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Location resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
@@ -81,9 +81,10 @@ module Inferno
         validate_history_reply(@medication, versioned_resource_class('Medication'))
       end
 
-      test 'Medication resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '04'
+          name 'Medication resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -330,9 +330,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'MedicationRequest resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'MedicationRequest resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -210,9 +210,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Organization resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '08'
+          name 'Organization resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -344,9 +344,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Patient resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '13'
+          name 'Patient resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -211,9 +211,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Practitioner resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '08'
+          name 'Practitioner resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -294,6 +294,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
+          name 'PractitionerRole resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -291,7 +291,7 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'PractitionerRole resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '10'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -269,9 +269,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Procedure resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '10'
+          name 'Procedure resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -81,9 +81,10 @@ module Inferno
         validate_history_reply(@provenance, versioned_resource_class('Provenance'))
       end
 
-      test 'Provenance resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '04'
+          name 'Provenance resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry'
           description %(
 

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -308,9 +308,10 @@ module Inferno
         provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
       end
 
-      test 'Observation resources returned conform to US Core R4 profiles' do
+      test :validate_resources do
         metadata do
           id '11'
+          name 'Observation resources returned conform to US Core R4 profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus'
           description %(
 


### PR DESCRIPTION
The US Core IG states that ["Required binding to a value set definition means that one of the codes from the specified value set SHALL be used and using only text is not valid."](https://www.hl7.org/fhir/us/core/general-guidance.html#required-binding-for-codeableconcept-datatype). This branch adds tests for this to the US Core generator.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-564
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
