### PR TITLE
check for existence of all composite or values

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -654,6 +654,10 @@ module Inferno
               reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
               assert_response_ok(reply)
+              resources_returned = fetch_all_bundled_resources(reply.resource)
+              assert #{param_value_name(param)}.split(',').all? do |val|
+                resolve_element_from_path(resources_returned, '#{param}') { |val_found| val_found == val }
+              end
             end
             skip 'Cannot find second value for #{param} to perform a multipleOr search' unless found_second_val
           )

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -655,9 +655,10 @@ module Inferno
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
               assert_response_ok(reply)
               resources_returned = fetch_all_bundled_resources(reply.resource)
-              assert #{param_value_name(param)}.split(',').all? do |val|
+              missing_values = #{param_value_name(param)}.split(',').reject do |val|
                 resolve_element_from_path(resources_returned, '#{param}') { |val_found| val_found == val }
               end
+              assert missing_values.blank?, "Could not find \#{missing_values.join(',')} values from #{param} in any of the resources returned"
             end
             skip 'Cannot find second value for #{param} to perform a multipleOr search' unless found_second_val
           )

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -296,6 +296,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
           validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)
           assert_response_ok(reply)
+          resources_returned = fetch_all_bundled_resources(reply.resource)
+          assert search_params[:status].split(',').all? do |val|
+            resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
+          end
         end
         skip 'Cannot find second value for status to perform a multipleOr search' unless found_second_val
       end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -297,9 +297,10 @@ module Inferno
           validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)
           assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply.resource)
-          assert search_params[:status].split(',').all? do |val|
+          missing_values = search_params[:status].split(',').reject do |val|
             resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
           end
+          assert missing_values.blank?, "Could not find #{missing_values.join(',')} values from status in any of the resources returned"
         end
         skip 'Cannot find second value for status to perform a multipleOr search' unless found_second_val
       end

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -520,9 +520,10 @@ module Inferno
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
           assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply.resource)
-          assert search_params[:status].split(',').all? do |val|
+          missing_values = search_params[:status].split(',').reject do |val|
             resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
           end
+          assert missing_values.blank?, "Could not find #{missing_values.join(',')} values from status in any of the resources returned"
         end
         skip 'Cannot find second value for status to perform a multipleOr search' unless found_second_val
       end

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -519,6 +519,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
           assert_response_ok(reply)
+          resources_returned = fetch_all_bundled_resources(reply.resource)
+          assert search_params[:status].split(',').all? do |val|
+            resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
+          end
         end
         skip 'Cannot find second value for status to perform a multipleOr search' unless found_second_val
       end


### PR DESCRIPTION
This makes the composite or searches check if all values being or'd by are found

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-598
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
