### PR TITLE
FI-590: Add input for Device type

### DIFF
--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -13,7 +13,7 @@ module Inferno
 
       test_id_prefix '<%=test_id_prefix%>'
 
-      requires :token<%=", :patient_ids" unless delayed_sequence%>
+      requires :token<%=", :patient_ids" unless delayed_sequence%><%=', :device_system, :device_code' if resource == 'Device'  %>
       conformance_supports :<%=resource%><%="
       delayed_sequence" if delayed_sequence%>
 <%=search_validator%>

--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -13,7 +13,7 @@ module Inferno
 
       test_id_prefix '<%=test_id_prefix%>'
 
-      requires :token<%=", :patient_ids" unless delayed_sequence%><%=', :device_system, :device_code' if resource == 'Device'  %>
+      requires :token<%=", :patient_ids" unless delayed_sequence%><%=', :device_codes' if resource == 'Device'  %>
       conformance_supports :<%=resource%><%="
       delayed_sequence" if delayed_sequence%>
 <%=search_validator%>

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -129,7 +129,7 @@ module Inferno
 
       def no_resources_found_message(interaction_test, resource_type)
         if interaction_test
-          "No #{resource_type} resources could be found for this patient. Please use patients with more information."
+          "No #{resource_type} resources appear to be available. Please use patients with more information."
         else
           "No #{resource_type} references found from the prior searches"
         end

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -952,10 +952,9 @@ module Inferno
 
           if sequence[:resource] == 'Device'
             first_search += %(.select do |resource|
-                  resource&.type&.coding&.any? do |coding|
-                    system_match = @instance.device_system.blank? || coding.system == @instance.device_system
-                    code_match = @instance.device_code.blank? || coding.code == @instance.device_code
-                    system_match && code_match
+                  device_codes = @instance&.device_codes&.split(',')&.map(&:strip)
+                  device_codes.blank? || resource&.type&.coding&.any? do |coding|
+                    device_codes.include?(coding.code)
                   end
                 end
             )

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -278,12 +278,13 @@ module Inferno
           index: sequence[:tests].length + 1,
           link: 'https://www.hl7.org/fhir/search.html#revinclude',
           description: "A Server SHALL be capable of supporting the following _revincludes: #{sequence[:revincludes].join(', ')}",
-          test_code: ''
+          test_code: skip_if_not_found_code(sequence)
         }
         search_params = get_search_params(first_search[:names], sequence)
         resolve_param_from_resource = search_params.include? 'get_value_for_search_param'
         if resolve_param_from_resource && !sequence[:delayed_sequence]
           revinclude_test[:test_code] += %(
+
             could_not_resolve_all = []
             resolved_one = false
           )
@@ -450,7 +451,7 @@ module Inferno
               )
             end
             %(
-              #{skip_if_not_found(sequence)}
+              #{skip_if_not_found_code(sequence)}
               #{resolved_one_str if resolve_param_from_resource && !sequence[:delayed_sequence]}
               #{reply_code}
               #{skip_if_could_not_resolve if resolve_param_from_resource && !sequence[:delayed_sequence]}
@@ -499,7 +500,7 @@ module Inferno
         }
 
         search_test[:test_code] = %(
-          #{skip_if_not_found(sequence)}
+          #{skip_if_not_found_code(sequence)}
 
           practitioner_role = @practitioner_role_ary.find { |role| role.practitioner&.reference.present? }
           skip_if practitioner_role.blank?, 'No PractitionerRoles containing a Practitioner reference were found'
@@ -569,7 +570,7 @@ module Inferno
 
         interaction_test[:test_code] = %(
               skip_if_known_not_supported(:#{sequence[:resource]}, [:#{interaction[:code]}])
-              skip 'No #{sequence[:resource]} resources could be found for this patient. Please use patients with more information.' unless @resources_found
+              #{skip_if_not_found_code(sequence)}
 
               validate_#{interaction[:code]}_reply(#{validate_reply_args_string}))
 
@@ -617,7 +618,7 @@ module Inferno
         end
 
         test[:test_code] += %(
-          #{skip_if_not_found(sequence)}
+          #{skip_if_not_found_code(sequence)}
         )
         resource_array = sequence[:delayed_sequence] ? "@#{sequence[:resource].underscore}_ary" : "@#{sequence[:resource].underscore}_ary&.values&.flatten"
 
@@ -740,7 +741,7 @@ module Inferno
         }
         profile_uri = validation_profile_uri(sequence)
         test[:test_code] = %(
-          #{skip_if_not_found(sequence)}
+          #{skip_if_not_found_code(sequence)}
           test_resources_against_profile('#{sequence[:resource]}'#{', ' + profile_uri if profile_uri}))
 
         if sequence[:required_concepts].present?
@@ -844,7 +845,7 @@ module Inferno
         resource_array = sequence[:delayed_sequence] ? "@#{sequence[:resource].underscore}_ary" : "@#{sequence[:resource].underscore}_ary&.values&.flatten"
         test[:test_code] = %(
               skip_if_known_not_supported(:#{sequence[:resource]}, [:search, :read])
-              #{skip_if_not_found(sequence)}
+              #{skip_if_not_found_code(sequence)}
 
               validated_resources = Set.new
               max_resolutions = 50
@@ -918,11 +919,10 @@ module Inferno
             assert_bundle_response(reply)
 
             @resources_found = reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == '#{sequence[:resource]}' }
-            #{skip_if_not_found(sequence)}
-            @#{sequence[:resource].underscore} = reply.resource.entry
-              .find { |entry| entry&.resource&.resourceType == '#{sequence[:resource]}' }
-              .resource
+            #{skip_if_not_found_code(sequence)}
             @#{sequence[:resource].underscore}_ary = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            @#{sequence[:resource].underscore} = @#{sequence[:resource].underscore}_ary
+              .find { |resource| resource.resourceType == '#{sequence[:resource]}' }
 
             save_resource_references(#{save_resource_references_arguments})
             save_delayed_sequence_references(@#{sequence[:resource].underscore}_ary)
@@ -942,11 +942,6 @@ module Inferno
 
               next unless any_resources
 
-              @resources_found = true
-
-              @#{sequence[:resource].underscore} = reply.resource.entry
-                .find { |entry| entry&.resource&.resourceType == '#{sequence[:resource]}' }
-                .resource
               @#{sequence[:resource].underscore}_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           )
 
@@ -957,16 +952,23 @@ module Inferno
                     device_codes.include?(coding.code)
                   end
                 end
+              if  @#{sequence[:resource].underscore}_ary[patient].blank? && reply&.resource&.entry&.present?
+                @skip_if_not_found_message = "No Devices of the specified type (\#{@instance&.device_codes}) were found"
+              end
             )
           end
 
           first_search + %(
+              @#{sequence[:resource].underscore} = @#{sequence[:resource].underscore}_ary[patient]
+                .find { |resource| resource.resourceType == '#{sequence[:resource]}' }
+              @resources_found = @#{sequence[:resource].underscore}.present?
+
               save_resource_references(#{save_resource_references_arguments})
               save_delayed_sequence_references(@#{sequence[:resource].underscore}_ary[patient])
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
             end
 
-            #{skip_if_not_found(sequence)}
+            #{skip_if_not_found_code(sequence)}
           )
         end
       end
@@ -1025,7 +1027,7 @@ module Inferno
               break#{' if values_found == 2' if find_two_values}
             end
           end
-          #{skip_if_not_found(sequence)})
+          #{skip_if_not_found_code(sequence)})
       end
 
       def get_search_params(search_parameters, sequence, grab_first_value = false)
@@ -1106,9 +1108,8 @@ module Inferno
         end
       end
 
-      def skip_if_not_found(sequence)
-        use_other_patient = ' Please use patients with more information.'
-        "skip 'No #{sequence[:resource]} resources appear to be available.#{use_other_patient unless sequence[:delayed_sequence]}' unless @resources_found"
+      def skip_if_not_found_code(sequence)
+        "skip_if_not_found(resource_type: '#{sequence[:resource]}', delayed: #{sequence[:delayed_sequence]})"
       end
 
       def skip_if_could_not_resolve

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -64,6 +64,9 @@ module Inferno
       property :data_absent_code_found, Boolean
       property :data_absent_extension_found, Boolean
 
+      property :device_system, String
+      property :device_code, String
+
       # Bulk Data Parameters
       property :bulk_url, String
       property :bulk_token_endpoint, String

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -64,8 +64,7 @@ module Inferno
       property :data_absent_code_found, Boolean
       property :data_absent_extension_found, Boolean
 
-      property :device_system, String
-      property :device_code, String
+      property :device_codes, String
 
       # Bulk Data Parameters
       property :bulk_url, String

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -250,14 +250,20 @@ module Inferno
         reload
       end
 
+      def save_resource_references(klass, resources, profile = nil)
+        resources
+          .select { |resource| resource.is_a? klass }
+          .each do |resource|
+            save_resource_reference(klass.name.demodulize, resource.id, profile)
+          end
+      end
+
       def save_resource_ids_in_bundle(klass, reply, profile = nil)
         return if reply&.resource&.entry&.blank?
 
-        reply.resource.entry
-          .select { |entry| entry.resource.class == klass }
-          .each do |entry|
-          save_resource_reference(klass.name.demodulize, entry.resource.id, profile)
-        end
+        resources = reply.resource.entry.map(&:resource)
+
+        save_resource_references(klass, resources, profile)
       end
 
       def versioned_conformance_class

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -54,6 +54,7 @@ module Inferno
       delegate :versioned_resource_class, to: :@client
       delegate :versioned_conformance_class, to: :@instance
       delegate :save_resource_ids_in_bundle, to: :@instance
+      delegate :save_resource_references, to: :@instance
 
       def initialize(instance, client, disable_tls_tests = false, sequence_result = nil)
         @client = client

--- a/lib/app/utils/skip_helpers.rb
+++ b/lib/app/utils/skip_helpers.rb
@@ -26,5 +26,11 @@ module Inferno
         skip "Invalid #{url_name} URI: '#{url}'", details
       end
     end
+
+    def skip_if_not_found(resource_type:, delayed:)
+      default_message = "No #{resource_type} resources appear to be available."
+      default_message += ' Please use patients with more information.' unless delayed
+      skip_unless @resources_found, @skip_if_not_found_message || default_message
+    end
   end
 end

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -231,18 +231,11 @@
               value: instance.refresh_token,
               })%>
 
-        <%= erb(:prerequisite_field,{},{prerequisite: :device_code,
+        <%= erb(:prerequisite_field,{},{prerequisite: :device_codes,
               label: 'Implantable Device Type Code',
-              description: 'Enter the code for an Implantable Device type. If blank, Inferno will validate all Device resources against the Implantable Device profile',
+              description: 'Enter the code for an Implantable Device type, or multiple codes separated by commas. If blank, Inferno will validate all Device resources against the Implantable Device profile',
               instance: instance,
-              value: instance.device_code,
-        })%>
-
-        <%= erb(:prerequisite_field,{},{prerequisite: :device_system,
-              label: 'Implantable Device Type System',
-              description: 'Enter the system for an Implantable Device type',
-              instance: instance,
-              value: instance.device_system,
+              value: instance.device_codes,
         })%>
 
         <%= erb(:prerequisite_field,{},{prerequisite: :group_id,

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -231,6 +231,20 @@
               value: instance.refresh_token,
               })%>
 
+        <%= erb(:prerequisite_field,{},{prerequisite: :device_code,
+              label: 'Implantable Device Type Code',
+              description: 'Enter the code for an Implantable Device type. If blank, Inferno will validate all Device resources against the Implantable Device profile',
+              instance: instance,
+              value: instance.device_code,
+        })%>
+
+        <%= erb(:prerequisite_field,{},{prerequisite: :device_system,
+              label: 'Implantable Device Type System',
+              description: 'Enter the system for an Implantable Device type',
+              instance: instance,
+              value: instance.device_system,
+        })%>
+
         <%= erb(:prerequisite_field,{},{prerequisite: :group_id,
               label: 'Group ID',
               instance: instance,

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -404,6 +404,26 @@
               value: instance.refresh_token,
               })%>
 
+        <%= erb(:prerequisite_field,{},{prerequisite: :device_code,
+              label: 'Implantable Device Type Code',
+              description: 'Enter the code for an Implantable Device type. If blank, Inferno will validate all Device resources against the Implantable Device profile',
+              instance: instance,
+              value: instance.device_code,
+        })%>
+
+        <%= erb(:prerequisite_field,{},{prerequisite: :device_system,
+              label: 'Implantable Device Type System',
+              description: 'Enter the system for an Implantable Device type',
+              instance: instance,
+              value: instance.device_system,
+        })%>
+
+        <%= erb(:prerequisite_field,{},{prerequisite: :group_id,
+                                        label: 'Group ID',
+                                        instance: instance,
+                                        value: instance.group_id,
+        })%>                 
+
         <%= erb(:prerequisite_field,{},{prerequisite: :group_id,
               label: 'Group ID',
               instance: instance,

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -404,18 +404,11 @@
               value: instance.refresh_token,
               })%>
 
-        <%= erb(:prerequisite_field,{},{prerequisite: :device_code,
+        <%= erb(:prerequisite_field,{},{prerequisite: :device_codes,
               label: 'Implantable Device Type Code',
-              description: 'Enter the code for an Implantable Device type. If blank, Inferno will validate all Device resources against the Implantable Device profile',
+              description: 'Enter the code for an Implantable Device type, or multiple codes separated by commas. If blank, Inferno will validate all Device resources against the Implantable Device profile',
               instance: instance,
-              value: instance.device_code,
-        })%>
-
-        <%= erb(:prerequisite_field,{},{prerequisite: :device_system,
-              label: 'Implantable Device Type System',
-              description: 'Enter the system for an Implantable Device type',
-              instance: instance,
-              value: instance.device_system,
+              value: instance.device_codes,
         })%>
 
         <%= erb(:prerequisite_field,{},{prerequisite: :group_id,

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:body_height])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:body_height])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:body_height])
       end
 
@@ -496,7 +497,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -577,7 +578,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:body_temperature])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:body_temperature])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:body_temperature])
       end
 
@@ -496,7 +497,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -577,7 +578,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:body_weight])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:body_weight])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:body_weight])
       end
 
@@ -496,7 +497,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -577,7 +578,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:blood_pressure])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:blood_pressure])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:blood_pressure])
       end
 
@@ -488,7 +489,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -565,7 +566,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:head_circumference])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:head_circumference])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:head_circumference])
       end
 
@@ -496,7 +497,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -577,7 +578,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:heart_rate])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:heart_rate])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:heart_rate])
       end
 
@@ -496,7 +497,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -577,7 +578,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
       end
 
@@ -492,7 +493,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -564,7 +565,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
       end
 
@@ -492,7 +493,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -564,7 +565,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:resp_rate])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:resp_rate])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:resp_rate])
       end
 
@@ -496,7 +497,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -577,7 +578,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310BpSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -292,7 +292,7 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No AllergyIntolerance resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -544,7 +544,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No CarePlan resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No CarePlan resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -195,7 +195,7 @@ describe Inferno::Sequence::USCore310CareteamSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No CareTeam resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No CareTeam resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -678,7 +678,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Condition resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Condition resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -855,7 +855,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -855,7 +855,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -949,7 +949,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No DocumentReference resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No DocumentReference resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -946,7 +946,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Encounter resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Encounter resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -408,7 +408,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Goal resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Goal resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -408,7 +408,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Immunization resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Immunization resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -229,7 +229,7 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Device resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Device resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -633,7 +633,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No MedicationRequest resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No MedicationRequest resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -587,7 +587,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Patient resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Patient resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -525,7 +525,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Procedure resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Procedure resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -730,7 +730,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @sequence.instance_variable_set(:'@resources_found', false)
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
     end
 
     it 'fails if a non-success response code is received' do

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -131,18 +131,18 @@ module Inferno
 
           next unless any_resources
 
-          @resources_found = true
-
-          @allergy_intolerance = reply.resource.entry
-            .find { |entry| entry&.resource&.resourceType == 'AllergyIntolerance' }
-            .resource
           @allergy_intolerance_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          save_resource_ids_in_bundle(versioned_resource_class('AllergyIntolerance'), reply)
+
+          @allergy_intolerance = @allergy_intolerance_ary[patient]
+            .find { |resource| resource.resourceType == 'AllergyIntolerance' }
+          @resources_found = @allergy_intolerance.present?
+
+          save_resource_references(versioned_resource_class('AllergyIntolerance'), @allergy_intolerance_ary[patient])
           save_delayed_sequence_references(@allergy_intolerance_ary[patient])
           validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)
         end
 
-        skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
       end
 
       test :search_by_patient_clinical_status do
@@ -159,7 +159,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -196,7 +196,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:AllergyIntolerance, [:read])
-        skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
 
         validate_read_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'), check_for_data_absent_reasons)
       end
@@ -214,7 +214,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:AllergyIntolerance, [:vread])
-        skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
 
         validate_vread_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'))
       end
@@ -232,7 +232,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:AllergyIntolerance, [:history])
-        skip 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
 
         validate_history_reply(@allergy_intolerance, versioned_resource_class('AllergyIntolerance'))
       end
@@ -246,7 +246,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
         provenance_results = []
         patient_ids.each do |patient|
           search_params = {
@@ -286,7 +286,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
         test_resources_against_profile('AllergyIntolerance') do |resource|
           ['clinicalStatus', 'verificationStatus'].flat_map do |path|
             concepts = resolve_path(resource, path)
@@ -322,7 +322,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
 
         must_support_elements = [
           { path: 'AllergyIntolerance.clinicalStatus' },
@@ -356,7 +356,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:AllergyIntolerance, [:search, :read])
-        skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -146,14 +146,14 @@ module Inferno
               .resource
             @care_plan_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('CarePlan'), reply)
+            save_resource_references(versioned_resource_class('CarePlan'), @care_plan_ary[patient])
             save_delayed_sequence_references(@care_plan_ary[patient])
             validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
 
             break
           end
         end
-        skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -171,7 +171,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -221,7 +221,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -269,7 +269,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -307,7 +307,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:CarePlan, [:read])
-        skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         validate_read_reply(@care_plan, versioned_resource_class('CarePlan'), check_for_data_absent_reasons)
       end
@@ -325,7 +325,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:CarePlan, [:vread])
-        skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         validate_vread_reply(@care_plan, versioned_resource_class('CarePlan'))
       end
@@ -343,7 +343,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:CarePlan, [:history])
-        skip 'No CarePlan resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         validate_history_reply(@care_plan, versioned_resource_class('CarePlan'))
       end
@@ -357,6 +357,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -403,7 +404,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
         test_resources_against_profile('CarePlan')
       end
 
@@ -434,7 +435,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         must_support_slices = [
           {
@@ -492,7 +493,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:CarePlan, [:search, :read])
-        skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -137,14 +137,14 @@ module Inferno
             @care_team_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             values_found += 1
 
-            save_resource_ids_in_bundle(versioned_resource_class('CareTeam'), reply)
+            save_resource_references(versioned_resource_class('CareTeam'), @care_team_ary[patient])
             save_delayed_sequence_references(@care_team_ary[patient])
             validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)
 
             break if values_found == 2
           end
         end
-        skip 'No CareTeam resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CareTeam', delayed: false)
       end
 
       test :read_interaction do
@@ -159,7 +159,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:CareTeam, [:read])
-        skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CareTeam', delayed: false)
 
         validate_read_reply(@care_team, versioned_resource_class('CareTeam'), check_for_data_absent_reasons)
       end
@@ -177,7 +177,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:CareTeam, [:vread])
-        skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CareTeam', delayed: false)
 
         validate_vread_reply(@care_team, versioned_resource_class('CareTeam'))
       end
@@ -195,7 +195,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:CareTeam, [:history])
-        skip 'No CareTeam resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CareTeam', delayed: false)
 
         validate_history_reply(@care_team, versioned_resource_class('CareTeam'))
       end
@@ -209,6 +209,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'CareTeam', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -253,7 +254,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No CareTeam resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CareTeam', delayed: false)
         test_resources_against_profile('CareTeam')
       end
 
@@ -280,7 +281,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No CareTeam resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CareTeam', delayed: false)
 
         must_support_elements = [
           { path: 'CareTeam.status' },
@@ -358,7 +359,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:CareTeam, [:search, :read])
-        skip 'No CareTeam resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'CareTeam', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -143,18 +143,18 @@ module Inferno
 
           next unless any_resources
 
-          @resources_found = true
-
-          @condition = reply.resource.entry
-            .find { |entry| entry&.resource&.resourceType == 'Condition' }
-            .resource
           @condition_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          save_resource_ids_in_bundle(versioned_resource_class('Condition'), reply)
+
+          @condition = @condition_ary[patient]
+            .find { |resource| resource.resourceType == 'Condition' }
+          @resources_found = @condition.present?
+
+          save_resource_references(versioned_resource_class('Condition'), @condition_ary[patient])
           save_delayed_sequence_references(@condition_ary[patient])
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
         end
 
-        skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
       end
 
       test :search_by_patient_category do
@@ -171,7 +171,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -213,7 +213,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -261,7 +261,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -300,7 +300,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -339,7 +339,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Condition, [:read])
-        skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         validate_read_reply(@condition, versioned_resource_class('Condition'), check_for_data_absent_reasons)
       end
@@ -357,7 +357,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Condition, [:vread])
-        skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         validate_vread_reply(@condition, versioned_resource_class('Condition'))
       end
@@ -375,7 +375,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Condition, [:history])
-        skip 'No Condition resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         validate_history_reply(@condition, versioned_resource_class('Condition'))
       end
@@ -389,7 +389,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
         provenance_results = []
         patient_ids.each do |patient|
           search_params = {
@@ -429,7 +429,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
         test_resources_against_profile('Condition') do |resource|
           ['clinicalStatus', 'verificationStatus'].flat_map do |path|
             concepts = resolve_path(resource, path)
@@ -467,7 +467,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         must_support_elements = [
           { path: 'Condition.clinicalStatus' },
@@ -502,7 +502,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Condition, [:search, :read])
-        skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @diagnostic_report_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
+            save_resource_references(versioned_resource_class('DiagnosticReport'), @diagnostic_report_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
             save_delayed_sequence_references(@diagnostic_report_ary[patient])
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
             break
           end
         end
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
       end
 
       test :search_by_patient do
@@ -173,7 +173,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         patient_ids.each do |patient|
           search_params = {
@@ -201,7 +201,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -242,7 +242,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -291,7 +291,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -331,7 +331,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -378,7 +378,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DiagnosticReport, [:read])
-        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'), check_for_data_absent_reasons)
       end
@@ -396,7 +396,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DiagnosticReport, [:vread])
-        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validate_vread_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
@@ -414,7 +414,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DiagnosticReport, [:history])
-        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validate_history_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
@@ -428,6 +428,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -474,7 +475,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
         test_resources_against_profile('DiagnosticReport', Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_lab])
       end
 
@@ -509,7 +510,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         must_support_slices = [
           {
@@ -569,7 +570,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DiagnosticReport, [:search, :read])
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @diagnostic_report_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('DiagnosticReport'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
+            save_resource_references(versioned_resource_class('DiagnosticReport'), @diagnostic_report_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
             save_delayed_sequence_references(@diagnostic_report_ary[patient])
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
             break
           end
         end
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
       end
 
       test :search_by_patient do
@@ -173,7 +173,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         patient_ids.each do |patient|
           search_params = {
@@ -201,7 +201,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -242,7 +242,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -291,7 +291,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -331,7 +331,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -378,7 +378,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DiagnosticReport, [:read])
-        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validate_read_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'), check_for_data_absent_reasons)
       end
@@ -396,7 +396,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DiagnosticReport, [:vread])
-        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validate_vread_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
@@ -414,7 +414,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DiagnosticReport, [:history])
-        skip 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validate_history_reply(@diagnostic_report, versioned_resource_class('DiagnosticReport'))
       end
@@ -428,6 +428,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -474,7 +475,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
         test_resources_against_profile('DiagnosticReport', Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
       end
 
@@ -509,7 +510,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         must_support_elements = [
           { path: 'DiagnosticReport.status' },
@@ -548,7 +549,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DiagnosticReport, [:search, :read])
-        skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -151,18 +151,18 @@ module Inferno
 
           next unless any_resources
 
-          @resources_found = true
-
-          @document_reference = reply.resource.entry
-            .find { |entry| entry&.resource&.resourceType == 'DocumentReference' }
-            .resource
           @document_reference_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          save_resource_ids_in_bundle(versioned_resource_class('DocumentReference'), reply)
+
+          @document_reference = @document_reference_ary[patient]
+            .find { |resource| resource.resourceType == 'DocumentReference' }
+          @resources_found = @document_reference.present?
+
+          save_resource_references(versioned_resource_class('DocumentReference'), @document_reference_ary[patient])
           save_delayed_sequence_references(@document_reference_ary[patient])
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
       end
 
       test :search_by__id do
@@ -178,7 +178,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -217,7 +217,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -258,7 +258,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -299,7 +299,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -341,7 +341,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -390,7 +390,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -427,7 +427,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DocumentReference, [:read])
-        skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         validate_read_reply(@document_reference, versioned_resource_class('DocumentReference'), check_for_data_absent_reasons)
       end
@@ -445,7 +445,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DocumentReference, [:vread])
-        skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         validate_vread_reply(@document_reference, versioned_resource_class('DocumentReference'))
       end
@@ -463,7 +463,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DocumentReference, [:history])
-        skip 'No DocumentReference resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         validate_history_reply(@document_reference, versioned_resource_class('DocumentReference'))
       end
@@ -493,7 +493,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
         provenance_results = []
         patient_ids.each do |patient|
           search_params = {
@@ -533,7 +533,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
         test_resources_against_profile('DocumentReference') do |resource|
           ['type'].flat_map do |path|
             concepts = resolve_path(resource, path)
@@ -595,7 +595,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         must_support_elements = [
           { path: 'DocumentReference.identifier' },
@@ -642,7 +642,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:DocumentReference, [:search, :read])
-        skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -151,18 +151,18 @@ module Inferno
 
           next unless any_resources
 
-          @resources_found = true
-
-          @encounter = reply.resource.entry
-            .find { |entry| entry&.resource&.resourceType == 'Encounter' }
-            .resource
           @encounter_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          save_resource_ids_in_bundle(versioned_resource_class('Encounter'), reply)
+
+          @encounter = @encounter_ary[patient]
+            .find { |resource| resource.resourceType == 'Encounter' }
+          @resources_found = @encounter.present?
+
+          save_resource_references(versioned_resource_class('Encounter'), @encounter_ary[patient])
           save_delayed_sequence_references(@encounter_ary[patient])
           validate_search_reply(versioned_resource_class('Encounter'), reply, search_params)
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
       end
 
       test :search_by__id do
@@ -178,7 +178,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -218,7 +218,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -266,7 +266,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -306,7 +306,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -345,7 +345,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -386,7 +386,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -425,7 +425,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Encounter, [:read])
-        skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         validate_read_reply(@encounter, versioned_resource_class('Encounter'), check_for_data_absent_reasons)
       end
@@ -443,7 +443,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Encounter, [:vread])
-        skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         validate_vread_reply(@encounter, versioned_resource_class('Encounter'))
       end
@@ -461,7 +461,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Encounter, [:history])
-        skip 'No Encounter resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         validate_history_reply(@encounter, versioned_resource_class('Encounter'))
       end
@@ -475,7 +475,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
         provenance_results = []
         patient_ids.each do |patient|
           search_params = {
@@ -511,7 +511,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
         test_resources_against_profile('Encounter')
       end
 
@@ -562,7 +562,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         must_support_elements = [
           { path: 'Encounter.identifier' },
@@ -609,7 +609,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Encounter, [:search, :read])
-        skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -135,18 +135,18 @@ module Inferno
 
           next unless any_resources
 
-          @resources_found = true
-
-          @goal = reply.resource.entry
-            .find { |entry| entry&.resource&.resourceType == 'Goal' }
-            .resource
           @goal_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          save_resource_ids_in_bundle(versioned_resource_class('Goal'), reply)
+
+          @goal = @goal_ary[patient]
+            .find { |resource| resource.resourceType == 'Goal' }
+          @resources_found = @goal.present?
+
+          save_resource_references(versioned_resource_class('Goal'), @goal_ary[patient])
           save_delayed_sequence_references(@goal_ary[patient])
           validate_search_reply(versioned_resource_class('Goal'), reply, search_params)
         end
 
-        skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
       end
 
       test :search_by_patient_target_date do
@@ -164,7 +164,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -212,7 +212,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -249,7 +249,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Goal, [:read])
-        skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
 
         validate_read_reply(@goal, versioned_resource_class('Goal'), check_for_data_absent_reasons)
       end
@@ -267,7 +267,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Goal, [:vread])
-        skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
 
         validate_vread_reply(@goal, versioned_resource_class('Goal'))
       end
@@ -285,7 +285,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Goal, [:history])
-        skip 'No Goal resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
 
         validate_history_reply(@goal, versioned_resource_class('Goal'))
       end
@@ -299,7 +299,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
         provenance_results = []
         patient_ids.each do |patient|
           search_params = {
@@ -335,7 +335,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
         test_resources_against_profile('Goal')
       end
 
@@ -362,7 +362,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
 
         must_support_slices = [
           {
@@ -416,7 +416,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Goal, [:search, :read])
-        skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Goal', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -135,18 +135,18 @@ module Inferno
 
           next unless any_resources
 
-          @resources_found = true
-
-          @immunization = reply.resource.entry
-            .find { |entry| entry&.resource&.resourceType == 'Immunization' }
-            .resource
           @immunization_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          save_resource_ids_in_bundle(versioned_resource_class('Immunization'), reply)
+
+          @immunization = @immunization_ary[patient]
+            .find { |resource| resource.resourceType == 'Immunization' }
+          @resources_found = @immunization.present?
+
+          save_resource_references(versioned_resource_class('Immunization'), @immunization_ary[patient])
           save_delayed_sequence_references(@immunization_ary[patient])
           validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)
         end
 
-        skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
       end
 
       test :search_by_patient_date do
@@ -164,7 +164,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -212,7 +212,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -249,7 +249,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Immunization, [:read])
-        skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
         validate_read_reply(@immunization, versioned_resource_class('Immunization'), check_for_data_absent_reasons)
       end
@@ -267,7 +267,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Immunization, [:vread])
-        skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
         validate_vread_reply(@immunization, versioned_resource_class('Immunization'))
       end
@@ -285,7 +285,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Immunization, [:history])
-        skip 'No Immunization resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
         validate_history_reply(@immunization, versioned_resource_class('Immunization'))
       end
@@ -299,7 +299,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
         provenance_results = []
         patient_ids.each do |patient|
           search_params = {
@@ -335,7 +335,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
         test_resources_against_profile('Immunization')
       end
 
@@ -364,7 +364,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
         must_support_elements = [
           { path: 'Immunization.status' },
@@ -400,7 +400,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Immunization, [:search, :read])
-        skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -137,13 +137,14 @@ module Inferno
 
         assert_response_ok(reply)
         assert_bundle_response(reply)
+
         @resources_found = reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == 'Location' }
-        skip 'No Location resources appear to be available.' unless @resources_found
-        @location = reply.resource.entry
-          .find { |entry| entry&.resource&.resourceType == 'Location' }
-          .resource
+        skip_if_not_found(resource_type: 'Location', delayed: true)
         @location_ary = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-        save_resource_ids_in_bundle(versioned_resource_class('Location'), reply)
+        @location = @location_ary
+          .find { |resource| resource.resourceType == 'Location' }
+
+        save_resource_references(versioned_resource_class('Location'), @location_ary)
         save_delayed_sequence_references(@location_ary)
         validate_search_reply(versioned_resource_class('Location'), reply, search_params)
       end
@@ -161,7 +162,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Location resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
 
         search_params = {
           'address': get_value_for_search_param(resolve_element_from_path(@location_ary, 'address'))
@@ -188,7 +189,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Location resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
 
         search_params = {
           'address-city': get_value_for_search_param(resolve_element_from_path(@location_ary, 'address.city'))
@@ -215,7 +216,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Location resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
 
         search_params = {
           'address-state': get_value_for_search_param(resolve_element_from_path(@location_ary, 'address.state'))
@@ -242,7 +243,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Location resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
 
         search_params = {
           'address-postalcode': get_value_for_search_param(resolve_element_from_path(@location_ary, 'address.postalCode'))
@@ -268,7 +269,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Location, [:vread])
-        skip 'No Location resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
 
         validate_vread_reply(@location, versioned_resource_class('Location'))
       end
@@ -286,7 +287,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Location, [:history])
-        skip 'No Location resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
 
         validate_history_reply(@location, versioned_resource_class('Location'))
       end
@@ -300,7 +301,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Location', delayed: true)
         provenance_results = []
 
         search_params = {
@@ -335,7 +336,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Location resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
         test_resources_against_profile('Location')
       end
 
@@ -370,7 +371,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Location resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
 
         must_support_elements = [
           { path: 'Location.status' },
@@ -409,7 +410,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Location, [:search, :read])
-        skip 'No Location resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Location', delayed: true)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medication_sequence.rb
@@ -67,7 +67,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Medication, [:vread])
-        skip 'No Medication resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Medication', delayed: true)
 
         validate_vread_reply(@medication, versioned_resource_class('Medication'))
       end
@@ -85,7 +85,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Medication, [:history])
-        skip 'No Medication resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Medication', delayed: true)
 
         validate_history_reply(@medication, versioned_resource_class('Medication'))
       end
@@ -104,7 +104,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Medication resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Medication', delayed: true)
         test_resources_against_profile('Medication')
       end
 
@@ -123,7 +123,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Medication resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Medication', delayed: true)
 
         must_support_elements = [
           { path: 'Medication.code' }
@@ -154,7 +154,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Medication, [:search, :read])
-        skip 'No Medication resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Medication', delayed: true)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -172,14 +172,14 @@ module Inferno
               .resource
             @medication_request_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('MedicationRequest'), reply)
+            save_resource_references(versioned_resource_class('MedicationRequest'), @medication_request_ary[patient])
             save_delayed_sequence_references(@medication_request_ary[patient])
             validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
             test_medication_inclusion(@medication_request_ary[patient], search_params)
             break
           end
         end
-        skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
       end
 
       test :search_by_patient_intent_status do
@@ -199,7 +199,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -244,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -292,7 +292,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -333,7 +333,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:MedicationRequest, [:read])
-        skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         validate_read_reply(@medication_request, versioned_resource_class('MedicationRequest'), check_for_data_absent_reasons)
       end
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:MedicationRequest, [:vread])
-        skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         validate_vread_reply(@medication_request, versioned_resource_class('MedicationRequest'))
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:MedicationRequest, [:history])
-        skip 'No MedicationRequest resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         validate_history_reply(@medication_request, versioned_resource_class('MedicationRequest'))
       end
@@ -419,6 +419,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -465,7 +466,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
         test_resources_against_profile('MedicationRequest')
       end
 
@@ -502,7 +503,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         must_support_elements = [
           { path: 'MedicationRequest.status' },
@@ -586,7 +587,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:MedicationRequest, [:search, :read])
-        skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_code do
@@ -173,7 +173,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -214,7 +214,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
       end
 
@@ -480,7 +481,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -539,7 +540,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -125,13 +125,14 @@ module Inferno
 
         assert_response_ok(reply)
         assert_bundle_response(reply)
+
         @resources_found = reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == 'Organization' }
-        skip 'No Organization resources appear to be available.' unless @resources_found
-        @organization = reply.resource.entry
-          .find { |entry| entry&.resource&.resourceType == 'Organization' }
-          .resource
+        skip_if_not_found(resource_type: 'Organization', delayed: true)
         @organization_ary = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-        save_resource_ids_in_bundle(versioned_resource_class('Organization'), reply)
+        @organization = @organization_ary
+          .find { |resource| resource.resourceType == 'Organization' }
+
+        save_resource_references(versioned_resource_class('Organization'), @organization_ary)
         save_delayed_sequence_references(@organization_ary)
         validate_search_reply(versioned_resource_class('Organization'), reply, search_params)
       end
@@ -149,7 +150,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Organization resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Organization', delayed: true)
 
         search_params = {
           'address': get_value_for_search_param(resolve_element_from_path(@organization_ary, 'address'))
@@ -175,7 +176,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Organization, [:vread])
-        skip 'No Organization resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Organization', delayed: true)
 
         validate_vread_reply(@organization, versioned_resource_class('Organization'))
       end
@@ -193,7 +194,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Organization, [:history])
-        skip 'No Organization resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Organization', delayed: true)
 
         validate_history_reply(@organization, versioned_resource_class('Organization'))
       end
@@ -207,7 +208,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Organization', delayed: true)
         provenance_results = []
 
         search_params = {
@@ -242,7 +243,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Organization resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Organization', delayed: true)
         test_resources_against_profile('Organization')
       end
 
@@ -287,7 +288,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Organization resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Organization', delayed: true)
 
         must_support_slices = [
           {
@@ -359,7 +360,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Organization, [:search, :read])
-        skip 'No Organization resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Organization', delayed: true)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -123,18 +123,18 @@ module Inferno
 
           next unless any_resources
 
-          @resources_found = true
-
-          @patient = reply.resource.entry
-            .find { |entry| entry&.resource&.resourceType == 'Patient' }
-            .resource
           @patient_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          save_resource_ids_in_bundle(versioned_resource_class('Patient'), reply)
+
+          @patient = @patient_ary[patient]
+            .find { |resource| resource.resourceType == 'Patient' }
+          @resources_found = @patient.present?
+
+          save_resource_references(versioned_resource_class('Patient'), @patient_ary[patient])
           save_delayed_sequence_references(@patient_ary[patient])
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
       end
 
       test :search_by_identifier do
@@ -150,7 +150,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -187,7 +187,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -224,7 +224,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -262,7 +262,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -301,7 +301,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -340,7 +340,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -377,7 +377,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Patient, [:read])
-        skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         validate_read_reply(@patient, versioned_resource_class('Patient'), check_for_data_absent_reasons)
       end
@@ -395,7 +395,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Patient, [:vread])
-        skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         validate_vread_reply(@patient, versioned_resource_class('Patient'))
       end
@@ -413,7 +413,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Patient, [:history])
-        skip 'No Patient resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         validate_history_reply(@patient, versioned_resource_class('Patient'))
       end
@@ -427,7 +427,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
         provenance_results = []
         patient_ids.each do |patient|
           search_params = {
@@ -461,7 +461,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
         test_resources_against_profile('Patient')
       end
 
@@ -524,7 +524,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         must_support_extensions = {
           'Patient.extension:race': 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
@@ -587,7 +587,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Patient, [:search, :read])
-        skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -126,13 +126,14 @@ module Inferno
 
         assert_response_ok(reply)
         assert_bundle_response(reply)
+
         @resources_found = reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == 'Practitioner' }
-        skip 'No Practitioner resources appear to be available.' unless @resources_found
-        @practitioner = reply.resource.entry
-          .find { |entry| entry&.resource&.resourceType == 'Practitioner' }
-          .resource
+        skip_if_not_found(resource_type: 'Practitioner', delayed: true)
         @practitioner_ary = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-        save_resource_ids_in_bundle(versioned_resource_class('Practitioner'), reply)
+        @practitioner = @practitioner_ary
+          .find { |resource| resource.resourceType == 'Practitioner' }
+
+        save_resource_references(versioned_resource_class('Practitioner'), @practitioner_ary)
         save_delayed_sequence_references(@practitioner_ary)
         validate_search_reply(versioned_resource_class('Practitioner'), reply, search_params)
       end
@@ -150,7 +151,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Practitioner resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Practitioner', delayed: true)
 
         search_params = {
           'identifier': get_value_for_search_param(resolve_element_from_path(@practitioner_ary, 'identifier'))
@@ -176,7 +177,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Practitioner, [:vread])
-        skip 'No Practitioner resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Practitioner', delayed: true)
 
         validate_vread_reply(@practitioner, versioned_resource_class('Practitioner'))
       end
@@ -194,7 +195,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Practitioner, [:history])
-        skip 'No Practitioner resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Practitioner', delayed: true)
 
         validate_history_reply(@practitioner, versioned_resource_class('Practitioner'))
       end
@@ -208,7 +209,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Practitioner', delayed: true)
         provenance_results = []
 
         search_params = {
@@ -243,7 +244,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Practitioner resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Practitioner', delayed: true)
         test_resources_against_profile('Practitioner')
       end
 
@@ -272,7 +273,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Practitioner resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Practitioner', delayed: true)
 
         must_support_slices = [
           {
@@ -328,7 +329,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Practitioner, [:search, :read])
-        skip 'No Practitioner resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Practitioner', delayed: true)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -119,13 +119,14 @@ module Inferno
 
         assert_response_ok(reply)
         assert_bundle_response(reply)
+
         @resources_found = reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == 'PractitionerRole' }
-        skip 'No PractitionerRole resources appear to be available.' unless @resources_found
-        @practitioner_role = reply.resource.entry
-          .find { |entry| entry&.resource&.resourceType == 'PractitionerRole' }
-          .resource
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
         @practitioner_role_ary = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-        save_resource_ids_in_bundle(versioned_resource_class('PractitionerRole'), reply)
+        @practitioner_role = @practitioner_role_ary
+          .find { |resource| resource.resourceType == 'PractitionerRole' }
+
+        save_resource_references(versioned_resource_class('PractitionerRole'), @practitioner_role_ary)
         save_delayed_sequence_references(@practitioner_role_ary)
         validate_search_reply(versioned_resource_class('PractitionerRole'), reply, search_params)
       end
@@ -143,7 +144,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No PractitionerRole resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
 
         search_params = {
           'practitioner': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'practitioner'))
@@ -170,7 +171,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No PractitionerRole resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
 
         practitioner_role = @practitioner_role_ary.find { |role| role.practitioner&.reference.present? }
         skip_if practitioner_role.blank?, 'No PractitionerRoles containing a Practitioner reference were found'
@@ -225,7 +226,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:PractitionerRole, [:vread])
-        skip 'No PractitionerRole resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
 
         validate_vread_reply(@practitioner_role, versioned_resource_class('PractitionerRole'))
       end
@@ -243,7 +244,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:PractitionerRole, [:history])
-        skip 'No PractitionerRole resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
 
         validate_history_reply(@practitioner_role, versioned_resource_class('PractitionerRole'))
       end
@@ -289,7 +290,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
         provenance_results = []
 
         search_params = {
@@ -324,7 +325,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No PractitionerRole resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
         test_resources_against_profile('PractitionerRole')
       end
 
@@ -359,7 +360,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No PractitionerRole resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
 
         must_support_elements = [
           { path: 'PractitionerRole.practitioner' },
@@ -398,7 +399,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:PractitionerRole, [:search, :read])
-        skip 'No PractitionerRole resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -139,18 +139,18 @@ module Inferno
 
           next unless any_resources
 
-          @resources_found = true
-
-          @procedure = reply.resource.entry
-            .find { |entry| entry&.resource&.resourceType == 'Procedure' }
-            .resource
           @procedure_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          save_resource_ids_in_bundle(versioned_resource_class('Procedure'), reply)
+
+          @procedure = @procedure_ary[patient]
+            .find { |resource| resource.resourceType == 'Procedure' }
+          @resources_found = @procedure.present?
+
+          save_resource_references(versioned_resource_class('Procedure'), @procedure_ary[patient])
           save_delayed_sequence_references(@procedure_ary[patient])
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
         end
 
-        skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
       end
 
       test :search_by_patient_date do
@@ -167,7 +167,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -216,7 +216,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -265,7 +265,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -302,7 +302,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Procedure, [:read])
-        skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         validate_read_reply(@procedure, versioned_resource_class('Procedure'), check_for_data_absent_reasons)
       end
@@ -320,7 +320,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Procedure, [:vread])
-        skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         validate_vread_reply(@procedure, versioned_resource_class('Procedure'))
       end
@@ -338,7 +338,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Procedure, [:history])
-        skip 'No Procedure resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         validate_history_reply(@procedure, versioned_resource_class('Procedure'))
       end
@@ -352,7 +352,7 @@ module Inferno
           )
           versions :r4
         end
-
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
         provenance_results = []
         patient_ids.each do |patient|
           search_params = {
@@ -388,7 +388,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
         test_resources_against_profile('Procedure')
       end
 
@@ -413,7 +413,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         must_support_elements = [
           { path: 'Procedure.status' },
@@ -447,7 +447,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Procedure, [:search, :read])
-        skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -67,7 +67,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Provenance, [:vread])
-        skip 'No Provenance resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Provenance', delayed: true)
 
         validate_vread_reply(@provenance, versioned_resource_class('Provenance'))
       end
@@ -85,7 +85,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Provenance, [:history])
-        skip 'No Provenance resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Provenance', delayed: true)
 
         validate_history_reply(@provenance, versioned_resource_class('Provenance'))
       end
@@ -104,7 +104,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Provenance resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Provenance', delayed: true)
         test_resources_against_profile('Provenance')
       end
 
@@ -141,7 +141,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Provenance resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Provenance', delayed: true)
 
         must_support_slices = [
           {
@@ -211,7 +211,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Provenance, [:search, :read])
-        skip 'No Provenance resources appear to be available.' unless @resources_found
+        skip_if_not_found(resource_type: 'Provenance', delayed: true)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:pulse_oximetry])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:pulse_oximetry])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:pulse_oximetry])
       end
 
@@ -530,7 +531,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -662,7 +663,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -150,14 +150,14 @@ module Inferno
               .resource
             @observation_ary[patient] += fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-            save_resource_ids_in_bundle(versioned_resource_class('Observation'), reply, Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
             save_delayed_sequence_references(@observation_ary[patient])
             validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
             break
           end
         end
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 
       test :search_by_patient_category_date do
@@ -174,7 +174,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -222,7 +222,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -264,7 +264,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -313,7 +313,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -351,7 +351,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:read])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_read_reply(@observation, versioned_resource_class('Observation'), check_for_data_absent_reasons)
       end
@@ -369,7 +369,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:vread])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_vread_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -387,7 +387,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:history])
-        skip 'No Observation resources could be found for this patient. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validate_history_reply(@observation, versioned_resource_class('Observation'))
       end
@@ -401,6 +401,7 @@ module Inferno
           )
           versions :r4
         end
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         could_not_resolve_all = []
         resolved_one = false
@@ -447,7 +448,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
         test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
       end
 
@@ -474,7 +475,7 @@ module Inferno
           versions :r4
         end
 
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         must_support_slices = [
           {
@@ -528,7 +529,7 @@ module Inferno
         end
 
         skip_if_known_not_supported(:Observation, [:search, :read])
-        skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
+        skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new
         max_resolutions = 50


### PR DESCRIPTION
This branch adds an input field for Device type. This is needed because the US Core Implantable Device profile only applies to implantable devices, but without specifying a Device type, there is no way for Inferno to differentiate between implantable and non-implantable devices.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-590
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
