### PR TITLE
Update UMLS Version

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -480,7 +480,7 @@ namespace :terminology do |_argv|
   desc 'download and execute UMLS terminology data'
   task :download_umls, [:username, :password] do |_t, args|
     # Adapted from python https://github.com/jmandel/umls-bloomer/blob/master/01-download.py
-    default_target_file = 'https://download.nlm.nih.gov/umls/kss/2018AB/umls-2018AB-full.zip'
+    default_target_file = 'https://download.nlm.nih.gov/umls/kss/2019AB/umls-2019AB-full.zip'
 
     puts 'Getting Login Page'
     response = RestClient.get default_target_file


### PR DESCRIPTION
- Updates the version of UMLS from `2018AB` to `2019AB`.
- Create msgpack files with `wb` open mode to avoid encoding issues encountered during debugging.
- Remove ValueSets that use NDF-RT which has been replaced by MED-RT
  - [See the 2019AB Release Notes](https://www.nlm.nih.gov/research/umls/knowledge_sources/metathesaurus/release/notes.html)
- Fix issue where `#import_valueset` returned a `Inferno::Terminology::Valueset` instead of the expected `Set`



**Submitter:**
- [x] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
