### PR TITLE
Fi 600 build errors

### DIFF
--- a/generator/uscore/templates/unit_tests/unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/unit_test.rb.erb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::<%= class_name %> do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: '<%= module_name %>')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: '<%= module_name %>')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, '<%= resource_type %>')

--- a/generator/uscore/templates/unit_tests/unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/unit_test.rb.erb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::<%= class_name %> do
     @sequence_class = Inferno::Sequence::<%= class_name %>
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: '<%= module_name %>', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: '<%= module_name %>')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/generator/uscore/templates/unit_tests/unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/unit_test.rb.erb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::<%= class_name %> do
   before do
     @sequence_class = Inferno::Sequence::<%= class_name %>
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: '<%= module_name %>')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: '<%= module_name %>', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, '<%= resource_type %>')

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310BodyheightSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     @sequence_class = Inferno::Sequence::USCore310BodyheightSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310BodytempSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310BodytempSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     @sequence_class = Inferno::Sequence::USCore310BodytempSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     @sequence_class = Inferno::Sequence::USCore310BodyweightSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310BodyweightSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310BpSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310BpSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     @sequence_class = Inferno::Sequence::USCore310BpSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     @sequence_class = Inferno::Sequence::USCore310HeadcircumSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310HeadcircumSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     @sequence_class = Inferno::Sequence::USCore310HeartrateSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310HeartrateSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310PediatricBmiForAgeSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     @sequence_class = Inferno::Sequence::USCore310PediatricBmiForAgeSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310PediatricWeightForHeightSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     @sequence_class = Inferno::Sequence::USCore310PediatricWeightForHeightSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     @sequence_class = Inferno::Sequence::USCore310ResprateSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310ResprateSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310ResprateSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310AllergyintoleranceSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'AllergyIntolerance')

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'AllergyIntolerance')

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     @sequence_class = Inferno::Sequence::USCore310AllergyintoleranceSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     @sequence_class = Inferno::Sequence::USCore310CareplanSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310CareplanSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310CareplanSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'CarePlan')

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'CarePlan')

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310CareteamSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'CareTeam')

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310CareteamSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310CareteamSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'CareTeam')

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310CareteamSequence do
     @sequence_class = Inferno::Sequence::USCore310CareteamSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310ConditionSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310ConditionSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Condition')

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Condition')

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     @sequence_class = Inferno::Sequence::USCore310ConditionSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310DiagnosticreportLabSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'DiagnosticReport')

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'DiagnosticReport')

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     @sequence_class = Inferno::Sequence::USCore310DiagnosticreportLabSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     @sequence_class = Inferno::Sequence::USCore310DiagnosticreportNoteSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'DiagnosticReport')

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310DiagnosticreportNoteSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'DiagnosticReport')

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310DocumentreferenceSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'DocumentReference')

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'DocumentReference')

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     @sequence_class = Inferno::Sequence::USCore310DocumentreferenceSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     @sequence_class = Inferno::Sequence::USCore310EncounterSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Encounter')

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310EncounterSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310EncounterSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Encounter')

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
     @sequence_class = Inferno::Sequence::USCore310GoalSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310GoalSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310GoalSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Goal')

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Goal')

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Immunization')

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     @sequence_class = Inferno::Sequence::USCore310ImmunizationSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310ImmunizationSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Immunization')

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310ImplantableDeviceSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Device')

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     @sequence_class = Inferno::Sequence::USCore310ImplantableDeviceSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Device')

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310LocationSequence do
     @sequence_class = Inferno::Sequence::USCore310LocationSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310LocationSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310LocationSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Location')

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310LocationSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Location')

--- a/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310MedicationSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Medication')

--- a/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310MedicationSequence do
     @sequence_class = Inferno::Sequence::USCore310MedicationSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310MedicationSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310MedicationSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Medication')

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310MedicationrequestSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'MedicationRequest')

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'MedicationRequest')

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     @sequence_class = Inferno::Sequence::USCore310MedicationrequestSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310ObservationLabSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     @sequence_class = Inferno::Sequence::USCore310ObservationLabSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Organization')

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310OrganizationSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Organization')

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
     @sequence_class = Inferno::Sequence::USCore310OrganizationSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Patient')

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310PatientSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310PatientSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Patient')

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     @sequence_class = Inferno::Sequence::USCore310PatientSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Practitioner')

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310PractitionerSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Practitioner')

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
     @sequence_class = Inferno::Sequence::USCore310PractitionerSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'PractitionerRole')

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310PractitionerroleSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'PractitionerRole')

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     @sequence_class = Inferno::Sequence::USCore310PractitionerroleSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310ProcedureSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Procedure')

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     @sequence_class = Inferno::Sequence::USCore310ProcedureSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Procedure')

--- a/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310ProvenanceSequence do
     @sequence_class = Inferno::Sequence::USCore310ProvenanceSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310ProvenanceSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Provenance')

--- a/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310ProvenanceSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310ProvenanceSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Provenance')

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310PulseOximetrySequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     @sequence_class = Inferno::Sequence::USCore310PulseOximetrySequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -9,9 +9,9 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
   before do
     @sequence_class = Inferno::Sequence::USCore310SmokingstatusSequence
     @base_url = 'http://www.example.com/fhir'
-    @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -10,7 +10,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     @sequence_class = Inferno::Sequence::USCore310SmokingstatusSequence
     @base_url = 'http://www.example.com/fhir'
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0', fhir_version: 'r4')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_id = 'example'
     @instance.patient_id = @patient_id

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -11,7 +11,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     @base_url = 'http://www.example.com/fhir'
     @client = FHIR::Client.new(@base_url)
     @token = 'ABC'
-    @instance = Inferno::Models::TestingInstance.create(token: @token, selected_module: 'uscore_v3.1.0')
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @patient_id = 'example'
     @instance.patient_id = @patient_id
     set_resource_support(@instance, 'Observation')


### PR DESCRIPTION
Occasionally there are build errors on the practitioner role chain tests.  One problem seems to be that inferno tests are trying to hit `example.com/Practitioner...` instead of `example.com/fhir/Practitioner...` and that could be because we haven't set a `url` on the testing instance.

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
