### PR TITLE
Fi 600 fix build due to test helper issue

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,10 +61,12 @@ def valid_uri?(uri)
 end
 
 def wrap_resources_in_bundle(resources, type: 'searchset')
-  bundle = FHIR::DSTU2::Bundle.new('id': 'foo', 'type': type)
   resources = [resources].flatten.compact
+  # get the Bundle class from the same version of FHIR models
+  bundle_class = resources.first.class.parent::Bundle
+  bundle = bundle_class.new('id': 'foo', 'type': type)
   resources.each do |resource|
-    bundle.entry << FHIR::DSTU2::Bundle::Entry.new
+    bundle.entry << bundle_class::Entry.new
     bundle.entry.last.resource = resource
   end
   bundle


### PR DESCRIPTION
Fixes issue where test helper wraps resources in potentially wrong FHIR version bundle.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
