### PR TITLE
Fi 612 fix tests for multi patient

### DIFF
--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -3,7 +3,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
     @test = @sequence_class[:<%= test_key %>]
     @sequence = @sequence_class.new(@instance, @client)
     @<%= resource_var_name %> = FHIR.from_contents(load_fixture(:<%= sequence_name %>))
-    @<%= resource_var_name %>_ary = <% unless delayed_sequence %>{ 'example' => @<%= resource_var_name %> }<% else %> [ @<%= resource_var_name %> ] <% end %>
+    @<%= resource_var_name %>_ary = <% unless delayed_sequence %>{ @sequence.patient_ids.first => @<%= resource_var_name %> }<% else %> [ @<%= resource_var_name %> ] <% end %>
     @sequence.instance_variable_set(:'@<%= resource_var_name %>', @<%= resource_var_name %>)
     @sequence.instance_variable_set(:'@<%= resource_var_name %>_ary', @<%= resource_var_name %>_ary)
 <% unless is_first_search %>
@@ -25,7 +25,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
 
   <% if has_dynamic_search_params %>
   it 'skips if a value for one of the search parameters cannot be found' do
-    @sequence.instance_variable_set(:'@<%= resource_var_name %>_ary', <% unless delayed_sequence %>'example' => FHIR::<%= resource_type %>.new <% else %> [FHIR::<%= resource_type %>.new] <% end %>)
+    @sequence.instance_variable_set(:'@<%= resource_var_name %>_ary', <% unless delayed_sequence %>@sequence.patient_ids.first => FHIR::<%= resource_type %>.new <% else %> [FHIR::<%= resource_type %>.new] <% end %>)
 
     exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -157,7 +157,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% if is_first_search && is_fixed_value_search %>
       [<%= fixed_value_search_string %>].each do |value|
         query_params = {
-          'patient': @instance.patient_id,
+          'patient': @sequence.patient_ids.first,
           '<%= fixed_value_search_param %>': value
         }
         stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -179,7 +179,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% if is_first_search && is_fixed_value_search %>
       [<%= fixed_value_search_string %>].each do |value|
         query_params = {
-          'patient': @instance.patient_id,
+          'patient': @sequence.patient_ids.first,
           '<%= fixed_value_search_param %>': value
         }
         stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -205,7 +205,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% if is_first_search && is_fixed_value_search %>
       [<%= fixed_value_search_string %>].each do |value|
         query_params = {
-          'patient': @instance.patient_id,
+          'patient': @sequence.patient_ids.first,
           '<%= fixed_value_search_param %>': value
         }
         stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -233,7 +233,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% if is_first_search && is_fixed_value_search %>
       [<%= fixed_value_search_string %>].each do |value|
         query_params = {
-          'patient': @instance.patient_id,
+          'patient': @sequence.patient_ids.first,
           '<%= fixed_value_search_param %>': value
         }
         stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -262,7 +262,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
     <% if is_first_search && is_fixed_value_search %>
       [<%= fixed_value_search_string %>].each do |value|
         query_params = {
-          'patient': @instance.patient_id,
+          'patient': @sequence.patient_ids.first,
           '<%= fixed_value_search_param %>': value
         }
         stub_request(:get, "#{@base_url}/<%= resource_type %>")

--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -3,7 +3,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
     @test = @sequence_class[:<%= test_key %>]
     @sequence = @sequence_class.new(@instance, @client)
     @<%= resource_var_name %> = FHIR.from_contents(load_fixture(:<%= sequence_name %>))
-    @<%= resource_var_name %>_ary = [@<%= resource_var_name %>]
+    @<%= resource_var_name %>_ary = <% unless delayed_sequence %>{ 'example' => @<%= resource_var_name %> }<% else %> [ @<%= resource_var_name %> ] <% end %>
     @sequence.instance_variable_set(:'@<%= resource_var_name %>', @<%= resource_var_name %>)
     @sequence.instance_variable_set(:'@<%= resource_var_name %>_ary', @<%= resource_var_name %>_ary)
 <% unless is_first_search %>
@@ -25,11 +25,11 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
 
   <% if has_dynamic_search_params %>
   it 'skips if a value for one of the search parameters cannot be found' do
-    @sequence.instance_variable_set(:'@<%= resource_var_name %>_ary', [FHIR::<%= resource_type %>.new])
+    @sequence.instance_variable_set(:'@<%= resource_var_name %>_ary', <% unless delayed_sequence %>{ 'example' => FHIR::<%= resource_type %>.new } <% else %> [FHIR::<%= resource_type %>.new] <% end %>)
 
     exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
-    assert_match(/Could not resolve [\w-]+ in given resource/, exception.message)
+    assert_match(/Could not resolve .* in any resource\./, exception.message)
   end
   <% end %>
 <% end %>
@@ -38,7 +38,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
 <% if is_first_search && is_fixed_value_search %>
     [<%= fixed_value_search_string %>].each do |value|
       query_params = {
-        'patient': @instance.patient_id,
+        'patient': @sequence.patient_ids.first,
         '<%= fixed_value_search_param %>': value
       }
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -60,7 +60,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
 <% if is_first_search && is_fixed_value_search %>
     [<%= fixed_value_search_string %>].each do |value|
       query_params = {
-        'patient': @instance.patient_id,
+        'patient': @sequence.patient_ids.first,
         '<%= fixed_value_search_param %>': value
       }
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -83,7 +83,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% if is_fixed_value_search %>
     [<%= fixed_value_search_string %>].each do |value|
       query_params = {
-        'patient': @instance.patient_id,
+        'patient': @sequence.patient_ids.first,
         '<%= fixed_value_search_param %>': value
       }
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -106,7 +106,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
 <% if is_first_search && is_fixed_value_search %>
     [<%= fixed_value_search_string %>].each do |value|
       query_params = {
-        'patient': @instance.patient_id,
+        'patient': @sequence.patient_ids.first,
         '<%= fixed_value_search_param %>': value
       }
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -129,12 +129,12 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% if is_first_search && is_fixed_value_search %>
     [<%= fixed_value_search_string %>].each do |value|
       query_params = {
-        'patient': @instance.patient_id,
+        'patient': @sequence.patient_ids.first,
         '<%= fixed_value_search_param %>': value
       }
       body =
         if @sequence.resolve_element_from_path(@<%= resource_var_name %>, '<%= fixed_value_search_path %>') == value
-          wrap_resources_in_bundle(@<%= resource_var_name %>_ary).to_json
+          wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json
         else
           FHIR::Bundle.new.to_json
         end
@@ -145,7 +145,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% else %>
     stub_request(:get, "#{@base_url}/<%= resource_type %>")
       .with(query: @query, headers: @auth_header)
-      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary).to_json)
+      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json)
   <% end %>
 
     @sequence.run_test(@test)

--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -25,7 +25,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
 
   <% if has_dynamic_search_params %>
   it 'skips if a value for one of the search parameters cannot be found' do
-    @sequence.instance_variable_set(:'@<%= resource_var_name %>_ary', <% unless delayed_sequence %>{ 'example' => FHIR::<%= resource_type %>.new } <% else %> [FHIR::<%= resource_type %>.new] <% end %>)
+    @sequence.instance_variable_set(:'@<%= resource_var_name %>_ary', <% unless delayed_sequence %>'example' => FHIR::<%= resource_type %>.new <% else %> [FHIR::<%= resource_type %>.new] <% end %>)
 
     exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/generator/uscore/templates/unit_tests/unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/unit_test.rb.erb
@@ -12,8 +12,8 @@ describe Inferno::Sequence::<%= class_name %> do
     @token = 'ABC'
     @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: '<%= module_name %>')
     @client = FHIR::Client.for_testing_instance(@instance)
-    @patient_id = 'example'
-    @instance.patient_id = @patient_id
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
     set_resource_support(@instance, '<%= resource_type %>')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -141,6 +141,8 @@ module Inferno
             dynamic_search_param_string(param, value)
           elsif value.start_with? '@'
             "'#{param}': #{value}"
+          elsif value == 'patient'
+            "'#{param}': 'example'"
           else
             "'#{param}': '#{value}'"
           end
@@ -151,6 +153,7 @@ module Inferno
         param_info = dynamic_search_param(value)
         path = param_info[:resource_path]
         variable_name = param_info[:variable_name]
+        variable_name.gsub!('[patient]', "['example']")
         "'#{param}': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(#{variable_name}, '#{path}'))"
       end
 
@@ -168,7 +171,7 @@ module Inferno
       #   get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'category'))
       # this method extracts the variable name '@careplan_ary' and the path 'category'
       def dynamic_search_param(param_value)
-        match = param_value.match(/(@\w+).*'([\w\.]+)'/)
+        match = param_value.match(/(@[^,]+).*'([\w\.]+)'/)
         {
           variable_name: match[1],
           resource_path: match[2]

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -142,7 +142,7 @@ module Inferno
           elsif value.start_with? '@'
             "'#{param}': #{value}"
           elsif value == 'patient'
-            "'#{param}': 'example'"
+            "'#{param}': @sequence.patient_ids.first"
           else
             "'#{param}': '#{value}'"
           end
@@ -153,7 +153,7 @@ module Inferno
         param_info = dynamic_search_param(value)
         path = param_info[:resource_path]
         variable_name = param_info[:variable_name]
-        variable_name.gsub!('[patient]', "['example']")
+        variable_name.gsub!('[patient]', '[@sequence.patient_ids.first]')
         "'#{param}': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(#{variable_name}, '#{path}'))"
       end
 

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310BodyheightSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310BodyheightSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '8302-2'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyheight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['8302-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['8302-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['8302-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['8302-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['8302-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['8302-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['8302-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['8302-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['8302-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['8302-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyheight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyheight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyheight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyheight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['8302-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['8302-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       it 'fails if searching with status is not successful' do
         ['8302-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['8302-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['8302-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '8302-2'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyheight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyheight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyheight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyheight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyheight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '8310-5'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodytemp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodytemp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodytemp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodytemp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodytemp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['8310-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['8310-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       it 'fails if searching with status is not successful' do
         ['8310-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['8310-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['8310-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310BodytempSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310BodytempSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '8310-5'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodytemp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['8310-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['8310-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['8310-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['8310-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['8310-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['8310-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['8310-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['8310-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['8310-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['8310-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodytemp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodytemp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodytemp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodytemp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310BodyweightSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310BodyweightSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '29463-7'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyweight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['29463-7'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['29463-7'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['29463-7'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['29463-7'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['29463-7'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['29463-7'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['29463-7'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['29463-7'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['29463-7'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['29463-7'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyweight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyweight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyweight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bodyweight))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '29463-7'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyweight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyweight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyweight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyweight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bodyweight))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['29463-7'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['29463-7'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       it 'fails if searching with status is not successful' do
         ['29463-7'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['29463-7'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['29463-7'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310BpSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['85354-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310BpSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['85354-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310BpSequence do
       it 'fails if searching with status is not successful' do
         ['85354-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310BpSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['85354-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310BpSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['85354-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310BpSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310BpSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '85354-9'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['85354-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['85354-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['85354-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['85354-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['85354-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['85354-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['85354-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['85354-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['85354-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['85354-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:bp))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310BpSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '85354-9'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310BpSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310BpSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310BpSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310BpSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310BpSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:bp))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310HeadcircumSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310HeadcircumSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '9843-4'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:headcircum))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['9843-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['9843-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['9843-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['9843-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['9843-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['9843-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['9843-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['9843-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['9843-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['9843-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:headcircum))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:headcircum))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:headcircum))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:headcircum))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '9843-4'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:headcircum))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:headcircum))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:headcircum))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:headcircum))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:headcircum))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['9843-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['9843-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       it 'fails if searching with status is not successful' do
         ['9843-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['9843-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['9843-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '8867-4'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:heartrate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:heartrate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:heartrate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:heartrate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:heartrate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310HeartrateSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310HeartrateSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '8867-4'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:heartrate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['8867-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['8867-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['8867-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['8867-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['8867-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['8867-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['8867-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['8867-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['8867-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['8867-4'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:heartrate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:heartrate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:heartrate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:heartrate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['8867-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['8867-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       it 'fails if searching with status is not successful' do
         ['8867-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['8867-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['8867-4'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310PediatricBmiForAgeSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '59576-9'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['59576-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['59576-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['59576-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['59576-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['59576-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['59576-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['59576-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['59576-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['59576-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['59576-9'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['59576-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['59576-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       it 'fails if searching with status is not successful' do
         ['59576-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['59576-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['59576-9'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '59576-9'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_bmi_for_age))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['77606-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['77606-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       it 'fails if searching with status is not successful' do
         ['77606-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['77606-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['77606-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310PediatricWeightForHeightSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '77606-2'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['77606-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['77606-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['77606-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['77606-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['77606-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['77606-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['77606-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['77606-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['77606-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['77606-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '77606-2'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:pediatric_weight_for_height))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310ResprateSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310ResprateSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '9279-1'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:resprate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['9279-1'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['9279-1'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['9279-1'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['9279-1'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['9279-1'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['9279-1'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['9279-1'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['9279-1'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['9279-1'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['9279-1'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:resprate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:resprate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:resprate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:resprate))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '9279-1'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:resprate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:resprate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:resprate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:resprate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:resprate))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['9279-1'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['9279-1'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       it 'fails if searching with status is not successful' do
         ['9279-1'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['9279-1'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['9279-1'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@allergy_intolerance_ary', { 'example' => FHIR::AllergyIntolerance.new })
+      @sequence.instance_variable_set(:'@allergy_intolerance_ary', 'example' => FHIR::AllergyIntolerance.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @allergy_intolerance = FHIR.from_contents(load_fixture(:us_core_allergyintolerance))
-      @allergy_intolerance_ary = { 'example' => @allergy_intolerance }
+      @allergy_intolerance_ary = { @sequence.patient_ids.first => @allergy_intolerance }
       @sequence.instance_variable_set(:'@allergy_intolerance', @allergy_intolerance)
       @sequence.instance_variable_set(:'@allergy_intolerance_ary', @allergy_intolerance_ary)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -199,15 +199,15 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       @test = @sequence_class[:search_by_patient_clinical_status]
       @sequence = @sequence_class.new(@instance, @client)
       @allergy_intolerance = FHIR.from_contents(load_fixture(:us_core_allergyintolerance))
-      @allergy_intolerance_ary = { 'example' => @allergy_intolerance }
+      @allergy_intolerance_ary = { @sequence.patient_ids.first => @allergy_intolerance }
       @sequence.instance_variable_set(:'@allergy_intolerance', @allergy_intolerance)
       @sequence.instance_variable_set(:'@allergy_intolerance_ary', @allergy_intolerance_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'clinical-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@allergy_intolerance_ary['example'], 'clinicalStatus'))
+        'patient': @sequence.patient_ids.first,
+        'clinical-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@allergy_intolerance_ary[@sequence.patient_ids.first], 'clinicalStatus'))
       }
     end
 
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@allergy_intolerance_ary', 'example' => FHIR::AllergyIntolerance.new)
+      @sequence.instance_variable_set(:'@allergy_intolerance_ary', @sequence.patient_ids.first => FHIR::AllergyIntolerance.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -1,0 +1,418 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310AllergyintoleranceSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'AllergyIntolerance')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if the AllergyIntolerance search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support AllergyIntolerance search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'AllergyIntolerance search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @allergy_intolerance = FHIR.from_contents(load_fixture(:us_core_allergyintolerance))
+      @allergy_intolerance_ary = { 'example' => @allergy_intolerance }
+      @sequence.instance_variable_set(:'@allergy_intolerance', @allergy_intolerance)
+      @sequence.instance_variable_set(:'@allergy_intolerance_ary', @allergy_intolerance_ary)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::AllergyIntolerance.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: AllergyIntolerance', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No AllergyIntolerance resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::AllergyIntolerance.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query.merge('clinical-status': ['active', 'inactive', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query.merge('clinical-status': ['active', 'inactive', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::AllergyIntolerance.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: AllergyIntolerance', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query.merge('clinical-status': ['active', 'inactive', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@allergy_intolerance]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'AllergyIntolerance search by patient+clinical-status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_clinical_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @allergy_intolerance = FHIR.from_contents(load_fixture(:us_core_allergyintolerance))
+      @allergy_intolerance_ary = { 'example' => @allergy_intolerance }
+      @sequence.instance_variable_set(:'@allergy_intolerance', @allergy_intolerance)
+      @sequence.instance_variable_set(:'@allergy_intolerance_ary', @allergy_intolerance_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'clinical-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@allergy_intolerance_ary['example'], 'clinicalStatus'))
+      }
+    end
+
+    it 'skips if no AllergyIntolerance resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No AllergyIntolerance resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@allergy_intolerance_ary', { 'example' => FHIR::AllergyIntolerance.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::AllergyIntolerance.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: AllergyIntolerance', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::AllergyIntolerance.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'AllergyIntolerance read test' do
+    before do
+      @allergy_intolerance_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@allergy_intolerance', FHIR::AllergyIntolerance.new(id: @allergy_intolerance_id))
+    end
+
+    it 'skips if the AllergyIntolerance read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support AllergyIntolerance read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no AllergyIntolerance has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No AllergyIntolerance resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected AllergyIntolerance resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a AllergyIntolerance' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type AllergyIntolerance.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      allergy_intolerance = FHIR::AllergyIntolerance.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: allergy_intolerance.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@allergy_intolerance_id}", exception.message
+    end
+
+    it 'succeeds when a AllergyIntolerance resource is read successfully' do
+      allergy_intolerance = FHIR::AllergyIntolerance.new(
+        id: @allergy_intolerance_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: allergy_intolerance.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'resource validation test' do
+    before do
+      @allergy_intolerance = FHIR::AllergyIntolerance.new(load_json_fixture(:us_core_allergyintolerance))
+      @test = @sequence_class[:validate_resources]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'AllergyIntolerance',
+        resource_id: @allergy_intolerance.id,
+        testing_instance: @instance
+      )
+    end
+
+    it 'fails if a resource does not contain a code for a CodeableConcept with a required binding' do
+      ['clinicalStatus', 'verificationStatus'].each do |path|
+        @sequence.resolve_path(@allergy_intolerance, path).each do |concept|
+          concept&.coding&.each do |coding|
+            coding&.code = nil
+            coding&.system = nil
+          end
+          concept&.text = 'abc'
+        end
+      end
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance/#{@allergy_intolerance.id}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @allergy_intolerance.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      ['clinicalStatus', 'verificationStatus'].each do |path|
+        assert_match(%r{AllergyIntolerance/#{@allergy_intolerance.id}: The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes\.}, exception.message)
+      end
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -1,0 +1,633 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310CareplanSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310CareplanSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'CarePlan')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'category': 'assess-plan'
+      }
+    end
+
+    it 'skips if the CarePlan search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support CarePlan search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'CarePlan search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @care_plan = FHIR.from_contents(load_fixture(:us_core_careplan))
+      @care_plan_ary = { 'example' => @care_plan }
+      @sequence.instance_variable_set(:'@care_plan', @care_plan)
+      @sequence.instance_variable_set(:'@care_plan_ary', @care_plan_ary)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'category'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['assess-plan'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['assess-plan'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::CarePlan.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: CarePlan', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['assess-plan'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CarePlan resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['assess-plan'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::CarePlan.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['assess-plan'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@care_plan, 'category.coding.code') == value
+            wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['assess-plan'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['assess-plan'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['assess-plan'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params.merge('status': ['draft,active,on-hold,revoked,completed,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['assess-plan'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params.merge('status': ['draft,active,on-hold,revoked,completed,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::CarePlan.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: CarePlan', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['assess-plan'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params.merge('status': ['draft,active,on-hold,revoked,completed,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@care_plan]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'CarePlan search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @care_plan = FHIR.from_contents(load_fixture(:us_core_careplan))
+      @care_plan_ary = { 'example' => @care_plan }
+      @sequence.instance_variable_set(:'@care_plan', @care_plan)
+      @sequence.instance_variable_set(:'@care_plan_ary', @care_plan_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'period'))
+      }
+    end
+
+    it 'skips if no CarePlan resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CarePlan resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@care_plan_ary', { 'example' => FHIR::CarePlan.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::CarePlan.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: CarePlan', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::CarePlan.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: @query.merge('status': ['draft,active,on-hold,revoked,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: @query.merge('status': ['draft,active,on-hold,revoked,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::CarePlan.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: CarePlan', exception.message
+      end
+    end
+  end
+
+  describe 'CarePlan search by patient+category+status+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @care_plan = FHIR.from_contents(load_fixture(:us_core_careplan))
+      @care_plan_ary = { 'example' => @care_plan }
+      @sequence.instance_variable_set(:'@care_plan', @care_plan)
+      @sequence.instance_variable_set(:'@care_plan_ary', @care_plan_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'status')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'period'))
+      }
+    end
+
+    it 'skips if no CarePlan resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CarePlan resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@care_plan_ary', { 'example' => FHIR::CarePlan.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::CarePlan.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: CarePlan', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::CarePlan.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+  end
+
+  describe 'CarePlan search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @care_plan = FHIR.from_contents(load_fixture(:us_core_careplan))
+      @care_plan_ary = { 'example' => @care_plan }
+      @sequence.instance_variable_set(:'@care_plan', @care_plan)
+      @sequence.instance_variable_set(:'@care_plan_ary', @care_plan_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no CarePlan resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CarePlan resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@care_plan_ary', { 'example' => FHIR::CarePlan.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::CarePlan.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: CarePlan', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::CarePlan.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'CarePlan read test' do
+    before do
+      @care_plan_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@care_plan', FHIR::CarePlan.new(id: @care_plan_id))
+    end
+
+    it 'skips if the CarePlan read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support CarePlan read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no CarePlan has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CarePlan resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected CarePlan resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a CarePlan' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type CarePlan.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      care_plan = FHIR::CarePlan.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: care_plan.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@care_plan_id}", exception.message
+    end
+
+    it 'succeeds when a CarePlan resource is read successfully' do
+      care_plan = FHIR::CarePlan.new(
+        id: @care_plan_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CarePlan',
+        resource_id: @care_plan_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CarePlan/#{@care_plan_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: care_plan.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'category': 'assess-plan'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @care_plan = FHIR.from_contents(load_fixture(:us_core_careplan))
-      @care_plan_ary = { 'example' => @care_plan }
+      @care_plan_ary = { @sequence.patient_ids.first => @care_plan }
       @sequence.instance_variable_set(:'@care_plan', @care_plan)
       @sequence.instance_variable_set(:'@care_plan_ary', @care_plan_ary)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @care_plan = FHIR.from_contents(load_fixture(:us_core_careplan))
-      @care_plan_ary = { 'example' => @care_plan }
+      @care_plan_ary = { @sequence.patient_ids.first => @care_plan }
       @sequence.instance_variable_set(:'@care_plan', @care_plan)
       @sequence.instance_variable_set(:'@care_plan_ary', @care_plan_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'period'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'period'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@care_plan_ary', 'example' => FHIR::CarePlan.new)
+      @sequence.instance_variable_set(:'@care_plan_ary', @sequence.patient_ids.first => FHIR::CarePlan.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,17 +384,17 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @test = @sequence_class[:search_by_patient_category_status_date]
       @sequence = @sequence_class.new(@instance, @client)
       @care_plan = FHIR.from_contents(load_fixture(:us_core_careplan))
-      @care_plan_ary = { 'example' => @care_plan }
+      @care_plan_ary = { @sequence.patient_ids.first => @care_plan }
       @sequence.instance_variable_set(:'@care_plan', @care_plan)
       @sequence.instance_variable_set(:'@care_plan_ary', @care_plan_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'status')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'period'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'status')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'period'))
       }
     end
 
@@ -407,7 +407,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@care_plan_ary', 'example' => FHIR::CarePlan.new)
+      @sequence.instance_variable_set(:'@care_plan_ary', @sequence.patient_ids.first => FHIR::CarePlan.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -450,16 +450,16 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @care_plan = FHIR.from_contents(load_fixture(:us_core_careplan))
-      @care_plan_ary = { 'example' => @care_plan }
+      @care_plan_ary = { @sequence.patient_ids.first => @care_plan }
       @sequence.instance_variable_set(:'@care_plan', @care_plan)
       @sequence.instance_variable_set(:'@care_plan_ary', @care_plan_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -472,7 +472,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@care_plan_ary', 'example' => FHIR::CarePlan.new)
+      @sequence.instance_variable_set(:'@care_plan_ary', @sequence.patient_ids.first => FHIR::CarePlan.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['assess-plan'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/CarePlan")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['assess-plan'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/CarePlan")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       it 'fails if searching with status is not successful' do
         ['assess-plan'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/CarePlan")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['assess-plan'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/CarePlan")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['assess-plan'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/CarePlan")

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@care_plan_ary', { 'example' => FHIR::CarePlan.new })
+      @sequence.instance_variable_set(:'@care_plan_ary', 'example' => FHIR::CarePlan.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -407,7 +407,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@care_plan_ary', { 'example' => FHIR::CarePlan.new })
+      @sequence.instance_variable_set(:'@care_plan_ary', 'example' => FHIR::CarePlan.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -472,7 +472,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@care_plan_ary', { 'example' => FHIR::CarePlan.new })
+      @sequence.instance_variable_set(:'@care_plan_ary', 'example' => FHIR::CarePlan.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310CareteamSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310CareteamSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'CareTeam')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'status': 'proposed'
+      }
+    end
+
+    it 'skips if the CareTeam search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support CareTeam search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/CareTeam")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/CareTeam")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'CareTeam search by patient+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @care_team = FHIR.from_contents(load_fixture(:us_core_careteam))
+      @care_team_ary = { 'example' => @care_team }
+      @sequence.instance_variable_set(:'@care_team', @care_team)
+      @sequence.instance_variable_set(:'@care_team_ary', @care_team_ary)
+
+      @query = {
+        'patient': 'example',
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_team_ary['example'], 'status'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'status': value
+        }
+        stub_request(:get, "#{@base_url}/CareTeam")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'status': value
+        }
+        stub_request(:get, "#{@base_url}/CareTeam")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::CareTeam.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: CareTeam', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'status': value
+        }
+        stub_request(:get, "#{@base_url}/CareTeam")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CareTeam resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'status': value
+        }
+        stub_request(:get, "#{@base_url}/CareTeam")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::CareTeam.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'status': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@care_team, 'status') == value
+            wrap_resources_in_bundle(@care_team_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/CareTeam")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'CareTeam read test' do
+    before do
+      @care_team_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@care_team', FHIR::CareTeam.new(id: @care_team_id))
+    end
+
+    it 'skips if the CareTeam read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support CareTeam read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no CareTeam has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No CareTeam resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected CareTeam resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a CareTeam' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type CareTeam.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      care_team = FHIR::CareTeam.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: care_team.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@care_team_id}", exception.message
+    end
+
+    it 'succeeds when a CareTeam resource is read successfully' do
+      care_team = FHIR::CareTeam.new(
+        id: @care_team_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'CareTeam',
+        resource_id: @care_team_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/CareTeam/#{@care_team_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: care_team.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310CareteamSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'status': 'proposed'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310CareteamSequence do
       @test = @sequence_class[:search_by_patient_status]
       @sequence = @sequence_class.new(@instance, @client)
       @care_team = FHIR.from_contents(load_fixture(:us_core_careteam))
-      @care_team_ary = { 'example' => @care_team }
+      @care_team_ary = { @sequence.patient_ids.first => @care_team }
       @sequence.instance_variable_set(:'@care_team', @care_team)
       @sequence.instance_variable_set(:'@care_team_ary', @care_team_ary)
 
       @query = {
-        'patient': 'example',
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_team_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_team_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@condition_ary', { 'example' => FHIR::Condition.new })
+      @sequence.instance_variable_set(:'@condition_ary', 'example' => FHIR::Condition.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -355,7 +355,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@condition_ary', { 'example' => FHIR::Condition.new })
+      @sequence.instance_variable_set(:'@condition_ary', 'example' => FHIR::Condition.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -471,7 +471,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@condition_ary', { 'example' => FHIR::Condition.new })
+      @sequence.instance_variable_set(:'@condition_ary', 'example' => FHIR::Condition.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -543,7 +543,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@condition_ary', { 'example' => FHIR::Condition.new })
+      @sequence.instance_variable_set(:'@condition_ary', 'example' => FHIR::Condition.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -1,0 +1,804 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310ConditionSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310ConditionSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Condition')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if the Condition search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Condition search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Condition search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @condition = FHIR.from_contents(load_fixture(:us_core_condition))
+      @condition_ary = { 'example' => @condition }
+      @sequence.instance_variable_set(:'@condition', @condition)
+      @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Condition resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Condition.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@condition]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Condition search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @condition = FHIR.from_contents(load_fixture(:us_core_condition))
+      @condition_ary = { 'example' => @condition }
+      @sequence.instance_variable_set(:'@condition', @condition)
+      @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Condition resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Condition resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@condition_ary', { 'example' => FHIR::Condition.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Condition.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@condition]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Condition search by patient+onset-date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_onset_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @condition = FHIR.from_contents(load_fixture(:us_core_condition))
+      @condition_ary = { 'example' => @condition }
+      @sequence.instance_variable_set(:'@condition', @condition)
+      @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'onset-date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary['example'], 'onsetDateTime'))
+      }
+    end
+
+    it 'skips if no Condition resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Condition resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@condition_ary', { 'example' => FHIR::Condition.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Condition.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+      end
+    end
+  end
+
+  describe 'Condition search by patient+clinical-status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_clinical_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @condition = FHIR.from_contents(load_fixture(:us_core_condition))
+      @condition_ary = { 'example' => @condition }
+      @sequence.instance_variable_set(:'@condition', @condition)
+      @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'clinical-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary['example'], 'clinicalStatus'))
+      }
+    end
+
+    it 'skips if no Condition resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Condition resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@condition_ary', { 'example' => FHIR::Condition.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Condition.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Condition search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @condition = FHIR.from_contents(load_fixture(:us_core_condition))
+      @condition_ary = { 'example' => @condition }
+      @sequence.instance_variable_set(:'@condition', @condition)
+      @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary['example'], 'code'))
+      }
+    end
+
+    it 'skips if no Condition resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Condition resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@condition_ary', { 'example' => FHIR::Condition.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Condition.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Condition.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Condition', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@condition]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Condition read test' do
+    before do
+      @condition_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@condition', FHIR::Condition.new(id: @condition_id))
+    end
+
+    it 'skips if the Condition read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Condition read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Condition has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Condition resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Condition resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Condition' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Condition.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      condition = FHIR::Condition.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: condition.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@condition_id}", exception.message
+    end
+
+    it 'succeeds when a Condition resource is read successfully' do
+      condition = FHIR::Condition.new(
+        id: @condition_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: condition.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'resource validation test' do
+    before do
+      @condition = FHIR::Condition.new(load_json_fixture(:us_core_condition))
+      @test = @sequence_class[:validate_resources]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Condition',
+        resource_id: @condition.id,
+        testing_instance: @instance
+      )
+    end
+
+    it 'fails if a resource does not contain a code for a CodeableConcept with a required binding' do
+      ['clinicalStatus', 'verificationStatus'].each do |path|
+        @sequence.resolve_path(@condition, path).each do |concept|
+          concept&.coding&.each do |coding|
+            coding&.code = nil
+            coding&.system = nil
+          end
+          concept&.text = 'abc'
+        end
+      end
+
+      stub_request(:get, "#{@base_url}/Condition/#{@condition.id}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @condition.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      ['clinicalStatus', 'verificationStatus'].each do |path|
+        assert_match(%r{Condition/#{@condition.id}: The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes\.}, exception.message)
+      end
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @condition = FHIR.from_contents(load_fixture(:us_core_condition))
-      @condition_ary = { 'example' => @condition }
+      @condition_ary = { @sequence.patient_ids.first => @condition }
       @sequence.instance_variable_set(:'@condition', @condition)
       @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -199,15 +199,15 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @condition = FHIR.from_contents(load_fixture(:us_core_condition))
-      @condition_ary = { 'example' => @condition }
+      @condition_ary = { @sequence.patient_ids.first => @condition }
       @sequence.instance_variable_set(:'@condition', @condition)
       @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@condition_ary', 'example' => FHIR::Condition.new)
+      @sequence.instance_variable_set(:'@condition_ary', @sequence.patient_ids.first => FHIR::Condition.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -334,15 +334,15 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @test = @sequence_class[:search_by_patient_onset_date]
       @sequence = @sequence_class.new(@instance, @client)
       @condition = FHIR.from_contents(load_fixture(:us_core_condition))
-      @condition_ary = { 'example' => @condition }
+      @condition_ary = { @sequence.patient_ids.first => @condition }
       @sequence.instance_variable_set(:'@condition', @condition)
       @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'onset-date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary['example'], 'onsetDateTime'))
+        'patient': @sequence.patient_ids.first,
+        'onset-date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary[@sequence.patient_ids.first], 'onsetDateTime'))
       }
     end
 
@@ -355,7 +355,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@condition_ary', 'example' => FHIR::Condition.new)
+      @sequence.instance_variable_set(:'@condition_ary', @sequence.patient_ids.first => FHIR::Condition.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -450,15 +450,15 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @test = @sequence_class[:search_by_patient_clinical_status]
       @sequence = @sequence_class.new(@instance, @client)
       @condition = FHIR.from_contents(load_fixture(:us_core_condition))
-      @condition_ary = { 'example' => @condition }
+      @condition_ary = { @sequence.patient_ids.first => @condition }
       @sequence.instance_variable_set(:'@condition', @condition)
       @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'clinical-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary['example'], 'clinicalStatus'))
+        'patient': @sequence.patient_ids.first,
+        'clinical-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary[@sequence.patient_ids.first], 'clinicalStatus'))
       }
     end
 
@@ -471,7 +471,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@condition_ary', 'example' => FHIR::Condition.new)
+      @sequence.instance_variable_set(:'@condition_ary', @sequence.patient_ids.first => FHIR::Condition.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -522,15 +522,15 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @condition = FHIR.from_contents(load_fixture(:us_core_condition))
-      @condition_ary = { 'example' => @condition }
+      @condition_ary = { @sequence.patient_ids.first => @condition }
       @sequence.instance_variable_set(:'@condition', @condition)
       @sequence.instance_variable_set(:'@condition_ary', @condition_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -543,7 +543,7 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@condition_ary', 'example' => FHIR::Condition.new)
+      @sequence.instance_variable_set(:'@condition_ary', @sequence.patient_ids.first => FHIR::Condition.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'category': 'LAB'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -267,14 +267,14 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -393,15 +393,15 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -414,7 +414,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @sequence.patient_ids.first => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -528,16 +528,16 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -550,7 +550,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @sequence.patient_ids.first => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -645,15 +645,15 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @test = @sequence_class[:search_by_patient_status]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -666,7 +666,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @sequence.patient_ids.first => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -717,16 +717,16 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -739,7 +739,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @sequence.patient_ids.first => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -1,0 +1,944 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310DiagnosticreportLabSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'DiagnosticReport')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'category': 'LAB'
+      }
+    end
+
+    it 'skips if the DiagnosticReport search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DiagnosticReport search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'category'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['LAB'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['LAB'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['LAB'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['LAB'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['LAB'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+            wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['LAB'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['LAB'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['LAB'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['LAB'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['LAB'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DiagnosticReport search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'code'))
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_lab))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+    end
+  end
+
+  describe 'DiagnosticReport read test' do
+    before do
+      @diagnostic_report_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@diagnostic_report', FHIR::DiagnosticReport.new(id: @diagnostic_report_id))
+    end
+
+    it 'skips if the DiagnosticReport read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DiagnosticReport read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no DiagnosticReport has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected DiagnosticReport resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a DiagnosticReport' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type DiagnosticReport.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      diagnostic_report = FHIR::DiagnosticReport.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: diagnostic_report.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@diagnostic_report_id}", exception.message
+    end
+
+    it 'succeeds when a DiagnosticReport resource is read successfully' do
+      diagnostic_report = FHIR::DiagnosticReport.new(
+        id: @diagnostic_report_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: diagnostic_report.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -414,7 +414,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -550,7 +550,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -666,7 +666,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -739,7 +739,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['LAB'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['LAB'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       it 'fails if searching with status is not successful' do
         ['LAB'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['LAB'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['LAB'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'category': 'LP29684-5'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -267,14 +267,14 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -393,15 +393,15 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -414,7 +414,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @sequence.patient_ids.first => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -528,16 +528,16 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -550,7 +550,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @sequence.patient_ids.first => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -645,15 +645,15 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @test = @sequence_class[:search_by_patient_status]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -666,7 +666,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @sequence.patient_ids.first => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -717,16 +717,16 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
-      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @diagnostic_report_ary = { @sequence.patient_ids.first => @diagnostic_report }
       @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
       @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -739,7 +739,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @sequence.patient_ids.first => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       it 'fails if searching with status is not successful' do
         ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/DiagnosticReport")

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -1,0 +1,944 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310DiagnosticreportNoteSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'DiagnosticReport')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'category': 'LP29684-5'
+      }
+    end
+
+    it 'skips if the DiagnosticReport search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DiagnosticReport search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'category'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+            wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DiagnosticReport search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'code'))
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'DiagnosticReport search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @diagnostic_report = FHIR.from_contents(load_fixture(:us_core_diagnosticreport_note))
+      @diagnostic_report_ary = { 'example' => @diagnostic_report }
+      @sequence.instance_variable_set(:'@diagnostic_report', @diagnostic_report)
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', @diagnostic_report_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no DiagnosticReport resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DiagnosticReport.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DiagnosticReport.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DiagnosticReport', exception.message
+      end
+    end
+  end
+
+  describe 'DiagnosticReport read test' do
+    before do
+      @diagnostic_report_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@diagnostic_report', FHIR::DiagnosticReport.new(id: @diagnostic_report_id))
+    end
+
+    it 'skips if the DiagnosticReport read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DiagnosticReport read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no DiagnosticReport has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DiagnosticReport resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected DiagnosticReport resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a DiagnosticReport' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type DiagnosticReport.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      diagnostic_report = FHIR::DiagnosticReport.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: diagnostic_report.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@diagnostic_report_id}", exception.message
+    end
+
+    it 'succeeds when a DiagnosticReport resource is read successfully' do
+      diagnostic_report = FHIR::DiagnosticReport.new(
+        id: @diagnostic_report_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DiagnosticReport',
+        resource_id: @diagnostic_report_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DiagnosticReport/#{@diagnostic_report_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: diagnostic_report.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -414,7 +414,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -550,7 +550,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -666,7 +666,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -739,7 +739,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@diagnostic_report_ary', { 'example' => FHIR::DiagnosticReport.new })
+      @sequence.instance_variable_set(:'@diagnostic_report_ary', 'example' => FHIR::DiagnosticReport.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
-      @document_reference_ary = { 'example' => @document_reference }
+      @document_reference_ary = { @sequence.patient_ids.first => @document_reference }
       @sequence.instance_variable_set(:'@document_reference', @document_reference)
       @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -199,14 +199,14 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @test = @sequence_class[:search_by__id]
       @sequence = @sequence_class.new(@instance, @client)
       @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
-      @document_reference_ary = { 'example' => @document_reference }
+      @document_reference_ary = { @sequence.patient_ids.first => @document_reference }
       @sequence.instance_variable_set(:'@document_reference', @document_reference)
       @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        '_id': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'id'))
+        '_id': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'id'))
       }
     end
 
@@ -219,7 +219,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
+      @sequence.instance_variable_set(:'@document_reference_ary', @sequence.patient_ids.first => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -333,15 +333,15 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @test = @sequence_class[:search_by_patient_type]
       @sequence = @sequence_class.new(@instance, @client)
       @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
-      @document_reference_ary = { 'example' => @document_reference }
+      @document_reference_ary = { @sequence.patient_ids.first => @document_reference }
       @sequence.instance_variable_set(:'@document_reference', @document_reference)
       @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'type'))
+        'patient': @sequence.patient_ids.first,
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'type'))
       }
     end
 
@@ -354,7 +354,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
+      @sequence.instance_variable_set(:'@document_reference_ary', @sequence.patient_ids.first => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -468,16 +468,16 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
-      @document_reference_ary = { 'example' => @document_reference }
+      @document_reference_ary = { @sequence.patient_ids.first => @document_reference }
       @sequence.instance_variable_set(:'@document_reference', @document_reference)
       @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'date'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'date'))
       }
     end
 
@@ -490,7 +490,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
+      @sequence.instance_variable_set(:'@document_reference_ary', @sequence.patient_ids.first => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -604,15 +604,15 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
-      @document_reference_ary = { 'example' => @document_reference }
+      @document_reference_ary = { @sequence.patient_ids.first => @document_reference }
       @sequence.instance_variable_set(:'@document_reference', @document_reference)
       @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -625,7 +625,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
+      @sequence.instance_variable_set(:'@document_reference_ary', @sequence.patient_ids.first => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -739,16 +739,16 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @test = @sequence_class[:search_by_patient_type_period]
       @sequence = @sequence_class.new(@instance, @client)
       @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
-      @document_reference_ary = { 'example' => @document_reference }
+      @document_reference_ary = { @sequence.patient_ids.first => @document_reference }
       @sequence.instance_variable_set(:'@document_reference', @document_reference)
       @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'type')),
-        'period': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'context.period'))
+        'patient': @sequence.patient_ids.first,
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'type')),
+        'period': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'context.period'))
       }
     end
 
@@ -761,7 +761,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
+      @sequence.instance_variable_set(:'@document_reference_ary', @sequence.patient_ids.first => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -856,15 +856,15 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @test = @sequence_class[:search_by_patient_status]
       @sequence = @sequence_class.new(@instance, @client)
       @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
-      @document_reference_ary = { 'example' => @document_reference }
+      @document_reference_ary = { @sequence.patient_ids.first => @document_reference }
       @sequence.instance_variable_set(:'@document_reference', @document_reference)
       @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -877,7 +877,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
+      @sequence.instance_variable_set(:'@document_reference_ary', @sequence.patient_ids.first => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -1,0 +1,1075 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310DocumentreferenceSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310DocumentreferenceSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'DocumentReference')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if the DocumentReference search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DocumentReference search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'DocumentReference search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
+      @document_reference_ary = { 'example' => @document_reference }
+      @sequence.instance_variable_set(:'@document_reference', @document_reference)
+      @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DocumentReference.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DocumentReference search by _id test' do
+    before do
+      @test = @sequence_class[:search_by__id]
+      @sequence = @sequence_class.new(@instance, @client)
+      @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
+      @document_reference_ary = { 'example' => @document_reference }
+      @sequence.instance_variable_set(:'@document_reference', @document_reference)
+      @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        '_id': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'id'))
+      }
+    end
+
+    it 'skips if no DocumentReference resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DocumentReference.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DocumentReference search by patient+type test' do
+    before do
+      @test = @sequence_class[:search_by_patient_type]
+      @sequence = @sequence_class.new(@instance, @client)
+      @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
+      @document_reference_ary = { 'example' => @document_reference }
+      @sequence.instance_variable_set(:'@document_reference', @document_reference)
+      @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'type'))
+      }
+    end
+
+    it 'skips if no DocumentReference resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DocumentReference.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DocumentReference search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
+      @document_reference_ary = { 'example' => @document_reference }
+      @sequence.instance_variable_set(:'@document_reference', @document_reference)
+      @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'date'))
+      }
+    end
+
+    it 'skips if no DocumentReference resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DocumentReference.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DocumentReference search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
+      @document_reference_ary = { 'example' => @document_reference }
+      @sequence.instance_variable_set(:'@document_reference', @document_reference)
+      @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no DocumentReference resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DocumentReference.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'DocumentReference search by patient+type+period test' do
+    before do
+      @test = @sequence_class[:search_by_patient_type_period]
+      @sequence = @sequence_class.new(@instance, @client)
+      @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
+      @document_reference_ary = { 'example' => @document_reference }
+      @sequence.instance_variable_set(:'@document_reference', @document_reference)
+      @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'type')),
+        'period': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'context.period'))
+      }
+    end
+
+    it 'skips if no DocumentReference resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DocumentReference.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+      end
+    end
+  end
+
+  describe 'DocumentReference search by patient+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @document_reference = FHIR.from_contents(load_fixture(:us_core_documentreference))
+      @document_reference_ary = { 'example' => @document_reference }
+      @sequence.instance_variable_set(:'@document_reference', @document_reference)
+      @sequence.instance_variable_set(:'@document_reference_ary', @document_reference_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no DocumentReference resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::DocumentReference.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: DocumentReference', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::DocumentReference.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'DocumentReference read test' do
+    before do
+      @document_reference_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@document_reference', FHIR::DocumentReference.new(id: @document_reference_id))
+    end
+
+    it 'skips if the DocumentReference read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support DocumentReference read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no DocumentReference has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No DocumentReference resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected DocumentReference resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a DocumentReference' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type DocumentReference.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      document_reference = FHIR::DocumentReference.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: document_reference.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@document_reference_id}", exception.message
+    end
+
+    it 'succeeds when a DocumentReference resource is read successfully' do
+      document_reference = FHIR::DocumentReference.new(
+        id: @document_reference_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: document_reference.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'resource validation test' do
+    before do
+      @document_reference = FHIR::DocumentReference.new(load_json_fixture(:us_core_documentreference))
+      @test = @sequence_class[:validate_resources]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'DocumentReference',
+        resource_id: @document_reference.id,
+        testing_instance: @instance
+      )
+    end
+
+    it 'fails if a resource does not contain a code for a CodeableConcept with a required binding' do
+      ['type'].each do |path|
+        @sequence.resolve_path(@document_reference, path).each do |concept|
+          concept&.coding&.each do |coding|
+            coding&.code = nil
+            coding&.system = nil
+          end
+          concept&.text = 'abc'
+        end
+      end
+
+      stub_request(:get, "#{@base_url}/DocumentReference/#{@document_reference.id}")
+        .with(headers: @auth_header)
+        .to_return(status: 200, body: @document_reference.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      ['type'].each do |path|
+        assert_match(%r{DocumentReference/#{@document_reference.id}: The CodeableConcept at '#{path}' is bound to a required ValueSet but does not contain any codes\.}, exception.message)
+      end
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -219,7 +219,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -354,7 +354,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -490,7 +490,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -625,7 +625,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -761,7 +761,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -877,7 +877,7 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@document_reference_ary', { 'example' => FHIR::DocumentReference.new })
+      @sequence.instance_variable_set(:'@document_reference_ary', 'example' => FHIR::DocumentReference.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -1,0 +1,1035 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310EncounterSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310EncounterSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Encounter')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if the Encounter search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Encounter search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Encounter search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
+      @encounter_ary = { 'example' => @encounter }
+      @sequence.instance_variable_set(:'@encounter', @encounter)
+      @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Encounter.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@encounter_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@encounter]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Encounter search by _id test' do
+    before do
+      @test = @sequence_class[:search_by__id]
+      @sequence = @sequence_class.new(@instance, @client)
+      @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
+      @encounter_ary = { 'example' => @encounter }
+      @sequence.instance_variable_set(:'@encounter', @encounter)
+      @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        '_id': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'id'))
+      }
+    end
+
+    it 'skips if no Encounter resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Encounter.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@encounter_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@encounter]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Encounter search by date+patient test' do
+    before do
+      @test = @sequence_class[:search_by_date_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
+      @encounter_ary = { 'example' => @encounter }
+      @sequence.instance_variable_set(:'@encounter', @encounter)
+      @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'period')),
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if no Encounter resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Encounter.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+      end
+    end
+  end
+
+  describe 'Encounter search by identifier test' do
+    before do
+      @test = @sequence_class[:search_by_identifier]
+      @sequence = @sequence_class.new(@instance, @client)
+      @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
+      @encounter_ary = { 'example' => @encounter }
+      @sequence.instance_variable_set(:'@encounter', @encounter)
+      @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'identifier'))
+      }
+    end
+
+    it 'skips if no Encounter resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Encounter.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@encounter_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@encounter]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Encounter search by patient+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
+      @encounter_ary = { 'example' => @encounter }
+      @sequence.instance_variable_set(:'@encounter', @encounter)
+      @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Encounter resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Encounter.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@encounter_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Encounter search by class+patient test' do
+    before do
+      @test = @sequence_class[:search_by_class_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
+      @encounter_ary = { 'example' => @encounter }
+      @sequence.instance_variable_set(:'@encounter', @encounter)
+      @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'class': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'local_class')),
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if no Encounter resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Encounter.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@encounter_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@encounter]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Encounter search by patient+type test' do
+    before do
+      @test = @sequence_class[:search_by_patient_type]
+      @sequence = @sequence_class.new(@instance, @client)
+      @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
+      @encounter_ary = { 'example' => @encounter }
+      @sequence.instance_variable_set(:'@encounter', @encounter)
+      @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'type'))
+      }
+    end
+
+    it 'skips if no Encounter resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Encounter.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Encounter")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@encounter_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Encounter.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Encounter', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Encounter")
+          .with(query: @query.merge('status': ['planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished', 'cancelled', 'entered-in-error', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@encounter]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Encounter read test' do
+    before do
+      @encounter_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@encounter', FHIR::Encounter.new(id: @encounter_id))
+    end
+
+    it 'skips if the Encounter read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Encounter read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Encounter has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Encounter resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Encounter resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Encounter' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Encounter.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      encounter = FHIR::Encounter.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: encounter.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@encounter_id}", exception.message
+    end
+
+    it 'succeeds when a Encounter resource is read successfully' do
+      encounter = FHIR::Encounter.new(
+        id: @encounter_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Encounter',
+        resource_id: @encounter_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Encounter/#{@encounter_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: encounter.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -219,7 +219,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -354,7 +354,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -469,7 +469,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -604,7 +604,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -676,7 +676,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -811,7 +811,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', { 'example' => FHIR::Encounter.new })
+      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
-      @encounter_ary = { 'example' => @encounter }
+      @encounter_ary = { @sequence.patient_ids.first => @encounter }
       @sequence.instance_variable_set(:'@encounter', @encounter)
       @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -199,14 +199,14 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @test = @sequence_class[:search_by__id]
       @sequence = @sequence_class.new(@instance, @client)
       @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
-      @encounter_ary = { 'example' => @encounter }
+      @encounter_ary = { @sequence.patient_ids.first => @encounter }
       @sequence.instance_variable_set(:'@encounter', @encounter)
       @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        '_id': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'id'))
+        '_id': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'id'))
       }
     end
 
@@ -219,7 +219,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
+      @sequence.instance_variable_set(:'@encounter_ary', @sequence.patient_ids.first => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -333,15 +333,15 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @test = @sequence_class[:search_by_date_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
-      @encounter_ary = { 'example' => @encounter }
+      @encounter_ary = { @sequence.patient_ids.first => @encounter }
       @sequence.instance_variable_set(:'@encounter', @encounter)
       @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'period')),
-        'patient': 'example'
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'period')),
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -354,7 +354,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
+      @sequence.instance_variable_set(:'@encounter_ary', @sequence.patient_ids.first => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -449,14 +449,14 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @test = @sequence_class[:search_by_identifier]
       @sequence = @sequence_class.new(@instance, @client)
       @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
-      @encounter_ary = { 'example' => @encounter }
+      @encounter_ary = { @sequence.patient_ids.first => @encounter }
       @sequence.instance_variable_set(:'@encounter', @encounter)
       @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'identifier'))
+        'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'identifier'))
       }
     end
 
@@ -469,7 +469,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
+      @sequence.instance_variable_set(:'@encounter_ary', @sequence.patient_ids.first => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -583,15 +583,15 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @test = @sequence_class[:search_by_patient_status]
       @sequence = @sequence_class.new(@instance, @client)
       @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
-      @encounter_ary = { 'example' => @encounter }
+      @encounter_ary = { @sequence.patient_ids.first => @encounter }
       @sequence.instance_variable_set(:'@encounter', @encounter)
       @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -604,7 +604,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
+      @sequence.instance_variable_set(:'@encounter_ary', @sequence.patient_ids.first => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -655,15 +655,15 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @test = @sequence_class[:search_by_class_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
-      @encounter_ary = { 'example' => @encounter }
+      @encounter_ary = { @sequence.patient_ids.first => @encounter }
       @sequence.instance_variable_set(:'@encounter', @encounter)
       @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'class': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'local_class')),
-        'patient': 'example'
+        'class': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'local_class')),
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -676,7 +676,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
+      @sequence.instance_variable_set(:'@encounter_ary', @sequence.patient_ids.first => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -790,15 +790,15 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @test = @sequence_class[:search_by_patient_type]
       @sequence = @sequence_class.new(@instance, @client)
       @encounter = FHIR.from_contents(load_fixture(:us_core_encounter))
-      @encounter_ary = { 'example' => @encounter }
+      @encounter_ary = { @sequence.patient_ids.first => @encounter }
       @sequence.instance_variable_set(:'@encounter', @encounter)
       @sequence.instance_variable_set(:'@encounter_ary', @encounter_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary['example'], 'type'))
+        'patient': @sequence.patient_ids.first,
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'type'))
       }
     end
 
@@ -811,7 +811,7 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@encounter_ary', 'example' => FHIR::Encounter.new)
+      @sequence.instance_variable_set(:'@encounter_ary', @sequence.patient_ids.first => FHIR::Encounter.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -1,0 +1,497 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310GoalSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310GoalSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Goal')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if the Goal search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Goal search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Goal search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @goal = FHIR.from_contents(load_fixture(:us_core_goal))
+      @goal_ary = { 'example' => @goal }
+      @sequence.instance_variable_set(:'@goal', @goal)
+      @sequence.instance_variable_set(:'@goal_ary', @goal_ary)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Goal.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Goal', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Goal resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Goal.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query.merge('lifecycle-status': ['proposed', 'planned', 'accepted', 'active', 'on-hold', 'completed', 'cancelled', 'entered-in-error', 'rejected'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query.merge('lifecycle-status': ['proposed', 'planned', 'accepted', 'active', 'on-hold', 'completed', 'cancelled', 'entered-in-error', 'rejected'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Goal.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Goal', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query.merge('lifecycle-status': ['proposed', 'planned', 'accepted', 'active', 'on-hold', 'completed', 'cancelled', 'entered-in-error', 'rejected'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@goal]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Goal search by patient+target-date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_target_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @goal = FHIR.from_contents(load_fixture(:us_core_goal))
+      @goal_ary = { 'example' => @goal }
+      @sequence.instance_variable_set(:'@goal', @goal)
+      @sequence.instance_variable_set(:'@goal_ary', @goal_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'target-date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@goal_ary['example'], 'target.dueDate'))
+      }
+    end
+
+    it 'skips if no Goal resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Goal resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@goal_ary', { 'example' => FHIR::Goal.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Goal.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Goal', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Goal.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query.merge('lifecycle-status': ['proposed', 'planned', 'accepted', 'active', 'on-hold', 'completed', 'cancelled', 'entered-in-error', 'rejected'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query.merge('lifecycle-status': ['proposed', 'planned', 'accepted', 'active', 'on-hold', 'completed', 'cancelled', 'entered-in-error', 'rejected'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Goal.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Goal', exception.message
+      end
+    end
+  end
+
+  describe 'Goal search by patient+lifecycle-status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_lifecycle_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @goal = FHIR.from_contents(load_fixture(:us_core_goal))
+      @goal_ary = { 'example' => @goal }
+      @sequence.instance_variable_set(:'@goal', @goal)
+      @sequence.instance_variable_set(:'@goal_ary', @goal_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'lifecycle-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@goal_ary['example'], 'lifecycleStatus'))
+      }
+    end
+
+    it 'skips if no Goal resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Goal resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@goal_ary', { 'example' => FHIR::Goal.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Goal.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Goal', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Goal.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Goal read test' do
+    before do
+      @goal_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@goal', FHIR::Goal.new(id: @goal_id))
+    end
+
+    it 'skips if the Goal read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Goal read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Goal has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Goal resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Goal resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Goal' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Goal.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      goal = FHIR::Goal.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: goal.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@goal_id}", exception.message
+    end
+
+    it 'succeeds when a Goal resource is read successfully' do
+      goal = FHIR::Goal.new(
+        id: @goal_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Goal',
+        resource_id: @goal_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Goal/#{@goal_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: goal.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310GoalSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @goal = FHIR.from_contents(load_fixture(:us_core_goal))
-      @goal_ary = { 'example' => @goal }
+      @goal_ary = { @sequence.patient_ids.first => @goal }
       @sequence.instance_variable_set(:'@goal', @goal)
       @sequence.instance_variable_set(:'@goal_ary', @goal_ary)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -199,15 +199,15 @@ describe Inferno::Sequence::USCore310GoalSequence do
       @test = @sequence_class[:search_by_patient_target_date]
       @sequence = @sequence_class.new(@instance, @client)
       @goal = FHIR.from_contents(load_fixture(:us_core_goal))
-      @goal_ary = { 'example' => @goal }
+      @goal_ary = { @sequence.patient_ids.first => @goal }
       @sequence.instance_variable_set(:'@goal', @goal)
       @sequence.instance_variable_set(:'@goal_ary', @goal_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'target-date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@goal_ary['example'], 'target.dueDate'))
+        'patient': @sequence.patient_ids.first,
+        'target-date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@goal_ary[@sequence.patient_ids.first], 'target.dueDate'))
       }
     end
 
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@goal_ary', 'example' => FHIR::Goal.new)
+      @sequence.instance_variable_set(:'@goal_ary', @sequence.patient_ids.first => FHIR::Goal.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -315,15 +315,15 @@ describe Inferno::Sequence::USCore310GoalSequence do
       @test = @sequence_class[:search_by_patient_lifecycle_status]
       @sequence = @sequence_class.new(@instance, @client)
       @goal = FHIR.from_contents(load_fixture(:us_core_goal))
-      @goal_ary = { 'example' => @goal }
+      @goal_ary = { @sequence.patient_ids.first => @goal }
       @sequence.instance_variable_set(:'@goal', @goal)
       @sequence.instance_variable_set(:'@goal_ary', @goal_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'lifecycle-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@goal_ary['example'], 'lifecycleStatus'))
+        'patient': @sequence.patient_ids.first,
+        'lifecycle-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@goal_ary[@sequence.patient_ids.first], 'lifecycleStatus'))
       }
     end
 
@@ -336,7 +336,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@goal_ary', 'example' => FHIR::Goal.new)
+      @sequence.instance_variable_set(:'@goal_ary', @sequence.patient_ids.first => FHIR::Goal.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@goal_ary', { 'example' => FHIR::Goal.new })
+      @sequence.instance_variable_set(:'@goal_ary', 'example' => FHIR::Goal.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -336,7 +336,7 @@ describe Inferno::Sequence::USCore310GoalSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@goal_ary', { 'example' => FHIR::Goal.new })
+      @sequence.instance_variable_set(:'@goal_ary', 'example' => FHIR::Goal.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -1,0 +1,497 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310ImmunizationSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310ImmunizationSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Immunization')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if the Immunization search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Immunization search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Immunization search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @immunization = FHIR.from_contents(load_fixture(:us_core_immunization))
+      @immunization_ary = { 'example' => @immunization }
+      @sequence.instance_variable_set(:'@immunization', @immunization)
+      @sequence.instance_variable_set(:'@immunization_ary', @immunization_ary)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Immunization.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Immunization', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Immunization resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Immunization.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query.merge('status': ['completed', 'entered-in-error', 'not-done', 'preparation', 'in-progress', 'on-hold', 'stopped', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query.merge('status': ['completed', 'entered-in-error', 'not-done', 'preparation', 'in-progress', 'on-hold', 'stopped', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Immunization.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Immunization', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query.merge('status': ['completed', 'entered-in-error', 'not-done', 'preparation', 'in-progress', 'on-hold', 'stopped', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@immunization]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Immunization search by patient+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @immunization = FHIR.from_contents(load_fixture(:us_core_immunization))
+      @immunization_ary = { 'example' => @immunization }
+      @sequence.instance_variable_set(:'@immunization', @immunization)
+      @sequence.instance_variable_set(:'@immunization_ary', @immunization_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@immunization_ary['example'], 'occurrence'))
+      }
+    end
+
+    it 'skips if no Immunization resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Immunization resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@immunization_ary', { 'example' => FHIR::Immunization.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Immunization.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Immunization', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Immunization.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query.merge('status': ['completed', 'entered-in-error', 'not-done', 'preparation', 'in-progress', 'on-hold', 'stopped', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query.merge('status': ['completed', 'entered-in-error', 'not-done', 'preparation', 'in-progress', 'on-hold', 'stopped', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Immunization.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Immunization', exception.message
+      end
+    end
+  end
+
+  describe 'Immunization search by patient+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @immunization = FHIR.from_contents(load_fixture(:us_core_immunization))
+      @immunization_ary = { 'example' => @immunization }
+      @sequence.instance_variable_set(:'@immunization', @immunization)
+      @sequence.instance_variable_set(:'@immunization_ary', @immunization_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@immunization_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Immunization resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Immunization resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@immunization_ary', { 'example' => FHIR::Immunization.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Immunization.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Immunization', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Immunization.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Immunization read test' do
+    before do
+      @immunization_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@immunization', FHIR::Immunization.new(id: @immunization_id))
+    end
+
+    it 'skips if the Immunization read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Immunization read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Immunization has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Immunization resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Immunization resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Immunization' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Immunization.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      immunization = FHIR::Immunization.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: immunization.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@immunization_id}", exception.message
+    end
+
+    it 'succeeds when a Immunization resource is read successfully' do
+      immunization = FHIR::Immunization.new(
+        id: @immunization_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Immunization',
+        resource_id: @immunization_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Immunization/#{@immunization_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: immunization.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @immunization = FHIR.from_contents(load_fixture(:us_core_immunization))
-      @immunization_ary = { 'example' => @immunization }
+      @immunization_ary = { @sequence.patient_ids.first => @immunization }
       @sequence.instance_variable_set(:'@immunization', @immunization)
       @sequence.instance_variable_set(:'@immunization_ary', @immunization_ary)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -199,15 +199,15 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       @test = @sequence_class[:search_by_patient_date]
       @sequence = @sequence_class.new(@instance, @client)
       @immunization = FHIR.from_contents(load_fixture(:us_core_immunization))
-      @immunization_ary = { 'example' => @immunization }
+      @immunization_ary = { @sequence.patient_ids.first => @immunization }
       @sequence.instance_variable_set(:'@immunization', @immunization)
       @sequence.instance_variable_set(:'@immunization_ary', @immunization_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@immunization_ary['example'], 'occurrence'))
+        'patient': @sequence.patient_ids.first,
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@immunization_ary[@sequence.patient_ids.first], 'occurrence'))
       }
     end
 
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@immunization_ary', 'example' => FHIR::Immunization.new)
+      @sequence.instance_variable_set(:'@immunization_ary', @sequence.patient_ids.first => FHIR::Immunization.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -315,15 +315,15 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       @test = @sequence_class[:search_by_patient_status]
       @sequence = @sequence_class.new(@instance, @client)
       @immunization = FHIR.from_contents(load_fixture(:us_core_immunization))
-      @immunization_ary = { 'example' => @immunization }
+      @immunization_ary = { @sequence.patient_ids.first => @immunization }
       @sequence.instance_variable_set(:'@immunization', @immunization)
       @sequence.instance_variable_set(:'@immunization_ary', @immunization_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@immunization_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@immunization_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -336,7 +336,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@immunization_ary', 'example' => FHIR::Immunization.new)
+      @sequence.instance_variable_set(:'@immunization_ary', @sequence.patient_ids.first => FHIR::Immunization.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@immunization_ary', { 'example' => FHIR::Immunization.new })
+      @sequence.instance_variable_set(:'@immunization_ary', 'example' => FHIR::Immunization.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -336,7 +336,7 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@immunization_ary', { 'example' => FHIR::Immunization.new })
+      @sequence.instance_variable_set(:'@immunization_ary', 'example' => FHIR::Immunization.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310ImplantableDeviceSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Device')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if the Device search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Device search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Device search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @device = FHIR.from_contents(load_fixture(:us_core_implantable_device))
+      @device_ary = { 'example' => @device }
+      @sequence.instance_variable_set(:'@device', @device)
+      @sequence.instance_variable_set(:'@device_ary', @device_ary)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Device.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Device', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Device resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Device.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Device search by patient+type test' do
+    before do
+      @test = @sequence_class[:search_by_patient_type]
+      @sequence = @sequence_class.new(@instance, @client)
+      @device = FHIR.from_contents(load_fixture(:us_core_implantable_device))
+      @device_ary = { 'example' => @device }
+      @sequence.instance_variable_set(:'@device', @device)
+      @sequence.instance_variable_set(:'@device_ary', @device_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@device_ary['example'], 'type'))
+      }
+    end
+
+    it 'skips if no Device resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Device resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@device_ary', { 'example' => FHIR::Device.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Device.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Device', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Device.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Device read test' do
+    before do
+      @device_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@device', FHIR::Device.new(id: @device_id))
+    end
+
+    it 'skips if the Device read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Device read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Device has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Device resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Device resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Device' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Device.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      device = FHIR::Device.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: device.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@device_id}", exception.message
+    end
+
+    it 'succeeds when a Device resource is read successfully' do
+      device = FHIR::Device.new(
+        id: @device_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Device',
+        resource_id: @device_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Device/#{@device_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: device.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @device = FHIR.from_contents(load_fixture(:us_core_implantable_device))
-      @device_ary = { 'example' => @device }
+      @device_ary = { @sequence.patient_ids.first => @device }
       @sequence.instance_variable_set(:'@device', @device)
       @sequence.instance_variable_set(:'@device_ary', @device_ary)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -136,15 +136,15 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
       @test = @sequence_class[:search_by_patient_type]
       @sequence = @sequence_class.new(@instance, @client)
       @device = FHIR.from_contents(load_fixture(:us_core_implantable_device))
-      @device_ary = { 'example' => @device }
+      @device_ary = { @sequence.patient_ids.first => @device }
       @sequence.instance_variable_set(:'@device', @device)
       @sequence.instance_variable_set(:'@device_ary', @device_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@device_ary['example'], 'type'))
+        'patient': @sequence.patient_ids.first,
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@device_ary[@sequence.patient_ids.first], 'type'))
       }
     end
 
@@ -157,7 +157,7 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@device_ary', 'example' => FHIR::Device.new)
+      @sequence.instance_variable_set(:'@device_ary', @sequence.patient_ids.first => FHIR::Device.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -157,7 +157,7 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@device_ary', { 'example' => FHIR::Device.new })
+      @sequence.instance_variable_set(:'@device_ary', 'example' => FHIR::Device.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -12,8 +12,8 @@ describe Inferno::Sequence::USCore310LocationSequence do
     @token = 'ABC'
     @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
-    @patient_id = 'example'
-    @instance.patient_id = @patient_id
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
     set_resource_support(@instance, 'Location')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
@@ -123,6 +123,406 @@ describe Inferno::Sequence::USCore310LocationSequence do
       stub_request(:get, "#{@base_url}/Location/#{@location_id}")
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: location.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @location_ary = FHIR.from_contents(load_fixture(:us_core_location))
+      @sequence.instance_variable_set(:'@location_ary', @location_ary)
+
+      @query = {
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'name'))
+      }
+    end
+
+    it 'skips if the Location search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Location search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Location search by name test' do
+    before do
+      @test = @sequence_class[:search_by_name]
+      @sequence = @sequence_class.new(@instance, @client)
+      @location = FHIR.from_contents(load_fixture(:us_core_location))
+      @location_ary = [@location]
+      @sequence.instance_variable_set(:'@location', @location)
+      @sequence.instance_variable_set(:'@location_ary', @location_ary)
+
+      @query = {
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'name'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Location.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Location', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Location resources appear to be available.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Location.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@location_ary).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Location search by address test' do
+    before do
+      @test = @sequence_class[:search_by_address]
+      @sequence = @sequence_class.new(@instance, @client)
+      @location = FHIR.from_contents(load_fixture(:us_core_location))
+      @location_ary = [@location]
+      @sequence.instance_variable_set(:'@location', @location)
+      @sequence.instance_variable_set(:'@location_ary', @location_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'address': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'address'))
+      }
+    end
+
+    it 'skips if no Location resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Location resources appear to be available.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@location_ary', [FHIR::Location.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Location.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Location', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Location.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@location_ary).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Location search by address-city test' do
+    before do
+      @test = @sequence_class[:search_by_address_city]
+      @sequence = @sequence_class.new(@instance, @client)
+      @location = FHIR.from_contents(load_fixture(:us_core_location))
+      @location_ary = [@location]
+      @sequence.instance_variable_set(:'@location', @location)
+      @sequence.instance_variable_set(:'@location_ary', @location_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'address-city': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'address.city'))
+      }
+    end
+
+    it 'skips if no Location resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Location resources appear to be available.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@location_ary', [FHIR::Location.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Location.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Location', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Location.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@location_ary).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Location search by address-state test' do
+    before do
+      @test = @sequence_class[:search_by_address_state]
+      @sequence = @sequence_class.new(@instance, @client)
+      @location = FHIR.from_contents(load_fixture(:us_core_location))
+      @location_ary = [@location]
+      @sequence.instance_variable_set(:'@location', @location)
+      @sequence.instance_variable_set(:'@location_ary', @location_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'address-state': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'address.state'))
+      }
+    end
+
+    it 'skips if no Location resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Location resources appear to be available.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@location_ary', [FHIR::Location.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Location.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Location', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Location.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@location_ary).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Location search by address-postalcode test' do
+    before do
+      @test = @sequence_class[:search_by_address_postalcode]
+      @sequence = @sequence_class.new(@instance, @client)
+      @location = FHIR.from_contents(load_fixture(:us_core_location))
+      @location_ary = [@location]
+      @sequence.instance_variable_set(:'@location', @location)
+      @sequence.instance_variable_set(:'@location_ary', @location_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'address-postalcode': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'address.postalCode'))
+      }
+    end
+
+    it 'skips if no Location resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Location resources appear to be available.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@location_ary', [FHIR::Location.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Location.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Location', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Location.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Location")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@location_ary).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
@@ -12,8 +12,8 @@ describe Inferno::Sequence::USCore310MedicationSequence do
     @token = 'ABC'
     @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
-    @patient_id = 'example'
-    @instance.patient_id = @patient_id
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
     set_resource_support(@instance, 'Medication')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -1,0 +1,784 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310MedicationrequestSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310MedicationrequestSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'MedicationRequest')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'intent': 'proposal'
+      }
+    end
+
+    it 'skips if the MedicationRequest search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support MedicationRequest search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'MedicationRequest search by patient+intent test' do
+    before do
+      @test = @sequence_class[:search_by_patient_intent]
+      @sequence = @sequence_class.new(@instance, @client)
+      @medication_request = FHIR.from_contents(load_fixture(:us_core_medicationrequest))
+      @medication_request_ary = { 'example' => @medication_request }
+      @sequence.instance_variable_set(:'@medication_request', @medication_request)
+      @sequence.instance_variable_set(:'@medication_request_ary', @medication_request_ary)
+
+      @query = {
+        'patient': 'example',
+        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'intent'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'intent': value
+        }
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'intent': value
+        }
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::MedicationRequest.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: MedicationRequest', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'intent': value
+        }
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No MedicationRequest resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'intent': value
+        }
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::MedicationRequest.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'intent': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@medication_request, 'intent') == value
+            wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'intent': value
+          }
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'intent': value
+          }
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'intent': value
+          }
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'intent': value
+          }
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::MedicationRequest.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: MedicationRequest', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'intent': value
+          }
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@medication_request]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'MedicationRequest search by patient+intent+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_intent_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @medication_request = FHIR.from_contents(load_fixture(:us_core_medicationrequest))
+      @medication_request_ary = { 'example' => @medication_request }
+      @sequence.instance_variable_set(:'@medication_request', @medication_request)
+      @sequence.instance_variable_set(:'@medication_request_ary', @medication_request_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'intent')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no MedicationRequest resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No MedicationRequest resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@medication_request_ary', { 'example' => FHIR::MedicationRequest.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::MedicationRequest.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: MedicationRequest', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::MedicationRequest.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'MedicationRequest search by patient+intent+encounter test' do
+    before do
+      @test = @sequence_class[:search_by_patient_intent_encounter]
+      @sequence = @sequence_class.new(@instance, @client)
+      @medication_request = FHIR.from_contents(load_fixture(:us_core_medicationrequest))
+      @medication_request_ary = { 'example' => @medication_request }
+      @sequence.instance_variable_set(:'@medication_request', @medication_request)
+      @sequence.instance_variable_set(:'@medication_request_ary', @medication_request_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'intent')),
+        'encounter': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'encounter'))
+      }
+    end
+
+    it 'skips if no MedicationRequest resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No MedicationRequest resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@medication_request_ary', { 'example' => FHIR::MedicationRequest.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::MedicationRequest.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: MedicationRequest', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::MedicationRequest.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::MedicationRequest.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: MedicationRequest', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@medication_request]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'MedicationRequest search by patient+intent+authoredon test' do
+    before do
+      @test = @sequence_class[:search_by_patient_intent_authoredon]
+      @sequence = @sequence_class.new(@instance, @client)
+      @medication_request = FHIR.from_contents(load_fixture(:us_core_medicationrequest))
+      @medication_request_ary = { 'example' => @medication_request }
+      @sequence.instance_variable_set(:'@medication_request', @medication_request)
+      @sequence.instance_variable_set(:'@medication_request_ary', @medication_request_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'intent')),
+        'authoredon': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'authoredOn'))
+      }
+    end
+
+    it 'skips if no MedicationRequest resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No MedicationRequest resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@medication_request_ary', { 'example' => FHIR::MedicationRequest.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::MedicationRequest.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: MedicationRequest', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::MedicationRequest.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::MedicationRequest.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: MedicationRequest', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: @query.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@medication_request]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'MedicationRequest read test' do
+    before do
+      @medication_request_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@medication_request', FHIR::MedicationRequest.new(id: @medication_request_id))
+    end
+
+    it 'skips if the MedicationRequest read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support MedicationRequest read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no MedicationRequest has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No MedicationRequest resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected MedicationRequest resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a MedicationRequest' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type MedicationRequest.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      medication_request = FHIR::MedicationRequest.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: medication_request.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@medication_request_id}", exception.message
+    end
+
+    it 'succeeds when a MedicationRequest resource is read successfully' do
+      medication_request = FHIR::MedicationRequest.new(
+        id: @medication_request_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'MedicationRequest',
+        resource_id: @medication_request_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/MedicationRequest/#{@medication_request_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: medication_request.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe '#test_medication_inclusion' do
+    before do
+      @sequence = @sequence_class.new(@instance, @client)
+      @request_with_code = FHIR::MedicationRequest.new(medicationCodeableConcept: { coding: [{ code: 'abc' }] })
+      @request_with_internal_reference = FHIR::MedicationRequest.new(medicationReference: { reference: '#456' })
+      @request_with_external_reference = FHIR::MedicationRequest.new(medicationReference: { reference: 'Medication/789' })
+      @search_params = {
+        patient: @instance.patient_id,
+        intent: 'order'
+      }
+      @search_params_with_medication = @search_params.merge(_include: 'MedicationRequest:medication')
+    end
+
+    it 'succeeds if no external Medication references are used' do
+      @sequence.test_medication_inclusion([@request_with_code, @request_with_internal_reference], @search_params)
+    end
+
+    it 'fails if the search including Medications returns a non-success response' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @search_params_with_medication)
+        .to_return(status: 400)
+
+      exception = assert_raises(Inferno::AssertionException) do
+        @sequence.test_medication_inclusion([@request_with_external_reference], @search_params)
+      end
+
+      assert_equal 'Bad response code: expected 200, 201, but found 400. ', exception.message
+    end
+
+    it 'fails if the search including Medications does not return a Bundle' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @search_params_with_medication)
+        .to_return(status: 200, body: FHIR::MedicationRequest.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) do
+        @sequence.test_medication_inclusion([@request_with_external_reference], @search_params)
+      end
+
+      assert_equal 'Expected FHIR Bundle but found: MedicationRequest', exception.message
+    end
+
+    it 'fails if no Medications are present in the search results' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @search_params_with_medication)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::MedicationRequest.new).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) do
+        @sequence.test_medication_inclusion([@request_with_external_reference], @search_params)
+      end
+
+      assert_equal 'No Medications were included in the search results', exception.message
+    end
+
+    it 'succeeds if Medications are present in the search results' do
+      stub_request(:get, "#{@base_url}/MedicationRequest")
+        .with(query: @search_params_with_medication)
+        .to_return(status: 200, body: wrap_resources_in_bundle([@request_with_external_reference, FHIR::Medication.new]).to_json)
+
+      @sequence.test_medication_inclusion([@request_with_external_reference], @search_params)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'intent': value
           }
           stub_request(:get, "#{@base_url}/MedicationRequest")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'intent': value
           }
           stub_request(:get, "#{@base_url}/MedicationRequest")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       it 'fails if searching with status is not successful' do
         ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'intent': value
           }
           stub_request(:get, "#{@base_url}/MedicationRequest")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'intent': value
           }
           stub_request(:get, "#{@base_url}/MedicationRequest")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'intent': value
           }
           stub_request(:get, "#{@base_url}/MedicationRequest")

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'intent': 'proposal'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       @test = @sequence_class[:search_by_patient_intent]
       @sequence = @sequence_class.new(@instance, @client)
       @medication_request = FHIR.from_contents(load_fixture(:us_core_medicationrequest))
-      @medication_request_ary = { 'example' => @medication_request }
+      @medication_request_ary = { @sequence.patient_ids.first => @medication_request }
       @sequence.instance_variable_set(:'@medication_request', @medication_request)
       @sequence.instance_variable_set(:'@medication_request_ary', @medication_request_ary)
 
       @query = {
-        'patient': 'example',
-        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'intent'))
+        'patient': @sequence.patient_ids.first,
+        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'intent'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       @test = @sequence_class[:search_by_patient_intent_status]
       @sequence = @sequence_class.new(@instance, @client)
       @medication_request = FHIR.from_contents(load_fixture(:us_core_medicationrequest))
-      @medication_request_ary = { 'example' => @medication_request }
+      @medication_request_ary = { @sequence.patient_ids.first => @medication_request }
       @sequence.instance_variable_set(:'@medication_request', @medication_request)
       @sequence.instance_variable_set(:'@medication_request_ary', @medication_request_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'intent')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'intent')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@medication_request_ary', 'example' => FHIR::MedicationRequest.new)
+      @sequence.instance_variable_set(:'@medication_request_ary', @sequence.patient_ids.first => FHIR::MedicationRequest.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -340,16 +340,16 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       @test = @sequence_class[:search_by_patient_intent_encounter]
       @sequence = @sequence_class.new(@instance, @client)
       @medication_request = FHIR.from_contents(load_fixture(:us_core_medicationrequest))
-      @medication_request_ary = { 'example' => @medication_request }
+      @medication_request_ary = { @sequence.patient_ids.first => @medication_request }
       @sequence.instance_variable_set(:'@medication_request', @medication_request)
       @sequence.instance_variable_set(:'@medication_request_ary', @medication_request_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'intent')),
-        'encounter': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'encounter'))
+        'patient': @sequence.patient_ids.first,
+        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'intent')),
+        'encounter': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'encounter'))
       }
     end
 
@@ -362,7 +362,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@medication_request_ary', 'example' => FHIR::MedicationRequest.new)
+      @sequence.instance_variable_set(:'@medication_request_ary', @sequence.patient_ids.first => FHIR::MedicationRequest.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -476,16 +476,16 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       @test = @sequence_class[:search_by_patient_intent_authoredon]
       @sequence = @sequence_class.new(@instance, @client)
       @medication_request = FHIR.from_contents(load_fixture(:us_core_medicationrequest))
-      @medication_request_ary = { 'example' => @medication_request }
+      @medication_request_ary = { @sequence.patient_ids.first => @medication_request }
       @sequence.instance_variable_set(:'@medication_request', @medication_request)
       @sequence.instance_variable_set(:'@medication_request_ary', @medication_request_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'intent')),
-        'authoredon': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary['example'], 'authoredOn'))
+        'patient': @sequence.patient_ids.first,
+        'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'intent')),
+        'authoredon': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'authoredOn'))
       }
     end
 
@@ -498,7 +498,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@medication_request_ary', 'example' => FHIR::MedicationRequest.new)
+      @sequence.instance_variable_set(:'@medication_request_ary', @sequence.patient_ids.first => FHIR::MedicationRequest.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@medication_request_ary', { 'example' => FHIR::MedicationRequest.new })
+      @sequence.instance_variable_set(:'@medication_request_ary', 'example' => FHIR::MedicationRequest.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -362,7 +362,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@medication_request_ary', { 'example' => FHIR::MedicationRequest.new })
+      @sequence.instance_variable_set(:'@medication_request_ary', 'example' => FHIR::MedicationRequest.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -498,7 +498,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@medication_request_ary', { 'example' => FHIR::MedicationRequest.new })
+      @sequence.instance_variable_set(:'@medication_request_ary', 'example' => FHIR::MedicationRequest.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['laboratory'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['laboratory'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       it 'fails if searching with status is not successful' do
         ['laboratory'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['laboratory'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['laboratory'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'category': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'category': 'laboratory'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -267,15 +267,15 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -288,7 +288,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -402,16 +402,16 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -424,7 +424,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -288,7 +288,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -424,7 +424,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310ObservationLabSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310ObservationLabSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'category': 'laboratory'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['laboratory'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['laboratory'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['laboratory'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['laboratory'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['laboratory'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'category.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['laboratory'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['laboratory'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['laboratory'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['laboratory'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['laboratory'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'category': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_observation_lab))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -12,8 +12,8 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
     @token = 'ABC'
     @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
-    @patient_id = 'example'
-    @instance.patient_id = @patient_id
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
     set_resource_support(@instance, 'Organization')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
@@ -123,6 +123,193 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
       stub_request(:get, "#{@base_url}/Organization/#{@organization_id}")
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: organization.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @organization_ary = FHIR.from_contents(load_fixture(:us_core_organization))
+      @sequence.instance_variable_set(:'@organization_ary', @organization_ary)
+
+      @query = {
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@organization_ary, 'name'))
+      }
+    end
+
+    it 'skips if the Organization search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Organization search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Organization search by name test' do
+    before do
+      @test = @sequence_class[:search_by_name]
+      @sequence = @sequence_class.new(@instance, @client)
+      @organization = FHIR.from_contents(load_fixture(:us_core_organization))
+      @organization_ary = [@organization]
+      @sequence.instance_variable_set(:'@organization', @organization)
+      @sequence.instance_variable_set(:'@organization_ary', @organization_ary)
+
+      @query = {
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@organization_ary, 'name'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Organization.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Organization', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Organization resources appear to be available.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Organization.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@organization_ary).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Organization search by address test' do
+    before do
+      @test = @sequence_class[:search_by_address]
+      @sequence = @sequence_class.new(@instance, @client)
+      @organization = FHIR.from_contents(load_fixture(:us_core_organization))
+      @organization_ary = [@organization]
+      @sequence.instance_variable_set(:'@organization', @organization)
+      @sequence.instance_variable_set(:'@organization_ary', @organization_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'address': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@organization_ary, 'address'))
+      }
+    end
+
+    it 'skips if no Organization resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Organization resources appear to be available.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@organization_ary', [FHIR::Organization.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Organization.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Organization', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Organization.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Organization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@organization_ary).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -1,0 +1,676 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310PatientSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310PatientSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Patient')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        '_id': 'example'
+      }
+    end
+
+    it 'skips if the Patient search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Patient search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Patient search by _id test' do
+    before do
+      @test = @sequence_class[:search_by__id]
+      @sequence = @sequence_class.new(@instance, @client)
+      @patient = FHIR.from_contents(load_fixture(:us_core_patient))
+      @patient_ary = { 'example' => @patient }
+      @sequence.instance_variable_set(:'@patient', @patient)
+      @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
+
+      @query = {
+        '_id': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Patient', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Patient.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Patient search by identifier test' do
+    before do
+      @test = @sequence_class[:search_by_identifier]
+      @sequence = @sequence_class.new(@instance, @client)
+      @patient = FHIR.from_contents(load_fixture(:us_core_patient))
+      @patient_ary = { 'example' => @patient }
+      @sequence.instance_variable_set(:'@patient', @patient)
+      @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'identifier'))
+      }
+    end
+
+    it 'skips if no Patient resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Patient', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Patient.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Patient search by name test' do
+    before do
+      @test = @sequence_class[:search_by_name]
+      @sequence = @sequence_class.new(@instance, @client)
+      @patient = FHIR.from_contents(load_fixture(:us_core_patient))
+      @patient_ary = { 'example' => @patient }
+      @sequence.instance_variable_set(:'@patient', @patient)
+      @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name'))
+      }
+    end
+
+    it 'skips if no Patient resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Patient', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Patient.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Patient search by gender+name test' do
+    before do
+      @test = @sequence_class[:search_by_gender_name]
+      @sequence = @sequence_class.new(@instance, @client)
+      @patient = FHIR.from_contents(load_fixture(:us_core_patient))
+      @patient_ary = { 'example' => @patient }
+      @sequence.instance_variable_set(:'@patient', @patient)
+      @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'gender': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'gender')),
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name'))
+      }
+    end
+
+    it 'skips if no Patient resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Patient', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Patient.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Patient search by birthdate+name test' do
+    before do
+      @test = @sequence_class[:search_by_birthdate_name]
+      @sequence = @sequence_class.new(@instance, @client)
+      @patient = FHIR.from_contents(load_fixture(:us_core_patient))
+      @patient_ary = { 'example' => @patient }
+      @sequence.instance_variable_set(:'@patient', @patient)
+      @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'birthdate': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'birthDate')),
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name'))
+      }
+    end
+
+    it 'skips if no Patient resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Patient', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Patient.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Patient search by birthdate+family test' do
+    before do
+      @test = @sequence_class[:search_by_birthdate_family]
+      @sequence = @sequence_class.new(@instance, @client)
+      @patient = FHIR.from_contents(load_fixture(:us_core_patient))
+      @patient_ary = { 'example' => @patient }
+      @sequence.instance_variable_set(:'@patient', @patient)
+      @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'birthdate': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'birthDate')),
+        'family': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name.family'))
+      }
+    end
+
+    it 'skips if no Patient resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Patient', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Patient.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Patient search by family+gender test' do
+    before do
+      @test = @sequence_class[:search_by_family_gender]
+      @sequence = @sequence_class.new(@instance, @client)
+      @patient = FHIR.from_contents(load_fixture(:us_core_patient))
+      @patient_ary = { 'example' => @patient }
+      @sequence.instance_variable_set(:'@patient', @patient)
+      @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'family': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name.family')),
+        'gender': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'gender'))
+      }
+    end
+
+    it 'skips if no Patient resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Patient', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Patient.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Patient read test' do
+    before do
+      @patient_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@patient', FHIR::Patient.new(id: @patient_id))
+    end
+
+    it 'skips if the Patient read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Patient read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Patient has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Patient resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Patient resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Patient' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Patient.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      patient = FHIR::Patient.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: patient.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@patient_id}", exception.message
+    end
+
+    it 'succeeds when a Patient resource is read successfully' do
+      patient = FHIR::Patient.new(
+        id: @patient_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Patient',
+        resource_id: @patient_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: patient.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        '_id': 'example'
+        '_id': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @test = @sequence_class[:search_by__id]
       @sequence = @sequence_class.new(@instance, @client)
       @patient = FHIR.from_contents(load_fixture(:us_core_patient))
-      @patient_ary = { 'example' => @patient }
+      @patient_ary = { @sequence.patient_ids.first => @patient }
       @sequence.instance_variable_set(:'@patient', @patient)
       @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
 
       @query = {
-        '_id': 'example'
+        '_id': @sequence.patient_ids.first
       }
     end
 
@@ -136,14 +136,14 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @test = @sequence_class[:search_by_identifier]
       @sequence = @sequence_class.new(@instance, @client)
       @patient = FHIR.from_contents(load_fixture(:us_core_patient))
-      @patient_ary = { 'example' => @patient }
+      @patient_ary = { @sequence.patient_ids.first => @patient }
       @sequence.instance_variable_set(:'@patient', @patient)
       @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'identifier'))
+        'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'identifier'))
       }
     end
 
@@ -156,7 +156,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
+      @sequence.instance_variable_set(:'@patient_ary', @sequence.patient_ids.first => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -207,14 +207,14 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @test = @sequence_class[:search_by_name]
       @sequence = @sequence_class.new(@instance, @client)
       @patient = FHIR.from_contents(load_fixture(:us_core_patient))
-      @patient_ary = { 'example' => @patient }
+      @patient_ary = { @sequence.patient_ids.first => @patient }
       @sequence.instance_variable_set(:'@patient', @patient)
       @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name'))
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name'))
       }
     end
 
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
+      @sequence.instance_variable_set(:'@patient_ary', @sequence.patient_ids.first => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -278,15 +278,15 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @test = @sequence_class[:search_by_gender_name]
       @sequence = @sequence_class.new(@instance, @client)
       @patient = FHIR.from_contents(load_fixture(:us_core_patient))
-      @patient_ary = { 'example' => @patient }
+      @patient_ary = { @sequence.patient_ids.first => @patient }
       @sequence.instance_variable_set(:'@patient', @patient)
       @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'gender': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'gender')),
-        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name'))
+        'gender': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'gender')),
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name'))
       }
     end
 
@@ -299,7 +299,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
+      @sequence.instance_variable_set(:'@patient_ary', @sequence.patient_ids.first => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -350,15 +350,15 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @test = @sequence_class[:search_by_birthdate_name]
       @sequence = @sequence_class.new(@instance, @client)
       @patient = FHIR.from_contents(load_fixture(:us_core_patient))
-      @patient_ary = { 'example' => @patient }
+      @patient_ary = { @sequence.patient_ids.first => @patient }
       @sequence.instance_variable_set(:'@patient', @patient)
       @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'birthdate': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'birthDate')),
-        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name'))
+        'birthdate': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'birthDate')),
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name'))
       }
     end
 
@@ -371,7 +371,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
+      @sequence.instance_variable_set(:'@patient_ary', @sequence.patient_ids.first => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -422,15 +422,15 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @test = @sequence_class[:search_by_birthdate_family]
       @sequence = @sequence_class.new(@instance, @client)
       @patient = FHIR.from_contents(load_fixture(:us_core_patient))
-      @patient_ary = { 'example' => @patient }
+      @patient_ary = { @sequence.patient_ids.first => @patient }
       @sequence.instance_variable_set(:'@patient', @patient)
       @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'birthdate': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'birthDate')),
-        'family': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name.family'))
+        'birthdate': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'birthDate')),
+        'family': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name.family'))
       }
     end
 
@@ -443,7 +443,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
+      @sequence.instance_variable_set(:'@patient_ary', @sequence.patient_ids.first => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -494,15 +494,15 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @test = @sequence_class[:search_by_family_gender]
       @sequence = @sequence_class.new(@instance, @client)
       @patient = FHIR.from_contents(load_fixture(:us_core_patient))
-      @patient_ary = { 'example' => @patient }
+      @patient_ary = { @sequence.patient_ids.first => @patient }
       @sequence.instance_variable_set(:'@patient', @patient)
       @sequence.instance_variable_set(:'@patient_ary', @patient_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'family': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'name.family')),
-        'gender': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary['example'], 'gender'))
+        'family': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name.family')),
+        'gender': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'gender'))
       }
     end
 
@@ -515,7 +515,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
+      @sequence.instance_variable_set(:'@patient_ary', @sequence.patient_ids.first => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -156,7 +156,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -299,7 +299,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -371,7 +371,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -443,7 +443,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -515,7 +515,7 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@patient_ary', { 'example' => FHIR::Patient.new })
+      @sequence.instance_variable_set(:'@patient_ary', 'example' => FHIR::Patient.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -12,8 +12,8 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
     @token = 'ABC'
     @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
-    @patient_id = 'example'
-    @instance.patient_id = @patient_id
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
     set_resource_support(@instance, 'Practitioner')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
@@ -123,6 +123,193 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
       stub_request(:get, "#{@base_url}/Practitioner/#{@practitioner_id}")
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: practitioner.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @practitioner_ary = FHIR.from_contents(load_fixture(:us_core_practitioner))
+      @sequence.instance_variable_set(:'@practitioner_ary', @practitioner_ary)
+
+      @query = {
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_ary, 'name'))
+      }
+    end
+
+    it 'skips if the Practitioner search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Practitioner search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Practitioner search by name test' do
+    before do
+      @test = @sequence_class[:search_by_name]
+      @sequence = @sequence_class.new(@instance, @client)
+      @practitioner = FHIR.from_contents(load_fixture(:us_core_practitioner))
+      @practitioner_ary = [@practitioner]
+      @sequence.instance_variable_set(:'@practitioner', @practitioner)
+      @sequence.instance_variable_set(:'@practitioner_ary', @practitioner_ary)
+
+      @query = {
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_ary, 'name'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Practitioner.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Practitioner', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Practitioner resources appear to be available.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Practitioner.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@practitioner_ary).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Practitioner search by identifier test' do
+    before do
+      @test = @sequence_class[:search_by_identifier]
+      @sequence = @sequence_class.new(@instance, @client)
+      @practitioner = FHIR.from_contents(load_fixture(:us_core_practitioner))
+      @practitioner_ary = [@practitioner]
+      @sequence.instance_variable_set(:'@practitioner', @practitioner)
+      @sequence.instance_variable_set(:'@practitioner_ary', @practitioner_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_ary, 'identifier'))
+      }
+    end
+
+    it 'skips if no Practitioner resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Practitioner resources appear to be available.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@practitioner_ary', [FHIR::Practitioner.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Practitioner.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Practitioner', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Practitioner.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Practitioner")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@practitioner_ary).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -12,8 +12,8 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     @token = 'ABC'
     @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
-    @patient_id = 'example'
-    @instance.patient_id = @patient_id
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
     set_resource_support(@instance, 'PractitionerRole')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
@@ -123,6 +123,193 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
       stub_request(:get, "#{@base_url}/PractitionerRole/#{@practitioner_role_id}")
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: practitioner_role.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @practitioner_role_ary = FHIR.from_contents(load_fixture(:us_core_practitionerrole))
+      @sequence.instance_variable_set(:'@practitioner_role_ary', @practitioner_role_ary)
+
+      @query = {
+        'specialty': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_role_ary, 'specialty'))
+      }
+    end
+
+    it 'skips if the PractitionerRole search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support PractitionerRole search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'PractitionerRole search by specialty test' do
+    before do
+      @test = @sequence_class[:search_by_specialty]
+      @sequence = @sequence_class.new(@instance, @client)
+      @practitioner_role = FHIR.from_contents(load_fixture(:us_core_practitionerrole))
+      @practitioner_role_ary = [@practitioner_role]
+      @sequence.instance_variable_set(:'@practitioner_role', @practitioner_role)
+      @sequence.instance_variable_set(:'@practitioner_role_ary', @practitioner_role_ary)
+
+      @query = {
+        'specialty': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_role_ary, 'specialty'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::PractitionerRole.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: PractitionerRole', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No PractitionerRole resources appear to be available.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::PractitionerRole.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@practitioner_role_ary).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'PractitionerRole search by practitioner test' do
+    before do
+      @test = @sequence_class[:search_by_practitioner]
+      @sequence = @sequence_class.new(@instance, @client)
+      @practitioner_role = FHIR.from_contents(load_fixture(:us_core_practitionerrole))
+      @practitioner_role_ary = [@practitioner_role]
+      @sequence.instance_variable_set(:'@practitioner_role', @practitioner_role)
+      @sequence.instance_variable_set(:'@practitioner_role_ary', @practitioner_role_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'practitioner': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_role_ary, 'practitioner'))
+      }
+    end
+
+    it 'skips if no PractitionerRole resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No PractitionerRole resources appear to be available.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@practitioner_role_ary', [FHIR::PractitionerRole.new])
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::PractitionerRole.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: PractitionerRole', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::PractitionerRole.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/PractitionerRole")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@practitioner_role_ary).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -1,0 +1,614 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310ProcedureSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310ProcedureSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Procedure')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'skips if the Procedure search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Procedure search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Procedure search by patient test' do
+    before do
+      @test = @sequence_class[:search_by_patient]
+      @sequence = @sequence_class.new(@instance, @client)
+      @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
+      @procedure_ary = { 'example' => @procedure }
+      @sequence.instance_variable_set(:'@procedure', @procedure)
+      @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
+
+      @query = {
+        'patient': 'example'
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Procedure resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Procedure.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query.merge('status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query.merge('status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query.merge('status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@procedure]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Procedure search by patient+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
+      @procedure_ary = { 'example' => @procedure }
+      @sequence.instance_variable_set(:'@procedure', @procedure)
+      @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary['example'], 'performed'))
+      }
+    end
+
+    it 'skips if no Procedure resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Procedure resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@procedure_ary', { 'example' => FHIR::Procedure.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Procedure.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query.merge('status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query.merge('status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+      end
+    end
+  end
+
+  describe 'Procedure search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
+      @procedure_ary = { 'example' => @procedure }
+      @sequence.instance_variable_set(:'@procedure', @procedure)
+      @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary['example'], 'performed'))
+      }
+    end
+
+    it 'skips if no Procedure resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Procedure resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@procedure_ary', { 'example' => FHIR::Procedure.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Procedure.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query.merge('status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query.merge('status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+      end
+    end
+  end
+
+  describe 'Procedure search by patient+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
+      @procedure_ary = { 'example' => @procedure }
+      @sequence.instance_variable_set(:'@procedure', @procedure)
+      @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Procedure resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Procedure resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@procedure_ary', { 'example' => FHIR::Procedure.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Procedure.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Procedure', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Procedure.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Procedure read test' do
+    before do
+      @procedure_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@procedure', FHIR::Procedure.new(id: @procedure_id))
+    end
+
+    it 'skips if the Procedure read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Procedure read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Procedure has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Procedure resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Procedure resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Procedure' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Procedure.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      procedure = FHIR::Procedure.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: procedure.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@procedure_id}", exception.message
+    end
+
+    it 'succeeds when a Procedure resource is read successfully' do
+      procedure = FHIR::Procedure.new(
+        id: @procedure_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Procedure',
+        resource_id: @procedure_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Procedure/#{@procedure_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: procedure.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -73,12 +73,12 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       @test = @sequence_class[:search_by_patient]
       @sequence = @sequence_class.new(@instance, @client)
       @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
-      @procedure_ary = { 'example' => @procedure }
+      @procedure_ary = { @sequence.patient_ids.first => @procedure }
       @sequence.instance_variable_set(:'@procedure', @procedure)
       @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
 
       @query = {
-        'patient': 'example'
+        'patient': @sequence.patient_ids.first
       }
     end
 
@@ -199,15 +199,15 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       @test = @sequence_class[:search_by_patient_date]
       @sequence = @sequence_class.new(@instance, @client)
       @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
-      @procedure_ary = { 'example' => @procedure }
+      @procedure_ary = { @sequence.patient_ids.first => @procedure }
       @sequence.instance_variable_set(:'@procedure', @procedure)
       @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary['example'], 'performed'))
+        'patient': @sequence.patient_ids.first,
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'performed'))
       }
     end
 
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@procedure_ary', 'example' => FHIR::Procedure.new)
+      @sequence.instance_variable_set(:'@procedure_ary', @sequence.patient_ids.first => FHIR::Procedure.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -315,16 +315,16 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
-      @procedure_ary = { 'example' => @procedure }
+      @procedure_ary = { @sequence.patient_ids.first => @procedure }
       @sequence.instance_variable_set(:'@procedure', @procedure)
       @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary['example'], 'performed'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'performed'))
       }
     end
 
@@ -337,7 +337,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@procedure_ary', 'example' => FHIR::Procedure.new)
+      @sequence.instance_variable_set(:'@procedure_ary', @sequence.patient_ids.first => FHIR::Procedure.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -432,15 +432,15 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       @test = @sequence_class[:search_by_patient_status]
       @sequence = @sequence_class.new(@instance, @client)
       @procedure = FHIR.from_contents(load_fixture(:us_core_procedure))
-      @procedure_ary = { 'example' => @procedure }
+      @procedure_ary = { @sequence.patient_ids.first => @procedure }
       @sequence.instance_variable_set(:'@procedure', @procedure)
       @sequence.instance_variable_set(:'@procedure_ary', @procedure_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -453,7 +453,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@procedure_ary', 'example' => FHIR::Procedure.new)
+      @sequence.instance_variable_set(:'@procedure_ary', @sequence.patient_ids.first => FHIR::Procedure.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -220,7 +220,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@procedure_ary', { 'example' => FHIR::Procedure.new })
+      @sequence.instance_variable_set(:'@procedure_ary', 'example' => FHIR::Procedure.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -337,7 +337,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@procedure_ary', { 'example' => FHIR::Procedure.new })
+      @sequence.instance_variable_set(:'@procedure_ary', 'example' => FHIR::Procedure.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -453,7 +453,7 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@procedure_ary', { 'example' => FHIR::Procedure.new })
+      @sequence.instance_variable_set(:'@procedure_ary', 'example' => FHIR::Procedure.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
@@ -12,8 +12,8 @@ describe Inferno::Sequence::USCore310ProvenanceSequence do
     @token = 'ABC'
     @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
     @client = FHIR::Client.for_testing_instance(@instance)
-    @patient_id = 'example'
-    @instance.patient_id = @patient_id
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
     set_resource_support(@instance, 'Provenance')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310PulseOximetrySequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310PulseOximetrySequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '2708-6'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['2708-6', '59408-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['2708-6', '59408-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['2708-6', '59408-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['2708-6', '59408-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['2708-6', '59408-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['2708-6', '59408-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['2708-6', '59408-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['2708-6', '59408-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['2708-6', '59408-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['2708-6', '59408-5'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '2708-6'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_pulse_oximetry))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['2708-6', '59408-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['2708-6', '59408-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       it 'fails if searching with status is not successful' do
         ['2708-6', '59408-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       it 'fails if searching with status does not return a Bundle' do
         ['2708-6', '59408-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       it 'succeeds if searching with status returns valid resources' do
         ['2708-6', '59408-5'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -172,7 +172,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       it 'fails if a 400 is received without an OperationOutcome' do
         ['72166-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -188,7 +188,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       it 'warns if the search is not documented in the CapabilityStatement' do
         ['72166-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -208,7 +208,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       it 'fails if searching with status is not successful' do
         ['72166-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -227,7 +227,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       it 'fails if searching with status does not return a Bundle' do
         ['72166-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")
@@ -246,7 +246,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       it 'succeeds if searching with status returns valid resources' do
         ['72166-2'].each do |value|
           query_params = {
-            'patient': @instance.patient_id,
+            'patient': @sequence.patient_ids.first,
             'code': value
           }
           stub_request(:get, "#{@base_url}/Observation")

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -1,0 +1,819 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::USCore310SmokingstatusSequence do
+  before do
+    @sequence_class = Inferno::Sequence::USCore310SmokingstatusSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_ids = @patient_ids
+    set_resource_support(@instance, 'Observation')
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'unauthorized search test' do
+    before do
+      @test = @sequence_class[:unauthorized_search]
+      @sequence = @sequence_class.new(@instance, @client)
+
+      @query = {
+        'patient': 'example',
+        'code': '72166-2'
+      }
+    end
+
+    it 'skips if the Observation search interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation search operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'fails when the token refresh response has a success status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 401, but found 200', exception.message
+    end
+
+    it 'succeeds when the token refresh response has an error status' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'is omitted when no token is set' do
+      @instance.token = ''
+
+      exception = assert_raises(Inferno::OmitException) { @sequence.run_test(@test) }
+
+      assert_equal 'Do not test if no bearer token set', exception.message
+    end
+  end
+
+  describe 'Observation search by patient+code test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+      }
+    end
+
+    it 'fails if a non-success response code is received' do
+      ['72166-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 401)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      ['72166-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'skips if an empty Bundle is received' do
+      ['72166-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Bundle.new.to_json)
+      end
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      ['72166-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      ['72166-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        body =
+          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+      end
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        ['72166-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        ['72166-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        end
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        ['72166-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+            .to_return(status: 500)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        ['72166-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+            .to_return(status: 200, body: FHIR::Observation.new.to_json)
+        end
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        ['72166-2'].each do |value|
+          query_params = {
+            'patient': @instance.patient_id,
+            'code': value
+          }
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params, headers: @auth_header)
+            .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+        end
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+
+      it 'succeeds if searching with status returns valid resources' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
+        @sequence.run_test(@test)
+      end
+    end
+  end
+
+  describe 'Observation search by patient+code+date test' do
+    before do
+      @test = @sequence_class[:search_by_patient_code_date]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    describe 'with servers that require status' do
+      it 'fails if a 400 is received without an OperationOutcome' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Server returned a status of 400 without an OperationOutcome.', exception.message
+      end
+
+      it 'warns if the search is not documented in the CapabilityStatement' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+
+        assert_raises(WebMock::NetConnectNotAllowedError) { @sequence.run_test(@test) }
+
+        warnings = @sequence.instance_variable_get(:@test_warnings)
+
+        assert warnings.present?, 'Test did not generate any warnings.'
+        assert warnings.any? { |warning| warning.match(/search interaction for this resource is not documented/) },
+               'Test did not generate the expected warning.'
+      end
+
+      it 'fails if searching with status is not successful' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 500)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Bad response code: expected 200, 201, but found 500. ', exception.message
+      end
+
+      it 'fails if searching with status does not return a Bundle' do
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query, headers: @auth_header)
+          .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+        assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+      end
+    end
+  end
+
+  describe 'Observation search by patient+category+status test' do
+    before do
+      @test = @sequence_class[:search_by_patient_category_status]
+      @sequence = @sequence_class.new(@instance, @client)
+      @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
+      @observation_ary = { 'example' => @observation }
+      @sequence.instance_variable_set(:'@observation', @observation)
+      @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
+
+      @sequence.instance_variable_set(:'@resources_found', true)
+
+      @query = {
+        'patient': 'example',
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+      }
+    end
+
+    it 'skips if no Observation resources have been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources appear to be available. Please use patients with more information.', exception.message
+    end
+
+    it 'skips if a value for one of the search parameters cannot be found' do
+      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/Could not resolve .* in any resource\./, exception.message)
+    end
+
+    it 'fails if a non-success response code is received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a Bundle is not received' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Observation.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected FHIR Bundle but found: Observation', exception.message
+    end
+
+    it 'fails if the bundle contains a resource which does not conform to the base FHIR spec' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(FHIR::Observation.new(id: '!@#$%')).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/Invalid \w+:/, exception.message)
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+
+  describe 'Observation read test' do
+    before do
+      @observation_id = '456'
+      @test = @sequence_class[:read_interaction]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resources_found', true)
+      @sequence.instance_variable_set(:'@observation', FHIR::Observation.new(id: @observation_id))
+    end
+
+    it 'skips if the Observation read interaction is not supported' do
+      @instance.server_capabilities.destroy
+      Inferno::Models::ServerCapabilities.create(
+        testing_instance_id: @instance.id,
+        capabilities: FHIR::CapabilityStatement.new.to_json
+      )
+      @instance.reload
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      skip_message = 'This server does not support Observation read operation(s) according to conformance statement.'
+      assert_equal skip_message, exception.message
+    end
+
+    it 'skips if no Observation has been found' do
+      @sequence.instance_variable_set(:'@resources_found', false)
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_equal 'No Observation resources could be found for this patient. Please use patients with more information.', exception.message
+    end
+
+    it 'fails if a non-success response code is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if no resource is received' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected Observation resource to be present.', exception.message
+    end
+
+    it 'fails if the resource returned is not a Observation' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: FHIR::Patient.new.to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Expected resource to be of type Observation.', exception.message
+    end
+
+    it 'fails if the resource has an incorrect id' do
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      observation = FHIR::Observation.new(
+        id: 'wrong_id'
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_equal "Expected resource to contain id: #{@observation_id}", exception.message
+    end
+
+    it 'succeeds when a Observation resource is read successfully' do
+      observation = FHIR::Observation.new(
+        id: @observation_id
+      )
+      Inferno::Models::ResourceReference.create(
+        resource_type: 'Observation',
+        resource_id: @observation_id,
+        testing_instance: @instance
+      )
+
+      stub_request(:get, "#{@base_url}/Observation/#{@observation_id}")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: observation.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', { 'example' => FHIR::Observation.new })
+      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -24,7 +24,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @sequence = @sequence_class.new(@instance, @client)
 
       @query = {
-        'patient': 'example',
+        'patient': @sequence.patient_ids.first,
         'code': '72166-2'
       }
     end
@@ -74,13 +74,13 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @test = @sequence_class[:search_by_patient_code]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
     end
 
@@ -267,16 +267,16 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @test = @sequence_class[:search_by_patient_category_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -289,7 +289,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -384,15 +384,15 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @test = @sequence_class[:search_by_patient_category]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
     end
 
@@ -405,7 +405,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -519,16 +519,16 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @test = @sequence_class[:search_by_patient_code_date]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'code')),
-        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'effective'))
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
 
@@ -541,7 +541,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 
@@ -636,16 +636,16 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @test = @sequence_class[:search_by_patient_category_status]
       @sequence = @sequence_class.new(@instance, @client)
       @observation = FHIR.from_contents(load_fixture(:us_core_smokingstatus))
-      @observation_ary = { 'example' => @observation }
+      @observation_ary = { @sequence.patient_ids.first => @observation }
       @sequence.instance_variable_set(:'@observation', @observation)
       @sequence.instance_variable_set(:'@observation_ary', @observation_ary)
 
       @sequence.instance_variable_set(:'@resources_found', true)
 
       @query = {
-        'patient': 'example',
-        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'category')),
-        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary['example'], 'status'))
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
     end
 
@@ -658,7 +658,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if a value for one of the search parameters cannot be found' do
-      @sequence.instance_variable_set(:'@observation_ary', 'example' => FHIR::Observation.new)
+      @sequence.instance_variable_set(:'@observation_ary', @sequence.patient_ids.first => FHIR::Observation.new)
 
       exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
 

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -101,7 +101,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@location_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
         assert_response_unauthorized reply
@@ -126,7 +126,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@location_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
 
@@ -162,7 +162,7 @@ module Inferno
           'address': get_value_for_search_param(resolve_element_from_path(@location_ary, 'address'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
 
@@ -189,7 +189,7 @@ module Inferno
           'address-city': get_value_for_search_param(resolve_element_from_path(@location_ary, 'address.city'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
 
@@ -216,7 +216,7 @@ module Inferno
           'address-state': get_value_for_search_param(resolve_element_from_path(@location_ary, 'address.state'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
 
@@ -243,7 +243,7 @@ module Inferno
           'address-postalcode': get_value_for_search_param(resolve_element_from_path(@location_ary, 'address.postalCode'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
 
@@ -302,7 +302,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@location_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -89,7 +89,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@organization_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Organization'), search_params)
         assert_response_unauthorized reply
@@ -114,7 +114,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@organization_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Organization'), search_params)
 
@@ -150,7 +150,7 @@ module Inferno
           'address': get_value_for_search_param(resolve_element_from_path(@organization_ary, 'address'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Organization'), search_params)
 
@@ -209,7 +209,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@organization_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('Organization'), search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -90,7 +90,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@practitioner_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Practitioner'), search_params)
         assert_response_unauthorized reply
@@ -115,7 +115,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@practitioner_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Practitioner'), search_params)
 
@@ -151,7 +151,7 @@ module Inferno
           'identifier': get_value_for_search_param(resolve_element_from_path(@practitioner_ary, 'identifier'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Practitioner'), search_params)
 
@@ -210,7 +210,7 @@ module Inferno
           'name': get_value_for_search_param(resolve_element_from_path(@practitioner_ary, 'name'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('Practitioner'), search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -83,7 +83,7 @@ module Inferno
           'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), search_params)
         assert_response_unauthorized reply
@@ -108,7 +108,7 @@ module Inferno
           'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), search_params)
 
@@ -144,7 +144,7 @@ module Inferno
           'practitioner': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'practitioner'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), search_params)
 
@@ -258,7 +258,7 @@ module Inferno
           'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         search_params['_include'] = 'PractitionerRole:endpoint'
         reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), search_params)
@@ -291,7 +291,7 @@ module Inferno
           'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
         }
 
-        search_params.each { |param, value| skip "Could not resolve #{param} in given resource" if value.nil? }
+        search_params.each { |param, value| skip "Could not resolve #{param} in any resource." if value.nil? }
 
         search_params['_revinclude'] = 'Provenance:target'
         reply = get_resource_by_params(versioned_resource_class('PractitionerRole'), search_params)


### PR DESCRIPTION
This PR just adds unit tests back in. It only uses one patient for the tests. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-612
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
