### PR TITLE
FI-582: Data Absent Reason tests

### DIFF
--- a/generator/uscore/static/data_absent_reason_checker.rb
+++ b/generator/uscore/static/data_absent_reason_checker.rb
@@ -2,6 +2,9 @@
 
 module Inferno
   module DataAbsentReasonChecker
+    DAR_EXTENSION_URL = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'
+    DAR_CODE_SYSTEM_URL = 'http://terminology.hl7.org/CodeSystem/data-absent-reason'
+
     def check_for_data_absent_reasons
       proc do |reply|
         if !@instance.data_absent_extension_found && contains_data_absent_extension?(reply.body)
@@ -17,11 +20,20 @@ module Inferno
     end
 
     def contains_data_absent_extension?(body)
-      body.include? 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'
+      body.include? DAR_EXTENSION_URL
     end
 
     def contains_data_absent_code?(body)
-      body.include? 'http://terminology.hl7.org/CodeSystem/data-absent-reason'
+      if body.include? DAR_CODE_SYSTEM_URL
+        resource = FHIR.from_contents(body)
+        walk_resource(resource) do |element, meta, path|
+          next unless meta['type'] == 'Coding'
+
+          return true if element.code == 'unknown' && element.system == DAR_CODE_SYSTEM_URL
+        end
+      end
+
+      false
     end
   end
 end

--- a/generator/uscore/static/data_absent_reason_checker.rb
+++ b/generator/uscore/static/data_absent_reason_checker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module DataAbsentReasonChecker
+  def check_for_data_absent_reasons
+    proc do |reply|
+      if !@instance.data_absent_extension_found && contains_data_absent_extension?(reply.body)
+        @instance.data_absent_extension_found = true
+        @instance.save
+      end
+
+      if !@instance.data_absent_code_found && contains_data_absent_code?(reply.body)
+        @instance.data_absent_code_found = true
+        @instance.save
+      end
+    end
+  end
+
+  def contains_data_absent_extension?(body)
+    body.include? 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'
+  end
+
+  def contains_data_absent_code?(body)
+    body.include? 'http://terminology.hl7.org/CodeSystem/data-absent-reason'
+  end
+end

--- a/generator/uscore/static/data_absent_reason_checker.rb
+++ b/generator/uscore/static/data_absent_reason_checker.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
 
-module DataAbsentReasonChecker
-  def check_for_data_absent_reasons
-    proc do |reply|
-      if !@instance.data_absent_extension_found && contains_data_absent_extension?(reply.body)
-        @instance.data_absent_extension_found = true
-        @instance.save
-      end
+module Inferno
+  module DataAbsentReasonChecker
+    def check_for_data_absent_reasons
+      proc do |reply|
+        if !@instance.data_absent_extension_found && contains_data_absent_extension?(reply.body)
+          @instance.data_absent_extension_found = true
+          @instance.save
+        end
 
-      if !@instance.data_absent_code_found && contains_data_absent_code?(reply.body)
-        @instance.data_absent_code_found = true
-        @instance.save
+        if !@instance.data_absent_code_found && contains_data_absent_code?(reply.body)
+          @instance.data_absent_code_found = true
+          @instance.save
+        end
       end
     end
-  end
 
-  def contains_data_absent_extension?(body)
-    body.include? 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'
-  end
+    def contains_data_absent_extension?(body)
+      body.include? 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'
+    end
 
-  def contains_data_absent_code?(body)
-    body.include? 'http://terminology.hl7.org/CodeSystem/data-absent-reason'
+    def contains_data_absent_code?(body)
+      body.include? 'http://terminology.hl7.org/CodeSystem/data-absent-reason'
+    end
   end
 end

--- a/generator/uscore/static/data_absent_reason_checker.rb
+++ b/generator/uscore/static/data_absent_reason_checker.rb
@@ -26,7 +26,7 @@ module Inferno
     def contains_data_absent_code?(body)
       if body.include? DAR_CODE_SYSTEM_URL
         resource = FHIR.from_contents(body)
-        walk_resource(resource) do |element, meta, path|
+        walk_resource(resource) do |element, meta, _path|
           next unless meta['type'] == 'Coding'
 
           return true if element.code == 'unknown' && element.system == DAR_CODE_SYSTEM_URL

--- a/generator/uscore/static_test/data_absent_reason_checker_test.rb
+++ b/generator/uscore/static_test/data_absent_reason_checker_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::DataAbsentReasonChecker do
+  class DataAbsentReasonCheckerTest
+    include Inferno::DataAbsentReasonChecker
+
+    attr_reader :instance
+
+    def initialize
+      @instance = Inferno::Models::TestingInstance.new
+    end
+  end
+
+  describe '#check_for_data_absent_reasons' do
+    it 'detects data absent extensions' do
+      resource = FHIR::Patient.new(
+        name: [{
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+              valueCode: 'unknown'
+            }
+          ]
+        }]
+      )
+
+      checker = DataAbsentReasonCheckerTest.new
+      reply = OpenStruct.new(body: resource.to_json)
+
+      checker.check_for_data_absent_reasons.call(reply)
+      assert checker.instance.data_absent_extension_found
+      refute checker.instance.data_absent_code_found
+    end
+
+    it 'detects data absent codes' do
+      resource = FHIR::Condition.new(
+        category: [{
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/data-absent-reason',
+              code: 'unknown'
+            }
+          ]
+        }]
+      )
+
+      checker = DataAbsentReasonCheckerTest.new
+      reply = OpenStruct.new(body: resource.to_json)
+
+      checker.check_for_data_absent_reasons.call(reply)
+      assert checker.instance.data_absent_code_found
+      refute checker.instance.data_absent_extension_found
+    end
+  end
+end

--- a/generator/uscore/templates/module.yml.erb
+++ b/generator/uscore/templates/module.yml.erb
@@ -22,3 +22,4 @@ test_sets:
         - <%=sequence[:class_name]%><% end %>
         - USCoreR4ClinicalNotesSequence<% delayed_sequences.each do |sequence| %>
         - <%=sequence[:class_name]%><% end %>
+        - USCoreR4DataAbsentReasonSequence

--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -5,7 +5,7 @@ require_relative './data_absent_reason_checker'
 module Inferno
   module Sequence
     class <%=class_name%> < SequenceBase
-      include DataAbsentReasonChecker
+      include Inferno::DataAbsentReasonChecker
 
       title '<%=title%> Tests'
 

--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class <%=class_name%> < SequenceBase
+      include DataAbsentReasonChecker
+
       title '<%=title%> Tests'
 
       description 'Verify that <%=resource%> resources on the FHIR server follow the US Core Implementation Guide'

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -37,6 +37,9 @@ module Inferno
         Dir.glob(File.join(__dir__, 'static', '*')).each do |static_file|
           FileUtils.cp(static_file, sequence_out_path)
         end
+        Dir.glob(File.join(__dir__, 'static_test', '*')).each do |static_file|
+          FileUtils.cp(static_file, "#{File.join(sequence_out_path, 'test')}")
+        end
       end
 
       def generate_search_validators(metadata)

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -815,7 +815,7 @@ module Inferno
               reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
               assert_response_ok(reply)
-              resources_returned = fetch_all_bundled_resources(reply.resource)
+              resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
               missing_values = #{param_value_name(param)}.split(',').reject do |val|
                 resolve_element_from_path(resources_returned, '#{param}') { |val_found| val_found == val }
               end
@@ -1197,7 +1197,7 @@ module Inferno
             response = get_resource_by_params(FHIR::MedicationRequest, search_params)
             assert_response_ok(response)
             assert_bundle_response(response)
-            requests_with_medications = fetch_all_bundled_resources(response.resource, check_for_data_absent_reasons)
+            requests_with_medications = fetch_all_bundled_resources(response, check_for_data_absent_reasons)
 
             medications = requests_with_medications.select { |resource| resource.resourceType == 'Medication' }
             assert medications.present?, 'No Medications were included in the search results'

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -38,7 +38,7 @@ module Inferno
           FileUtils.cp(static_file, sequence_out_path)
         end
         Dir.glob(File.join(__dir__, 'static_test', '*')).each do |static_file|
-          FileUtils.cp(static_file, "#{File.join(sequence_out_path, 'test')}")
+          FileUtils.cp(static_file, File.join(sequence_out_path, 'test').to_s)
         end
       end
 

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -61,6 +61,9 @@ module Inferno
       property :patient_ids, String
       property :group_id, String
 
+      property :data_absent_code_found, Boolean
+      property :data_absent_extension_found, Boolean
+
       # Bulk Data Parameters
       property :bulk_url, String
       property :bulk_token_endpoint, String

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -524,7 +524,7 @@ module Inferno
         end
       end
 
-      def validate_read_reply(resource, klass)
+      def validate_read_reply(resource, klass, reply_handler = nil)
         class_name = klass.name.demodulize
         assert !resource.nil?, "No #{class_name} resources available from search."
         if resource.is_a? versioned_resource_class('Reference')
@@ -535,6 +535,7 @@ module Inferno
           assert !id.nil?, "#{class_name} id not returned"
           read_response = @client.read(klass, id)
           assert_response_ok read_response
+          reply_handler&.call(read_response)
           read_response = read_response.resource
         end
         assert !read_response.nil?, "Expected #{class_name} resource to be present."

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -798,14 +798,23 @@ module Inferno
         end
       end
 
-      def fetch_all_bundled_resources(bundle)
+      def fetch_all_bundled_resources(reply, reply_handler = nil)
         page_count = 1
         resources = []
+        bundle = reply.resource
         until bundle.nil? || page_count == 20
           resources += bundle&.entry&.map { |entry| entry&.resource }
           next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url
-          bundle = bundle.next_bundle
-          assert next_bundle_link.nil? || !bundle.nil?, "Could not resolve next bundle. #{next_bundle_link}"
+          reply_handler&.call(reply)
+          break if next_bundle_link.blank?
+
+          reply = @client.raw_read_url(next_bundle_link)
+          error_message = "Could not resolve next bundle. #{next_bundle_link}"
+          assert_response_ok(reply, error_message)
+          assert_valid_json(reply.body, error_message)
+
+          bundle = FHIR.from_contents(reply.body)
+
           page_count += 1
         end
         resources

--- a/lib/app/utils/assertions.rb
+++ b/lib/app/utils/assertions.rb
@@ -12,10 +12,10 @@ module Inferno
       raise AssertionException.new message, data unless test
     end
 
-    def assert_valid_json(json)
+    def assert_valid_json(json, message = '')
       assert JSON.parse(json)
     rescue JSON::ParserError
-      assert false, 'Invalid JSON'
+      assert false, "Invalid JSON. #{message}"
     end
 
     def assert_equal(expected, actual, message = '', data = '')

--- a/lib/modules/smart/test/openid_connect_test.rb
+++ b/lib/modules/smart/test/openid_connect_test.rb
@@ -137,7 +137,7 @@ describe Inferno::Sequence::OpenIDConnectSequence do
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'Invalid JSON', exception.message
+      assert_equal 'Invalid JSON. ', exception.message
     end
 
     it 'succeeds if the configuration is valid json' do
@@ -272,7 +272,7 @@ describe Inferno::Sequence::OpenIDConnectSequence do
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'Invalid JSON', exception.message
+      assert_equal 'Invalid JSON. ', exception.message
     end
 
     it 'fails if the jwks keys field is not an array' do
@@ -589,7 +589,7 @@ describe Inferno::Sequence::OpenIDConnectSequence do
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_match 'Invalid JSON', exception.message
+      assert_match 'Invalid JSON. ', exception.message
     end
 
     it 'fails if fetching the user does not return an allowed FHIR resource type' do

--- a/lib/modules/smart/test/token_refresh_sequence_test.rb
+++ b/lib/modules/smart/test/token_refresh_sequence_test.rb
@@ -145,7 +145,7 @@ describe Inferno::Sequence::TokenRefreshSequence do
     it 'fails when the token response body is invalid json' do
       response = OpenStruct.new(code: 200, body: '{')
       exception = assert_raises(Inferno::AssertionException) { @sequence.validate_and_save_refresh_response(response) }
-      assert_equal('Invalid JSON', exception.message)
+      assert_equal('Invalid JSON. ', exception.message)
     end
 
     it 'fails when the token response does not contain an access token' do

--- a/lib/modules/us_core_guidance/clinicalnotes_sequence.rb
+++ b/lib/modules/us_core_guidance/clinicalnotes_sequence.rb
@@ -67,7 +67,7 @@ module Inferno
 
         self.document_attachments = ClinicalNoteAttachment.new(resource_class) if document_attachments.nil?
 
-        document_references = fetch_all_bundled_resources(reply.resource)
+        document_references = fetch_all_bundled_resources(reply)
 
         document_references&.each do |document|
           document&.content&.select { |content| !document_attachments.attachment.key?(content&.attachment&.url) }&.each do |content|
@@ -90,7 +90,7 @@ module Inferno
 
         self.report_attachments = ClinicalNoteAttachment.new(resource_class) if report_attachments.nil?
 
-        diagnostic_reports = fetch_all_bundled_resources(reply.resource)
+        diagnostic_reports = fetch_all_bundled_resources(reply)
 
         diagnostic_reports&.each do |report|
           report&.presentedForm&.select { |attachment| !report_attachments.attachment.key?(attachment&.url) }&.each do |attachment|

--- a/lib/modules/us_core_guidance/test/us_core_r4_data_absent_reason_sequence_test.rb
+++ b/lib/modules/us_core_guidance/test/us_core_r4_data_absent_reason_sequence_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCoreR4DataAbsentReasonSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCoreR4DataAbsentReasonSequence
+    @instance = Inferno::Models::TestingInstance.create
+  end
+
+  describe 'data absent reason extension test' do
+    before do
+      @test = @sequence_class[:extension]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips if no dar extensions have been found' do
+      assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+    end
+
+    it 'succeeds if a dar extension has been found' do
+      @instance.update(data_absent_extension_found: true)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'data absent reason code test' do
+    before do
+      @test = @sequence_class[:code]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'skips if no dar codes have been found' do
+      assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+    end
+
+    it 'succeeds if a dar code has been found' do
+      @instance.update(data_absent_code_found: true)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/us_core_guidance/us_core_r4_data_absent_reason_sequence.rb
+++ b/lib/modules/us_core_guidance/us_core_r4_data_absent_reason_sequence.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Inferno
+  module Sequence
+    class USCoreR4DataAbsentReasonSequence < SequenceBase
+      title 'Missing Data Tests'
+
+      description %(
+        Verify that the server is capable of representing missing data
+      )
+
+      details %(
+        The [US Core Missing Data
+        Guidance](http://hl7.org/fhir/us/core/general-guidance.html#missing-data)
+        gives instructions on how to represent various types of missing data.
+
+        In the previous resource tests, each resource returned from the server
+        was checked for the presence of missing data. These tests will pass if
+        the specified method of representing missing data was observed in the
+        earlier tests.
+      )
+
+      test_id_prefix 'USCDAR'
+
+      test :extension do
+        metadata do
+          id '01'
+          name 'Server represents missing data with the DataAbsentReason Extension'
+          link 'http://hl7.org/fhir/us/core/general-guidance.html#missing-data'
+          description %(
+            For non-coded data elements, servers shall use the DataAbsentReason
+            Extension to represent missing data in a required field
+          )
+          versions :r4
+        end
+
+        skip_unless @instance.data_absent_extension_found,
+                    'No resources using the DataAbsentReason Extension have been found'
+      end
+
+      test :code do
+        metadata do
+          id '02'
+          name 'Server represents missing data with the DataAbsentReason CodeSystem'
+          link 'http://hl7.org/fhir/us/core/general-guidance.html#missing-data'
+          description %(
+            For coded data elements with example, preferred, or extensible
+            binding strengths to ValueSets which do not include an appropriate
+            "unknown" code, servers shall use the "unknown" code from the
+            DataAbsentReason CodeSystem.
+          )
+          versions :r4
+        end
+
+        skip_unless @instance.data_absent_code_found,
+                    'No resources using the DataAbsentReason CodeSystem have been found'
+      end
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310BodyheightSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Observation Body Height Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:body_height])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310BodytempSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Observation Body Temperature Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:body_temperature])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310BodyweightSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Observation Body Weight Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:body_weight])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310BpSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Observation Blood Pressure Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:blood_pressure])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/data_absent_reason_checker.rb
+++ b/lib/modules/uscore_v3.1.0/data_absent_reason_checker.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Inferno
+  module DataAbsentReasonChecker
+    DAR_EXTENSION_URL = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'
+    DAR_CODE_SYSTEM_URL = 'http://terminology.hl7.org/CodeSystem/data-absent-reason'
+
+    def check_for_data_absent_reasons
+      proc do |reply|
+        check_for_data_absent_extension(reply)
+        check_for_data_absent_code(reply)
+      end
+    end
+
+    private
+
+    def check_for_data_absent_extension(reply)
+      return if @instance.data_absent_extension_found
+
+      return unless contains_data_absent_extension?(reply.body)
+
+      @instance.data_absent_extension_found = true
+      @instance.save
+    end
+
+    def check_for_data_absent_code(reply)
+      return if @instance.data_absent_code_found
+
+      return unless contains_data_absent_code?(reply.body)
+
+      @instance.data_absent_code_found = true
+      @instance.save
+    end
+
+    def contains_data_absent_extension?(body)
+      body.include? DAR_EXTENSION_URL
+    end
+
+    def contains_data_absent_code?(body)
+      return false unless body.include? DAR_CODE_SYSTEM_URL
+
+      walk_resource(FHIR.from_contents(body)) do |element, meta, _path|
+        next unless meta['type'] == 'Coding'
+
+        return true if data_absent_coding?(element)
+      end
+
+      false
+    end
+
+    def data_absent_coding?(coding)
+      coding.code == 'unknown' && coding.system == DAR_CODE_SYSTEM_URL
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310HeadcircumSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Observation Head Circumference Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:head_circumference])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310HeartrateSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Observation Heart Rate Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:heart_rate])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310PediatricBmiForAgeSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Pediatric BMI for Age Observation Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310PediatricWeightForHeightSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Pediatric Weight for Height Observation Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310ResprateSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Observation Respiratory Rate Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:resp_rate])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/test/data_absent_reason_checker_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/data_absent_reason_checker_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::DataAbsentReasonChecker do
+  class DataAbsentReasonCheckerTest
+    include Inferno::DataAbsentReasonChecker
+
+    attr_reader :instance
+
+    def initialize
+      @instance = Inferno::Models::TestingInstance.new
+    end
+  end
+
+  describe '#check_for_data_absent_reasons' do
+    it 'detects data absent extensions' do
+      resource = FHIR::Patient.new(
+        name: [{
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+              valueCode: 'unknown'
+            }
+          ]
+        }]
+      )
+
+      checker = DataAbsentReasonCheckerTest.new
+      reply = OpenStruct.new(body: resource.to_json)
+
+      checker.check_for_data_absent_reasons.call(reply)
+      assert checker.instance.data_absent_extension_found
+      refute checker.instance.data_absent_code_found
+    end
+
+    it 'detects data absent codes' do
+      resource = FHIR::Condition.new(
+        category: [{
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/data-absent-reason',
+              code: 'unknown'
+            }
+          ]
+        }]
+      )
+
+      checker = DataAbsentReasonCheckerTest.new
+      reply = OpenStruct.new(body: resource.to_json)
+
+      checker.check_for_data_absent_reasons.call(reply)
+      assert checker.instance.data_absent_code_found
+      refute checker.instance.data_absent_extension_found
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310CareplanSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'CarePlan Tests'
 
       description 'Verify that CarePlan resources on the FHIR server follow the US Core Implementation Guide'
@@ -140,7 +144,7 @@ module Inferno
             @care_plan = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'CarePlan' }
               .resource
-            @care_plan_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @care_plan_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
             save_delayed_sequence_references(@care_plan_ary[patient])
@@ -305,7 +309,7 @@ module Inferno
         skip_if_known_not_supported(:CarePlan, [:read])
         skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@care_plan, versioned_resource_class('CarePlan'))
+        validate_read_reply(@care_plan, versioned_resource_class('CarePlan'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -377,7 +381,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310DiagnosticreportLabSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'DiagnosticReport for Laboratory Results Reporting Tests'
 
       description 'Verify that DiagnosticReport resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @diagnostic_report = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'DiagnosticReport' }
               .resource
-            @diagnostic_report_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @diagnostic_report_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
             save_delayed_sequence_references(@diagnostic_report_ary[patient])
@@ -376,7 +380,7 @@ module Inferno
         skip_if_known_not_supported(:DiagnosticReport, [:read])
         skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
+        validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -448,7 +452,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310DiagnosticreportNoteSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'DiagnosticReport for Report and Note exchange Tests'
 
       description 'Verify that DiagnosticReport resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @diagnostic_report = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'DiagnosticReport' }
               .resource
-            @diagnostic_report_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @diagnostic_report_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
             save_delayed_sequence_references(@diagnostic_report_ary[patient])
@@ -376,7 +380,7 @@ module Inferno
         skip_if_known_not_supported(:DiagnosticReport, [:read])
         skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
+        validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -448,7 +452,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310DocumentreferenceSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'DocumentReference Tests'
 
       description 'Verify that DocumentReference resources on the FHIR server follow the US Core Implementation Guide'
@@ -152,7 +156,7 @@ module Inferno
           @document_reference = reply.resource.entry
             .find { |entry| entry&.resource&.resourceType == 'DocumentReference' }
             .resource
-          @document_reference_ary[patient] = fetch_all_bundled_resources(reply.resource)
+          @document_reference_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
           save_delayed_sequence_references(@document_reference_ary[patient])
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
@@ -425,7 +429,7 @@ module Inferno
         skip_if_known_not_supported(:DocumentReference, [:read])
         skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@document_reference, versioned_resource_class('DocumentReference'))
+        validate_read_reply(@document_reference, versioned_resource_class('DocumentReference'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -503,7 +507,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
 

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310EncounterSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Encounter Tests'
 
       description 'Verify that Encounter resources on the FHIR server follow the US Core Implementation Guide'
@@ -152,7 +156,7 @@ module Inferno
           @encounter = reply.resource.entry
             .find { |entry| entry&.resource&.resourceType == 'Encounter' }
             .resource
-          @encounter_ary[patient] = fetch_all_bundled_resources(reply.resource)
+          @encounter_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           save_resource_ids_in_bundle(versioned_resource_class('Encounter'), reply)
           save_delayed_sequence_references(@encounter_ary[patient])
           validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)
@@ -423,7 +427,7 @@ module Inferno
         skip_if_known_not_supported(:Encounter, [:read])
         skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@encounter, versioned_resource_class('Encounter'))
+        validate_read_reply(@encounter, versioned_resource_class('Encounter'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -485,7 +489,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
 

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310ImplantableDeviceSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Implantable Device Tests'
 
       description 'Verify that Device resources on the FHIR server follow the US Core Implementation Guide'
@@ -97,7 +101,7 @@ module Inferno
           @device = reply.resource.entry
             .find { |entry| entry&.resource&.resourceType == 'Device' }
             .resource
-          @device_ary[patient] = fetch_all_bundled_resources(reply.resource)
+          @device_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           save_resource_ids_in_bundle(versioned_resource_class('Device'), reply)
           save_delayed_sequence_references(@device_ary[patient])
           validate_search_reply(versioned_resource_class('Device'), reply, search_params)
@@ -159,7 +163,7 @@ module Inferno
         skip_if_known_not_supported(:Device, [:read])
         skip 'No Device resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@device, versioned_resource_class('Device'))
+        validate_read_reply(@device, versioned_resource_class('Device'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -219,7 +223,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
 

--- a/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310MedicationSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Medication Tests'
 
       description 'Verify that Medication resources on the FHIR server follow the US Core Implementation Guide'
@@ -42,7 +46,8 @@ module Inferno
         @medication_ary = medication_references.map do |reference|
           validate_read_reply(
             FHIR::Medication.new(id: reference.resource_id),
-            FHIR::Medication
+            FHIR::Medication,
+            check_for_data_absent_reasons
           )
         end
         @medication = @medication_ary.first

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310MedicationrequestSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'MedicationRequest Tests'
 
       description 'Verify that MedicationRequest resources on the FHIR server follow the US Core Implementation Guide'
@@ -50,7 +54,7 @@ module Inferno
         response = get_resource_by_params(FHIR::MedicationRequest, search_params)
         assert_response_ok(response)
         assert_bundle_response(response)
-        requests_with_medications = fetch_all_bundled_resources(response.resource)
+        requests_with_medications = fetch_all_bundled_resources(response, check_for_data_absent_reasons)
 
         medications = requests_with_medications.select { |resource| resource.resourceType == 'Medication' }
         assert medications.present?, 'No Medications were included in the search results'
@@ -166,7 +170,7 @@ module Inferno
             @medication_request = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'MedicationRequest' }
               .resource
-            @medication_request_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @medication_request_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
             save_delayed_sequence_references(@medication_request_ary[patient])
@@ -331,7 +335,7 @@ module Inferno
         skip_if_known_not_supported(:MedicationRequest, [:read])
         skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@medication_request, versioned_resource_class('MedicationRequest'))
+        validate_read_reply(@medication_request, versioned_resource_class('MedicationRequest'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -439,7 +443,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one
@@ -561,7 +566,7 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
           assert_response_ok(reply)
-          resources_returned = fetch_all_bundled_resources(reply.resource)
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           missing_values = search_params[:status].split(',').reject do |val|
             resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
           end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310ObservationLabSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Laboratory Result Observation Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310PatientSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Patient Tests'
 
       description 'Verify that Patient resources on the FHIR server follow the US Core Implementation Guide'
@@ -124,7 +128,7 @@ module Inferno
           @patient = reply.resource.entry
             .find { |entry| entry&.resource&.resourceType == 'Patient' }
             .resource
-          @patient_ary[patient] = fetch_all_bundled_resources(reply.resource)
+          @patient_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           save_resource_ids_in_bundle(versioned_resource_class('Patient'), reply)
           save_delayed_sequence_references(@patient_ary[patient])
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
@@ -375,7 +379,7 @@ module Inferno
         skip_if_known_not_supported(:Patient, [:read])
         skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@patient, versioned_resource_class('Patient'))
+        validate_read_reply(@patient, versioned_resource_class('Patient'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -435,7 +439,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
 

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310ProvenanceSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Provenance Tests'
 
       description 'Verify that Provenance resources on the FHIR server follow the US Core Implementation Guide'
@@ -42,7 +46,8 @@ module Inferno
         @provenance_ary = provenance_references.map do |reference|
           validate_read_reply(
             FHIR::Provenance.new(id: reference.resource_id),
-            FHIR::Provenance
+            FHIR::Provenance,
+            check_for_data_absent_reasons
           )
         end
         @provenance = @provenance_ary.first

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310PulseOximetrySequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Pulse Oximetry Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pulse_oximetry])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative './data_absent_reason_checker'
+
 module Inferno
   module Sequence
     class USCore310SmokingstatusSequence < SequenceBase
+      include Inferno::DataAbsentReasonChecker
+
       title 'Smoking Status Observation Tests'
 
       description 'Verify that Observation resources on the FHIR server follow the US Core Implementation Guide'
@@ -144,7 +148,7 @@ module Inferno
             @observation = reply.resource.entry
               .find { |entry| entry&.resource&.resourceType == 'Observation' }
               .resource
-            @observation_ary[patient] += fetch_all_bundled_resources(reply.resource)
+            @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
             save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
             save_delayed_sequence_references(@observation_ary[patient])
@@ -349,7 +353,7 @@ module Inferno
         skip_if_known_not_supported(:Observation, [:read])
         skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
 
-        validate_read_reply(@observation, versioned_resource_class('Observation'))
+        validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
 
       test :vread_interaction do
@@ -421,7 +425,8 @@ module Inferno
 
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          provenance_results += fetch_all_bundled_resources(reply.resource).select { |resource| resource.resourceType == 'Provenance' }
+          provenance_results += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            .select { |resource| resource.resourceType == 'Provenance' }
           provenance_results.each { |reference| @instance.save_resource_reference('Provenance', reference.id) }
         end
         skip "Could not resolve all parameters (#{could_not_resolve_all.join(', ')}) in any resource." unless resolved_one

--- a/lib/modules/uscore_v3.1.0_module.yml
+++ b/lib/modules/uscore_v3.1.0_module.yml
@@ -51,3 +51,4 @@ test_sets:
         - USCore310PractitionerSequence
         - USCore310PractitionerroleSequence
         - USCore310ProvenanceSequence
+        - USCoreR4DataAbsentReasonSequence

--- a/test/unit/assertions_test.rb
+++ b/test/unit/assertions_test.rb
@@ -34,7 +34,7 @@ describe Inferno::Assertions do
         @inferno_asserter.assert_valid_json('abc')
       end
 
-      assert_equal(exception.message, 'Invalid JSON')
+      assert_equal(exception.message, 'Invalid JSON. ')
     end
 
     it 'does not raise an exception if JSON is valid' do

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -97,7 +97,7 @@ class SequenceBaseTest < MiniTest::Test
       stub_request(:get, @bundle1.link.first.url)
         .to_return(body: @bundle2)
 
-      all_resources = @sequence.fetch_all_bundled_resources(@bundle1)
+      all_resources = @sequence.fetch_all_bundled_resources(OpenStruct.new(resource: @bundle1))
       assert all_resources.map(&:id) == ['1', '2']
     end
 
@@ -106,12 +106,14 @@ class SequenceBaseTest < MiniTest::Test
         .to_return(body: '', status: 404)
 
       assert_raises Inferno::AssertionException do
-        @sequence.fetch_all_bundled_resources(@bundle1)
+        @sequence.fetch_all_bundled_resources(OpenStruct.new(resource: @bundle1))
       end
     end
 
     it 'returns resources when no next page' do
-      all_resources = @sequence.fetch_all_bundled_resources(FHIR.from_contents(@bundle2))
+      all_resources = @sequence.fetch_all_bundled_resources(
+        OpenStruct.new(resource: FHIR.from_contents(@bundle2))
+      )
       assert all_resources.map(&:id) == ['2']
     end
   end


### PR DESCRIPTION
This branch adds tests for data absent reasons. It ties into `fetch_all_bundle_resources` and `validate_read_reply` to search each retrieved resource for the data absent reason extension and the data absent reason code. The `TestingInstance` tracks whether each of these have been found, and then the actual data absent reason sequence just checks the values on `TestingInstance`. As part of this branch I also added a way to include static files with the US Core generation.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-582
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
