### PR TITLE
FI-563: Omit invalid client ID token refresh test for public clients

### DIFF
--- a/lib/app/ext/fhir_client.rb
+++ b/lib/app/ext/fhir_client.rb
@@ -48,11 +48,7 @@ module FHIR
       }
       oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
 
-      if testing_instance.confidential_client
-        oauth2_headers['Authorization'] = encoded_secret(testing_instance.client_id, testing_instance.client_secret)
-      else
-        oauth2_params['client_id'] = testing_instance.client_id
-      end
+      oauth2_headers['Authorization'] = encoded_secret(testing_instance.client_id, testing_instance.client_secret) if testing_instance.confidential_client
 
       begin
         token_response = Inferno::LoggedRestClient.post(

--- a/lib/modules/smart/test/token_refresh_sequence_test.rb
+++ b/lib/modules/smart/test/token_refresh_sequence_test.rb
@@ -315,9 +315,7 @@ class TokenRefreshSequenceTest < MiniTest::Test
     exchange_response_json = exchange_response.to_json
     exchange_response_json = '<bad>' if failure_mode == :bad_json_response
 
-    if @instance.client_secret.present?
-      headers['Authorization'] = "Basic #{Base64.strict_encode64(@instance.client_id + ':' + @instance.client_secret)}"
-    end
+    headers['Authorization'] = "Basic #{Base64.strict_encode64(@instance.client_id + ':' + @instance.client_secret)}" if @instance.client_secret.present?
 
     stub_request(:post, @instance.oauth_token_endpoint)
       .with(headers: headers,

--- a/lib/modules/smart/test/token_refresh_sequence_test.rb
+++ b/lib/modules/smart/test/token_refresh_sequence_test.rb
@@ -35,7 +35,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
         .with(body: hash_including(refresh_token: @sequence_class::INVALID_REFRESH_TOKEN))
         .to_return(status: 200)
 
-      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 400 or 401, but found 200', exception.message
     end
 
     it 'succeeds when the token refresh response has an error status' do
@@ -61,7 +63,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
     it 'omits when the using a public client' do
       @instance.confidential_client = false
 
-      assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'This test is only valid for confidential clients.', exception.message
     end
 
     it 'fails when the token refresh response has a success status' do
@@ -69,7 +73,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
         .with(headers: @auth_header)
         .to_return(status: 200)
 
-      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 400 or 401, but found 200', exception.message
     end
 
     it 'succeeds when the token refresh has an error status' do
@@ -106,7 +112,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
         .with(body: hash_including(scope: 'jkl'))
         .to_return(status: 400)
 
-      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 400. ', exception.message
     end
   end
 
@@ -135,7 +143,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
         .with { |request| !request.body.include? 'scope' }
         .to_return(status: 400)
 
-      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 400. ', exception.message
     end
   end
 

--- a/lib/modules/smart/test/token_refresh_sequence_test.rb
+++ b/lib/modules/smart/test/token_refresh_sequence_test.rb
@@ -317,8 +317,6 @@ class TokenRefreshSequenceTest < MiniTest::Test
 
     if @instance.client_secret.present?
       headers['Authorization'] = "Basic #{Base64.strict_encode64(@instance.client_id + ':' + @instance.client_secret)}"
-    else
-      body['client_id'] = body_with_scope['client_id'] = @instance.client_id
     end
 
     stub_request(:post, @instance.oauth_token_endpoint)

--- a/lib/modules/smart/test/token_refresh_sequence_test.rb
+++ b/lib/modules/smart/test/token_refresh_sequence_test.rb
@@ -65,7 +65,7 @@ describe Inferno::Sequence::TokenRefreshSequence do
 
       exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
 
-      assert_equal 'This test is only valid for confidential clients.', exception.message
+      assert_equal 'This test is only applicable to confidential clients.', exception.message
     end
 
     it 'fails when the token refresh response has a success status' do

--- a/lib/modules/smart/token_refresh_sequence.rb
+++ b/lib/modules/smart/token_refresh_sequence.rb
@@ -62,7 +62,7 @@ module Inferno
             If the request failed verification or is invalid, the authorization server returns an error response.          )
         end
 
-        omit 'This test is only valid for confidential clients.' unless @instance.confidential_client
+        omit 'This test is only applicable to confidential clients.' unless @instance.confidential_client
 
         skip_if_no_refresh_token
 

--- a/lib/modules/smart/token_refresh_sequence.rb
+++ b/lib/modules/smart/token_refresh_sequence.rb
@@ -62,6 +62,8 @@ module Inferno
             If the request failed verification or is invalid, the authorization server returns an error response.          )
         end
 
+        omit 'This test is only valid for confidential clients.' unless @instance.confidential_client
+
         skip_if_no_refresh_token
 
         token_response = perform_refresh_request(INVALID_CLIENT_ID, @instance.refresh_token)

--- a/lib/modules/smart/token_refresh_sequence.rb
+++ b/lib/modules/smart/token_refresh_sequence.rb
@@ -149,11 +149,7 @@ module Inferno
         }
         oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
 
-        if @instance.confidential_client
-          oauth2_headers['Authorization'] = encoded_secret(client_id, @instance.client_secret)
-        else
-          oauth2_params['client_id'] = client_id
-        end
+        oauth2_headers['Authorization'] = encoded_secret(client_id, @instance.client_secret) if @instance.confidential_client
 
         oauth2_params['scope'] = @instance.scopes if provide_scope
 

--- a/lib/modules/uscore_v3.1.0_module.yml
+++ b/lib/modules/uscore_v3.1.0_module.yml
@@ -14,6 +14,8 @@ test_sets:
         - ManualRegistrationSequence
         - StandaloneLaunchSequence
         - EHRLaunchSequence
+        - TokenRefreshSequence
+        - OpenIDConnectSequence
       - name: US Core v3.1.0 Profiles
         run_all: true
         sequences:

--- a/lib/modules/uscore_v3.1.0_module.yml
+++ b/lib/modules/uscore_v3.1.0_module.yml
@@ -14,8 +14,6 @@ test_sets:
         - ManualRegistrationSequence
         - StandaloneLaunchSequence
         - EHRLaunchSequence
-        - TokenRefreshSequence
-        - OpenIDConnectSequence
       - name: US Core v3.1.0 Profiles
         run_all: true
         sequences:

--- a/test/unit/fhir_client_test.rb
+++ b/test/unit/fhir_client_test.rb
@@ -65,8 +65,7 @@ describe FHIR::Client do
       stub_request(:post, @instance.oauth_token_endpoint)
         .with(body: {
                 grant_type: 'refresh_token',
-                refresh_token: @instance.refresh_token,
-                client_id: @instance.client_id
+                refresh_token: @instance.refresh_token
               })
         .to_return(status: 500)
 
@@ -80,8 +79,7 @@ describe FHIR::Client do
       stub_request(:post, @instance.oauth_token_endpoint)
         .with(body: {
                 grant_type: 'refresh_token',
-                refresh_token: @instance.refresh_token,
-                client_id: @instance.client_id
+                refresh_token: @instance.refresh_token
               })
         .to_return(status: 200, body: @token_response.to_json)
 
@@ -119,8 +117,7 @@ describe FHIR::Client do
       stub_request(:post, @instance.oauth_token_endpoint)
         .with(body: {
                 grant_type: 'refresh_token',
-                refresh_token: @instance.refresh_token,
-                client_id: @instance.client_id
+                refresh_token: @instance.refresh_token
               })
         .to_return(status: 200, body: @token_response.to_json)
 


### PR DESCRIPTION
This branch omits the invalid client ID token refresh test for public clients because that test is only valid for confidential clients. [There is no client ID based authentication for public client during a token refresh.](http://hl7.org/fhir/smart-app-launch/#step-5-later-app-uses-a-refresh-token-to-obtain-a-new-access-token)

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-563
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
