### PR TITLE
WIP: FI-609 codeableConcept validation in Terminology service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,11 @@ tmp/*
 resources/terminology/*
 sequence_coverage.csv
 fhir-pgdata/
+.byebug_history
+
+# UMLS-related gitignores
+MRCONSO.pipe
+MRREL.pipe
+MRSAT.pipe
+umls.db
+umls.zip

--- a/test/fixtures/codesystem_validates_code_params_bad.json
+++ b/test/fixtures/codesystem_validates_code_params_bad.json
@@ -5,8 +5,8 @@
             "name": "coding",
             "valueCoding":
                     {
-                        "system": "http://snomed.info/sct",
-                        "code": "Robot"
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+                        "code": "Q"
                     }
         }
     ]

--- a/test/fixtures/codesystem_validates_code_params_good.json
+++ b/test/fixtures/codesystem_validates_code_params_good.json
@@ -5,8 +5,8 @@
             "name": "coding",
             "valueCoding":
                     {
-                        "system": "http://snomed.info/sct",
-                        "code": "69322001"
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+                        "code": "F"
                     }
         }
     ]

--- a/test/fixtures/validators/manifest.yml
+++ b/test/fixtures/validators/manifest.yml
@@ -7,3 +7,7 @@
   :file: hl7_org_fhir_us_core_ValueSet_birthsex.msgpack
   :count: 3
   :type: bloom
+- :url: http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender
+  :file: hl7_org_fhir_us_core_ValueSet_birthsex.msgpack
+  :count: 3
+  :type: bloom

--- a/test/fixtures/valueset_validates_codeableconcept_params_bad.json
+++ b/test/fixtures/valueset_validates_codeableconcept_params_bad.json
@@ -1,0 +1,24 @@
+{
+  "resourceType" : "Parameters",
+  "parameter" : [
+      {
+        "name": "url",
+        "valueUrl": "http://hl7.org/fhir/us/core/ValueSet/birthsex"
+      },
+      {
+      "name" : "codeableConcept",
+      "valueCodeableConcept" : {
+        "coding" : [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+            "code": "Q"
+          },
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+            "code": "R"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/valueset_validates_codeableconcept_params_good.json
+++ b/test/fixtures/valueset_validates_codeableconcept_params_good.json
@@ -1,0 +1,24 @@
+{
+  "resourceType" : "Parameters",
+  "parameter" : [
+      {
+        "name": "url",
+        "valueUrl": "http://hl7.org/fhir/us/core/ValueSet/birthsex"
+      },
+      {
+      "name" : "codeableConcept",
+      "valueCodeableConcept" : {
+        "coding" : [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+            "code": "F"
+          },
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+            "code": "M"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/integration/terminology_endpoint_test.rb
+++ b/test/integration/terminology_endpoint_test.rb
@@ -41,15 +41,25 @@ class TerminologyEndpointTest < MiniTest::Test
   end
 
   def test_codesystem_validates_good_code
-    skip # skipped until we can increase our codesystem support
     post '/fhir/CodeSystem/$validate-code', load_fixture('codesystem_validates_code_params_good'), 'CONTENT_TYPE' => 'application/fhir+json'
     assert last_response.ok?, 'Operation should return a 200 status code'
     assert FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
   end
 
   def test_codesystem_validates_bad_code
-    skip # skipped until we can increase our codesystem support
     post '/fhir/CodeSystem/$validate-code', load_fixture('codesystem_validates_code_params_bad'), 'CONTENT_TYPE' => 'application/fhir+json'
+    assert last_response.ok?, 'Operation should return a 200 status code'
+    refute FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
+  end
+
+  def test_valueset_validates_good_codeableconcept
+    post 'fhir/ValueSet/$validate-code', load_fixture('valueset_validates_codeableconcept_params_good'), 'CONTENT_TYPE' => 'application/fhir+json'
+    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
+  end
+
+  def test_valueset_validates_bad_codeableconcept
+    post 'fhir/ValueSet/$validate-code', load_fixture('valueset_validates_codeableconcept_params_bad'), 'CONTENT_TYPE' => 'application/fhir+json'
     assert last_response.ok?, 'Operation should return a 200 status code'
     refute FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
   end

--- a/test/integration/terminology_endpoint_test.rb
+++ b/test/integration/terminology_endpoint_test.rb
@@ -16,51 +16,51 @@ class TerminologyEndpointTest < MiniTest::Test
 
   def test_capability_statement
     get '/fhir/metadata'
-    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert last_response.ok?, "Operation should return a 200 status code, instead returned #{last_response.status}"
     assert_equal 'application/fhir+json', last_response.content_type
     assert FHIR.from_contents(last_response.body), "Couldn't deserialize CapabilityStatement into a FHIR::Models object"
   end
 
   def test_terminology_capability_statement
     get '/fhir/metadata?mode=terminology'
-    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert last_response.ok?, "Operation should return a 200 status code, instead returned #{last_response.status}"
     assert_equal 'application/fhir+json', last_response.content_type
     refute_empty FHIR.from_contents(last_response.body).codeSystem
   end
 
   def test_valueset_validates_good_code
     post '/fhir/ValueSet/$validate-code', load_fixture('valueset_validates_code_params_good'), 'CONTENT_TYPE' => 'application/fhir+json'
-    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert last_response.ok?, "Operation should return a 200 status code, instead returned #{last_response.status}"
     assert FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
   end
 
   def test_valueset_validates_bad_code
     post '/fhir/ValueSet/$validate-code', load_fixture('valueset_validates_code_params_bad'), 'CONTENT_TYPE' => 'application/fhir+json'
-    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert last_response.ok?, "Operation should return a 200 status code, instead returned #{last_response.status}"
     refute FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
   end
 
   def test_codesystem_validates_good_code
     post '/fhir/CodeSystem/$validate-code', load_fixture('codesystem_validates_code_params_good'), 'CONTENT_TYPE' => 'application/fhir+json'
-    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert last_response.ok?, "Operation should return a 200 status code, instead returned #{last_response.status}"
     assert FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
   end
 
   def test_codesystem_validates_bad_code
     post '/fhir/CodeSystem/$validate-code', load_fixture('codesystem_validates_code_params_bad'), 'CONTENT_TYPE' => 'application/fhir+json'
-    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert last_response.ok?, "Operation should return a 200 status code, instead returned #{last_response.status}"
     refute FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
   end
 
   def test_valueset_validates_good_codeableconcept
     post 'fhir/ValueSet/$validate-code', load_fixture('valueset_validates_codeableconcept_params_good'), 'CONTENT_TYPE' => 'application/fhir+json'
-    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert last_response.ok?, "Operation should return a 200 status code, instead returned #{last_response.status}"
     assert FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
   end
 
   def test_valueset_validates_bad_codeableconcept
     post 'fhir/ValueSet/$validate-code', load_fixture('valueset_validates_codeableconcept_params_bad'), 'CONTENT_TYPE' => 'application/fhir+json'
-    assert last_response.ok?, 'Operation should return a 200 status code'
+    assert last_response.ok?, "Operation should return a 200 status code, instead returned #{last_response.status}"
     refute FHIR.from_contents(last_response.body).parameter.find { |p| p.name == 'result' }&.value
   end
 end


### PR DESCRIPTION
This PR adds `CodeableConcept` support to the Terminology service endpoint, including support for multiple `Codings`. Note: this PR currently only supports `CodeableConcept` validation as described in the `ValueSet/$validate-code` and `CodeSystem/$validate-code` operation definitions; which is to say, if one `Coding` in the `CodeableConcept` is valid, the entire `CodeableConcept` is considered valid. Support for the two flags Grahame added to the validator service's terminology calls (`valueSetMode`, which can get either `CHECK_MEMERSHIP_ONLY` or `NO_MEMBERSHIP_CHECK`) is left for another ticket/PR.

Also, this PR updates the `.gitignore` file to ignore terminology-loading related artifacts, such as `umls.db`, `umls.zip`, and several `.pipe` files.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-609
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
