### PR TITLE
FI-505 Minor updates to allow for multiple urls.

### DIFF
--- a/lib/app/ext/fhir_client.rb
+++ b/lib/app/ext/fhir_client.rb
@@ -87,8 +87,8 @@ module FHIR
       "Basic #{Base64.strict_encode64(client_id + ':' + client_secret)}"
     end
 
-    def self.for_testing_instance(instance)
-      new(instance.url).tap do |client|
+    def self.for_testing_instance(instance, url_property: 'url')
+      new(instance.send(url_property)).tap do |client|
         client.testing_instance = instance
         case instance.fhir_version
         when 'stu3'

--- a/test/unit/module_validation_test.rb
+++ b/test/unit/module_validation_test.rb
@@ -10,10 +10,17 @@ class ModuleValidationTest < MiniTest::Test
 
   # Within any module, multiple sequences with the same test_id should not ever be loaded.
   # Note that we currently allow duplicates if the same sequence is referenced multiple times.
+  # Also we ignore first children of a single parent
   def test_no_duplicate_test_ids
     errors = []
     @modules&.each do |inferno_module|
-      unique_sequences = inferno_module.sequences.uniq
+      unique_sequences = inferno_module.sequences.uniq do |seq|
+        if seq.parent == Inferno::Sequence::SequenceBase
+          seq
+        else
+          seq.parent
+        end
+      end
       test_ids = unique_sequences.flat_map(&:tests).map(&:id)
       duplicate_id = test_ids.detect { |t| test_ids.count(t) > 1 }
       errors << "#{inferno_module.name} (#{duplicate_id})" unless duplicate_id.nil?


### PR DESCRIPTION
This gives the test writer a bit more flexibility by allowing the client to be generated from a different property than `url`.  It also loosens up the requirement for duplicate test names to allow for multiple children of the same parent to be in one module.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
