### PR TITLE
Fi 607 cache ref resolution

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -682,8 +682,11 @@ module Inferno
               skip_if_known_not_supported(:#{sequence[:resource]}, [:search, :read])
               #{skip_if_not_found(sequence)}
 
+              validated_resources = Set.new
+              max_resolutions = 50
+
               #{resource_array}&.each do |resource|
-                validate_reference_resolutions(resource)
+                validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
               end)
         sequence[:tests] << test
       end

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -180,12 +180,11 @@ module Inferno
 
         # For patient id list, don't clear it out but rather add it to the list of known
         # patients to pull from.
-        if self.patient_ids.blank?
-          self.patient_ids = patient_id
-        else
-          self.patient_ids = self.patient_ids.split(',').append(patient_id).uniq.join(',')
-        end
-
+        self.patient_ids = if patient_ids.blank?
+                             patient_id
+                           else
+                             patient_ids.split(',').append(patient_id).uniq.join(',')
+                           end
 
         ResourceReference.create(
           resource_type: 'Patient',

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -178,7 +178,14 @@ module Inferno
 
         resource_references.destroy
 
-        self.patient_ids = patient_id
+        # For patient id list, don't clear it out but rather add it to the list of known
+        # patients to pull from.
+        if self.patient_ids.blank?
+          self.patient_ids = patient_id
+        else
+          self.patient_ids = self.patient_ids.split(',').append(patient_id).uniq.join(',')
+        end
+
 
         ResourceReference.create(
           resource_type: 'Patient',

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -651,7 +651,7 @@ module Inferno
         assert(errors.empty?, errors.join("<br/>\n"))
       end
 
-      def validate_reference_resolutions(resource, resolved_references = Set.new, max_resolutions = Float::Infinity)
+      def validate_reference_resolutions(resource, resolved_references = Set.new, max_resolutions = 1000000)
         problems = []
 
         walk_resource(resource) do |value, meta, path|

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -651,7 +651,8 @@ module Inferno
         assert(errors.empty?, errors.join("<br/>\n"))
       end
 
-      def validate_reference_resolutions(resource, resolved_references = Set.new, max_resolutions = 1000000)
+      # Set max_resolutions in a single sequence to a large number by default
+      def validate_reference_resolutions(resource, resolved_references = Set.new, max_resolutions = 1_000_000)
         problems = []
 
         walk_resource(resource) do |value, meta, path|

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -659,7 +659,7 @@ module Inferno
           next if meta['type'] != 'Reference'
           next if value.reference.blank?
           next if resolved_references.include?(value.reference)
-          next if resolved_references.length > max_resolutions
+          break if resolved_references.length > max_resolutions
 
           begin
             # Should potentially update valid? method in fhir_dstu2_models

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -533,8 +533,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -533,8 +533,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -533,8 +533,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -869,8 +869,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -533,8 +533,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -533,8 +533,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -527,8 +527,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -527,8 +527,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -533,8 +533,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -311,8 +311,11 @@ module Inferno
         skip_if_known_not_supported(:AllergyIntolerance, [:search, :read])
         skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @allergy_intolerance_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -422,8 +422,11 @@ module Inferno
         skip_if_known_not_supported(:CarePlan, [:search, :read])
         skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @care_plan_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -288,7 +288,7 @@ module Inferno
           end
           resolved_one = true
 
-          second_status_val = resolve_element_from_path(@care_team_ary[patient], 'status') do |el| 
+          second_status_val = resolve_element_from_path(@care_team_ary[patient], 'status') do |el|
             get_value_for_search_param(el) != search_params[:status]
           end
           next if second_status_val.nil?

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -288,7 +288,9 @@ module Inferno
           end
           resolved_one = true
 
-          second_status_val = resolve_element_from_path(@care_team_ary[patient], 'status') { |el| get_value_for_search_param(el) != search_params[:status] }
+          second_status_val = resolve_element_from_path(@care_team_ary[patient], 'status') do |el| 
+            get_value_for_search_param(el) != search_params[:status]
+          end
           next if second_status_val.nil?
 
           found_second_val = true
@@ -313,8 +315,11 @@ module Inferno
         skip_if_known_not_supported(:CareTeam, [:search, :read])
         skip 'No CareTeam resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @care_team_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -288,9 +288,7 @@ module Inferno
           end
           resolved_one = true
 
-          second_status_val = resolve_element_from_path(@care_team_ary[patient], 'status') do |el|
-            get_value_for_search_param(el) != search_params[:status]
-          end
+          second_status_val = resolve_element_from_path(@care_team_ary[patient], 'status') { |el| get_value_for_search_param(el) != search_params[:status] }
           next if second_status_val.nil?
 
           found_second_val = true

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -448,8 +448,11 @@ module Inferno
         skip_if_known_not_supported(:Condition, [:search, :read])
         skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @condition_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -494,8 +494,11 @@ module Inferno
         skip_if_known_not_supported(:DiagnosticReport, [:search, :read])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @diagnostic_report_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -494,8 +494,11 @@ module Inferno
         skip_if_known_not_supported(:DiagnosticReport, [:search, :read])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @diagnostic_report_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -582,8 +582,11 @@ module Inferno
         skip_if_known_not_supported(:DocumentReference, [:search, :read])
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @document_reference_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -549,8 +549,11 @@ module Inferno
         skip_if_known_not_supported(:Encounter, [:search, :read])
         skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @encounter_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -349,8 +349,11 @@ module Inferno
         skip_if_known_not_supported(:Goal, [:search, :read])
         skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @goal_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -355,8 +355,11 @@ module Inferno
         skip_if_known_not_supported(:Immunization, [:search, :read])
         skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @immunization_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -317,8 +317,11 @@ module Inferno
         skip_if_known_not_supported(:Device, [:search, :read])
         skip 'No Device resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @device_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -397,8 +397,11 @@ module Inferno
         skip_if_known_not_supported(:Location, [:search, :read])
         skip 'No Location resources appear to be available.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @location_ary&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
@@ -149,8 +149,11 @@ module Inferno
         skip_if_known_not_supported(:Medication, [:search, :read])
         skip 'No Medication resources appear to be available.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @medication_ary&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -536,8 +536,11 @@ module Inferno
         skip_if_known_not_supported(:MedicationRequest, [:search, :read])
         skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @medication_request_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -497,8 +497,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -322,8 +322,11 @@ module Inferno
         skip_if_known_not_supported(:Organization, [:search, :read])
         skip 'No Organization resources appear to be available.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @organization_ary&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -574,8 +574,11 @@ module Inferno
         skip_if_known_not_supported(:Patient, [:search, :read])
         skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @patient_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -299,8 +299,11 @@ module Inferno
         skip_if_known_not_supported(:Practitioner, [:search, :read])
         skip 'No Practitioner resources appear to be available.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @practitioner_ary&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -389,8 +389,11 @@ module Inferno
         skip_if_known_not_supported(:PractitionerRole, [:search, :read])
         skip 'No PractitionerRole resources appear to be available.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @practitioner_role_ary&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -399,8 +399,11 @@ module Inferno
         skip_if_known_not_supported(:Procedure, [:search, :read])
         skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @procedure_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -176,8 +176,11 @@ module Inferno
         skip_if_known_not_supported(:Provenance, [:search, :read])
         skip 'No Provenance resources appear to be available.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @provenance_ary&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -893,8 +893,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -455,8 +455,11 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:search, :read])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
+        validated_resources = Set.new
+        max_resolutions = 50
+
         @observation_ary&.values&.flatten&.each do |resource|
-          validate_reference_resolutions(resource)
+          validate_reference_resolutions(resource, validated_resources, max_resolutions) if validated_resources.length < max_resolutions
         end
       end
     end


### PR DESCRIPTION
Fixes a few bugs in the US Core generator.  Also caps resource resolution step to a max number of references to follow (currently set to 50), and won't resolve the same reference multiple times, because this was tying up our database and tests were taking way too long to run for little benefit.

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
