### PR TITLE
FI-560: Check for search support

### DIFF
--- a/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/authorization_unit_test.rb.erb
@@ -14,7 +14,6 @@ describe 'unauthorized search test' do
   end
 
   it 'skips if the <%= resource_type %> search interaction is not supported' do
-    @instance.server_capabilities.destroy
     Inferno::Models::ServerCapabilities.create(
       testing_instance_id: @instance.id,
       capabilities: FHIR::CapabilityStatement.new.to_json

--- a/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/resource_read_unit_test.rb.erb
@@ -9,7 +9,6 @@ describe '<%= resource_type %> read test' do
   end
 
   it 'skips if the <%= resource_type %> read interaction is not supported' do
-    @instance.server_capabilities.destroy
     Inferno::Models::ServerCapabilities.create(
       testing_instance_id: @instance.id,
       capabilities: FHIR::CapabilityStatement.new.to_json

--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -14,6 +14,18 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
     }
   end
 
+  it 'skips if the search params are not supported' do
+    capabilities = Inferno::Models::ServerCapabilities.new
+    def capabilities.supported_search_params(_)
+      [<%=supported_search_params_string%>]
+    end
+    @instance.server_capabilities = capabilities
+
+    exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+    assert_match(/The server doesn't support the search parameters:/, exception.message)
+  end
+
 <% unless is_first_search %>
   it 'skips if no <%= resource_type %> resources have been found' do
     @sequence.instance_variable_set(:'@resources_found', false)

--- a/generator/uscore/templates/unit_tests/unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/unit_test.rb.erb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::<%= class_name %> do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, '<%= resource_type %>')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -53,12 +53,18 @@ module Inferno
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'search_unit_test.rb.erb')))
 
         resource_var_name = resource_type.underscore
+        supported_search_params_string =
+          search_params.keys
+            .take(search_params.length - 1)
+            .map { |value| "'#{value}'" }
+            .join(', ')
 
         test = template.result_with_hash(
           test_key: test_key,
           resource_type: resource_type,
           resource_var_name: resource_var_name,
           search_params: search_params,
+          supported_search_params_string: supported_search_params_string,
           search_param_string: search_params_to_string(search_params),
           sequence_name: sequence_name,
           is_first_search: is_first_search,

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -367,7 +367,7 @@ module Inferno
 
 
             warning do
-              assert @instance.server_capabilities.search_documented?('#{sequence[:resource]}'),
+              assert @instance.server_capabilities&.search_documented?('#{sequence[:resource]}'),
                 %(Server returned a status of 400 with an OperationOutcome, but the
                 search interaction for this resource is not documented in the
                 CapabilityStatement. If this response was due to the server

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -451,7 +451,7 @@ module Inferno
             end
 
             %(
-              #{skip_if_search_not_supported_code(sequence, search_param)}
+              #{skip_if_search_not_supported_code(sequence, search_param[:names])}
               #{skip_if_not_found(sequence)}
               #{resolved_one_str if resolve_param_from_resource && !sequence[:delayed_sequence]}
               #{reply_code}
@@ -481,7 +481,7 @@ module Inferno
       end
 
       def skip_if_search_not_supported_code(sequence, search_params)
-        search_param_string = search_params[:names].map { |param| "'#{param}'" }.join(', ')
+        search_param_string = search_params.map { |param| "'#{param}'" }.join(', ')
         "skip_if_known_search_not_supported('#{sequence[:resource]}', [#{search_param_string}])"
       end
 
@@ -806,7 +806,7 @@ module Inferno
           search_params = get_search_params(multiple_or_search[:names], sequence)
           resolve_param_from_resource = search_params.include? 'get_value_for_search_param'
           test[:test_code] += %(
-            #{skip_if_search_not_supported_code(sequence, multiple_or_search)}
+            #{skip_if_search_not_supported_code(sequence, multiple_or_search[:names])}
           )
           if resolve_param_from_resource
             test[:test_code] += %(
@@ -921,6 +921,7 @@ module Inferno
       def get_first_search_by_patient(sequence, search_parameters, save_resource_ids_in_bundle_arguments)
         if sequence[:delayed_sequence]
           %(
+            #{skip_if_search_not_supported_code(sequence, search_parameters)}
             #{get_search_params(search_parameters, sequence)}
             reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
             #{status_search_code(sequence, search_parameters)}
@@ -938,6 +939,7 @@ module Inferno
           )
         else
           %(
+            #{skip_if_search_not_supported_code(sequence, search_parameters)}
             @#{sequence[:resource].underscore}_ary = {}
             patient_ids.each do |patient|
               #{get_search_params(search_parameters, sequence)}
@@ -991,6 +993,7 @@ module Inferno
         find_two_values = get_multiple_or_params(sequence).include? search_param[:name]
         values_variable_name = "#{search_param[:name].tr('-', '_')}_val"
         %(
+          #{skip_if_search_not_supported_code(sequence, search_parameters)}
           @#{sequence[:resource].underscore}_ary = {}
           @resources_found = false
           #{'values_found = 0' if find_two_values}

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -449,7 +449,10 @@ module Inferno
                 end
               )
             end
+
+            search_param_string = search_param[:names].map { |param| "'#{param}'" }.join(', ')
             %(
+              skip_if_known_search_not_supported(#{sequence[:resource]}, [#{search_param_string}])
               #{skip_if_not_found(sequence)}
               #{resolved_one_str if resolve_param_from_resource && !sequence[:delayed_sequence]}
               #{reply_code}

--- a/lib/app/models/server_capabilities.rb
+++ b/lib/app/models/server_capabilities.rb
@@ -59,6 +59,12 @@ module Inferno
         end
       end
 
+      def supported_search_params(resource_type)
+        statement&.rest&.first&.resource
+            &.find { |resource| resource&.type == resource_type }
+            &.searchParam&.map(&:name) || []
+      end
+
       private
 
       def statement

--- a/lib/app/utils/skip_helpers.rb
+++ b/lib/app/utils/skip_helpers.rb
@@ -10,6 +10,19 @@ module Inferno
       skip_if_not_supported(resource, methods, operations)
     end
 
+    def skip_if_known_search_not_supported(resource, params)
+      # In the case that the user has not run the any capability statement sequences, we
+      # will allow this to silently pass because we don't know if the server supports it or not.
+      return if @instance.server_capabilities.nil?
+
+      skip_if_search_not_supported(resource, params)
+    end
+
+    def skip_if_search_not_supported(resource, params)
+      unsupported_search_params = params - @instance.server_capabilities.supported_search_params(resource)
+      skip_unless unsupported_search_params.blank?, "The server doesn't support the search parameters: #{unsupported_search_params.join(', ')}"
+    end
+
     def skip_if_not_supported(resource, methods = [], operations = [])
       skip_message = "This server does not support #{resource} #{(methods + operations).join(',')} operation(s) according to conformance statement."
       skip skip_message unless @instance.conformance_supported?(resource, methods, operations)

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310BodytempSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310BodytempSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310BpSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310BpSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310BpSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310BpSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310BpSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310BpSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310BpSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310ResprateSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310ResprateSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'AllergyIntolerance')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     end
 
     it 'skips if the AllergyIntolerance search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       @query = {
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -211,6 +221,18 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no AllergyIntolerance resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -276,7 +298,6 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     end
 
     it 'skips if the AllergyIntolerance read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'CarePlan')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
 
     it 'skips if the CarePlan search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310CareplanSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no CarePlan resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -398,6 +420,18 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category', 'status']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no CarePlan resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -461,6 +495,18 @@ describe Inferno::Sequence::USCore310CareplanSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'status'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no CarePlan resources have been found' do
@@ -528,7 +574,6 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     end
 
     it 'skips if the CarePlan read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310CareteamSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'CareTeam')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310CareteamSequence do
     end
 
     it 'skips if the CareTeam search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310CareteamSequence do
         'patient': @sequence.patient_ids.first,
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_team_ary[@sequence.patient_ids.first], 'status'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -179,7 +189,6 @@ describe Inferno::Sequence::USCore310CareteamSequence do
     end
 
     it 'skips if the CareTeam read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Condition')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if the Condition search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       @query = {
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -209,6 +219,18 @@ describe Inferno::Sequence::USCore310ConditionSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Condition resources have been found' do
@@ -346,6 +368,18 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Condition resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -462,6 +496,18 @@ describe Inferno::Sequence::USCore310ConditionSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Condition resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -532,6 +578,18 @@ describe Inferno::Sequence::USCore310ConditionSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@condition_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Condition resources have been found' do
@@ -662,7 +720,6 @@ describe Inferno::Sequence::USCore310ConditionSequence do
     end
 
     it 'skips if the Condition read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'DiagnosticReport')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if the DiagnosticReport search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -278,6 +288,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DiagnosticReport resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -403,6 +425,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no DiagnosticReport resources have been found' do
@@ -541,6 +575,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DiagnosticReport resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -657,6 +703,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DiagnosticReport resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -728,6 +786,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code')),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no DiagnosticReport resources have been found' do
@@ -839,7 +909,6 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
     end
 
     it 'skips if the DiagnosticReport read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'DiagnosticReport')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if the DiagnosticReport search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -278,6 +288,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DiagnosticReport resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -403,6 +425,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no DiagnosticReport resources have been found' do
@@ -541,6 +575,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DiagnosticReport resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -657,6 +703,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DiagnosticReport resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -728,6 +786,18 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code')),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no DiagnosticReport resources have been found' do
@@ -839,7 +909,6 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
     end
 
     it 'skips if the DiagnosticReport read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'DocumentReference')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if the DocumentReference search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @query = {
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -208,6 +218,18 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @query = {
         '_id': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'id'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no DocumentReference resources have been found' do
@@ -343,6 +365,18 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
         'patient': @sequence.patient_ids.first,
         'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'type'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no DocumentReference resources have been found' do
@@ -481,6 +515,18 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DocumentReference resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -614,6 +660,18 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no DocumentReference resources have been found' do
@@ -752,6 +810,18 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'type']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DocumentReference resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -868,6 +938,18 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no DocumentReference resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -933,7 +1015,6 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
     end
 
     it 'skips if the DocumentReference read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_encounter_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Encounter')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if the Encounter search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @query = {
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -208,6 +218,18 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @query = {
         '_id': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'id'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Encounter resources have been found' do
@@ -345,6 +367,18 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['date']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Encounter resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -458,6 +492,18 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       @query = {
         'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'identifier'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Encounter resources have been found' do
@@ -595,6 +641,18 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Encounter resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -665,6 +723,18 @@ describe Inferno::Sequence::USCore310EncounterSequence do
         'class': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@encounter_ary[@sequence.patient_ids.first], 'local_class')),
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['class']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Encounter resources have been found' do
@@ -802,6 +872,18 @@ describe Inferno::Sequence::USCore310EncounterSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Encounter resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -930,7 +1012,6 @@ describe Inferno::Sequence::USCore310EncounterSequence do
     end
 
     it 'skips if the Encounter read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310GoalSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Goal')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310GoalSequence do
     end
 
     it 'skips if the Goal search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310GoalSequence do
       @query = {
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -211,6 +221,18 @@ describe Inferno::Sequence::USCore310GoalSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Goal resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -327,6 +349,18 @@ describe Inferno::Sequence::USCore310GoalSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Goal resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -392,7 +426,6 @@ describe Inferno::Sequence::USCore310GoalSequence do
     end
 
     it 'skips if the Goal read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Immunization')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     end
 
     it 'skips if the Immunization search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       @query = {
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -211,6 +221,18 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Immunization resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -327,6 +349,18 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Immunization resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -392,7 +426,6 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
     end
 
     it 'skips if the Immunization read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Device')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     end
 
     it 'skips if the Device search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
       @query = {
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -148,6 +158,18 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Device resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -213,7 +235,6 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     end
 
     it 'skips if the Device read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_location_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310LocationSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Location')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -26,7 +25,6 @@ describe Inferno::Sequence::USCore310LocationSequence do
     end
 
     it 'skips if the Location read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -142,7 +140,6 @@ describe Inferno::Sequence::USCore310LocationSequence do
     end
 
     it 'skips if the Location search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -193,6 +190,18 @@ describe Inferno::Sequence::USCore310LocationSequence do
       @query = {
         'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'name'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -258,6 +267,18 @@ describe Inferno::Sequence::USCore310LocationSequence do
       @query = {
         'address': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'address'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Location resources have been found' do
@@ -331,6 +352,18 @@ describe Inferno::Sequence::USCore310LocationSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Location resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -402,6 +435,18 @@ describe Inferno::Sequence::USCore310LocationSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Location resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -471,6 +516,18 @@ describe Inferno::Sequence::USCore310LocationSequence do
       @query = {
         'address-postalcode': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@location_ary, 'address.postalCode'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Location resources have been found' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medication_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310MedicationSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Medication')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -26,7 +25,6 @@ describe Inferno::Sequence::USCore310MedicationSequence do
     end
 
     it 'skips if the Medication read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'MedicationRequest')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
 
     it 'skips if the MedicationRequest search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
         'patient': @sequence.patient_ids.first,
         'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'intent'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'intent']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no MedicationRequest resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -351,6 +373,18 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
         'intent': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'intent')),
         'encounter': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@medication_request_ary[@sequence.patient_ids.first], 'encounter'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'intent']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no MedicationRequest resources have been found' do
@@ -489,6 +523,18 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'intent']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no MedicationRequest resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -617,7 +663,6 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
     end
 
     it 'skips if the MedicationRequest read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -279,6 +289,18 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -415,6 +437,18 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -530,6 +564,18 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_organization_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Organization')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -26,7 +25,6 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
     end
 
     it 'skips if the Organization read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -142,7 +140,6 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
     end
 
     it 'skips if the Organization search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -193,6 +190,18 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
       @query = {
         'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@organization_ary, 'name'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -258,6 +267,18 @@ describe Inferno::Sequence::USCore310OrganizationSequence do
       @query = {
         'address': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@organization_ary, 'address'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Organization resources have been found' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310PatientSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Patient')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if the Patient search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @query = {
         '_id': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -145,6 +155,18 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @query = {
         'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'identifier'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Patient resources have been found' do
@@ -216,6 +238,18 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @query = {
         'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Patient resources have been found' do
@@ -290,6 +324,18 @@ describe Inferno::Sequence::USCore310PatientSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['gender']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Patient resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -360,6 +406,18 @@ describe Inferno::Sequence::USCore310PatientSequence do
         'birthdate': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'birthDate')),
         'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['birthdate']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Patient resources have been found' do
@@ -434,6 +492,18 @@ describe Inferno::Sequence::USCore310PatientSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['birthdate']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Patient resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -506,6 +576,18 @@ describe Inferno::Sequence::USCore310PatientSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['family']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Patient resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -571,7 +653,6 @@ describe Inferno::Sequence::USCore310PatientSequence do
     end
 
     it 'skips if the Patient read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitioner_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Practitioner')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -26,7 +25,6 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
     end
 
     it 'skips if the Practitioner read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -142,7 +140,6 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
     end
 
     it 'skips if the Practitioner search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -193,6 +190,18 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
       @query = {
         'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_ary, 'name'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -258,6 +267,18 @@ describe Inferno::Sequence::USCore310PractitionerSequence do
       @query = {
         'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_ary, 'identifier'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Practitioner resources have been found' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_practitionerrole_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'PractitionerRole')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -26,7 +25,6 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'skips if the PractitionerRole read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -142,7 +140,6 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
     end
 
     it 'skips if the PractitionerRole search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -193,6 +190,18 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
       @query = {
         'specialty': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_role_ary, 'specialty'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -258,6 +267,18 @@ describe Inferno::Sequence::USCore310PractitionerroleSequence do
       @query = {
         'practitioner': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@practitioner_role_ary, 'practitioner'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no PractitionerRole resources have been found' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Procedure')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -29,7 +28,6 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
 
     it 'skips if the Procedure search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -80,6 +78,18 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       @query = {
         'patient': @sequence.patient_ids.first
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        []
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -211,6 +221,18 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Procedure resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -326,6 +348,18 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'code')),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'performed'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Procedure resources have been found' do
@@ -444,6 +478,18 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Procedure resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -509,7 +555,6 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
     end
 
     it 'skips if the Procedure read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_provenance_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310ProvenanceSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Provenance')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -26,7 +25,6 @@ describe Inferno::Sequence::USCore310ProvenanceSequence do
     end
 
     it 'skips if the Provenance read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -14,7 +14,6 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     @client = FHIR::Client.for_testing_instance(@instance)
     @patient_ids = 'example'
     @instance.patient_ids = @patient_ids
-    set_resource_support(@instance, 'Observation')
     @auth_header = { 'Authorization' => "Bearer #{@token}" }
   end
 
@@ -30,7 +29,6 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if the Observation search interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json
@@ -82,6 +80,18 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'fails if a non-success response code is received' do
@@ -280,6 +290,18 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -394,6 +416,18 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+    end
+
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
     end
 
     it 'skips if no Observation resources have been found' do
@@ -532,6 +566,18 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'code']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -649,6 +695,18 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       }
     end
 
+    it 'skips if the search params are not supported' do
+      capabilities = Inferno::Models::ServerCapabilities.new
+      def capabilities.supported_search_params(_)
+        ['patient', 'category']
+      end
+      @instance.server_capabilities = capabilities
+
+      exception = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+
+      assert_match(/The server doesn't support the search parameters:/, exception.message)
+    end
+
     it 'skips if no Observation resources have been found' do
       @sequence.instance_variable_set(:'@resources_found', false)
 
@@ -714,7 +772,6 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     end
 
     it 'skips if the Observation read interaction is not supported' do
-      @instance.server_capabilities.destroy
       Inferno::Models::ServerCapabilities.create(
         testing_instance_id: @instance.id,
         capabilities: FHIR::CapabilityStatement.new.to_json

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -39,7 +39,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('AllergyIntolerance'),
+          assert @instance.server_capabilities&.search_documented?('AllergyIntolerance'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -114,6 +114,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('AllergyIntolerance', ['patient'])
         @allergy_intolerance_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -159,6 +160,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('AllergyIntolerance', ['patient', 'clinical-status'])
         skip 'No AllergyIntolerance resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -47,7 +47,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('CarePlan'),
+          assert @instance.server_capabilities&.search_documented?('CarePlan'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -123,6 +123,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('CarePlan', ['patient', 'category'])
         @care_plan_ary = {}
         @resources_found = false
 
@@ -171,6 +172,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('CarePlan', ['patient', 'category', 'date'])
         skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -221,6 +223,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('CarePlan', ['patient', 'category', 'status', 'date'])
         skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -269,6 +272,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('CarePlan', ['patient', 'category', 'status'])
         skip 'No CarePlan resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -39,7 +39,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('CareTeam'),
+          assert @instance.server_capabilities&.search_documented?('CareTeam'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -115,6 +115,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('CareTeam', ['patient', 'status'])
         @care_team_ary = {}
         @resources_found = false
         values_found = 0
@@ -313,6 +314,8 @@ module Inferno
           )
           versions :r4
         end
+
+        skip_if_known_search_not_supported('CareTeam', ['patient', 'status'])
 
         could_not_resolve_all = []
         resolved_one = false

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Condition'),
+          assert @instance.server_capabilities&.search_documented?('Condition'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -126,6 +126,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Condition', ['patient'])
         @condition_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -171,6 +172,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Condition', ['patient', 'category'])
         skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -213,6 +215,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Condition', ['patient', 'onset-date'])
         skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -261,6 +264,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Condition', ['patient', 'clinical-status'])
         skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -300,6 +304,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Condition', ['patient', 'code'])
         skip 'No Condition resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('DiagnosticReport'),
+          assert @instance.server_capabilities&.search_documented?('DiagnosticReport'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
 
@@ -173,6 +174,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         patient_ids.each do |patient|
@@ -201,6 +203,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'code'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -242,6 +245,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category', 'date'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -291,6 +295,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'status'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -331,6 +336,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'code', 'date'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('DiagnosticReport'),
+          assert @instance.server_capabilities&.search_documented?('DiagnosticReport'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
 
@@ -173,6 +174,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         patient_ids.each do |patient|
@@ -201,6 +203,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'code'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -242,6 +245,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category', 'date'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -291,6 +295,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'status'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -331,6 +336,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'code', 'date'])
         skip 'No DiagnosticReport resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -59,7 +59,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('DocumentReference'),
+          assert @instance.server_capabilities&.search_documented?('DocumentReference'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -134,6 +134,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DocumentReference', ['patient'])
         @document_reference_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -178,6 +179,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DocumentReference', ['_id'])
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -217,6 +219,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DocumentReference', ['patient', 'type'])
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -258,6 +261,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DocumentReference', ['patient', 'category', 'date'])
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -299,6 +303,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DocumentReference', ['patient', 'category'])
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -341,6 +346,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DocumentReference', ['patient', 'type', 'period'])
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -390,6 +396,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('DocumentReference', ['patient', 'status'])
         skip 'No DocumentReference resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -59,7 +59,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Encounter'),
+          assert @instance.server_capabilities&.search_documented?('Encounter'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -134,6 +134,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Encounter', ['patient'])
         @encounter_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -178,6 +179,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Encounter', ['_id'])
         skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -218,6 +220,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Encounter', ['date', 'patient'])
         skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -266,6 +269,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Encounter', ['identifier'])
         skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -306,6 +310,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Encounter', ['patient', 'status'])
         skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -345,6 +350,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Encounter', ['class', 'patient'])
         skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -386,6 +392,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Encounter', ['patient', 'type'])
         skip 'No Encounter resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -43,7 +43,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Goal'),
+          assert @instance.server_capabilities&.search_documented?('Goal'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -118,6 +118,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Goal', ['patient'])
         @goal_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -164,6 +165,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Goal', ['patient', 'target-date'])
         skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -212,6 +214,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Goal', ['patient', 'lifecycle-status'])
         skip 'No Goal resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -43,7 +43,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Immunization'),
+          assert @instance.server_capabilities&.search_documented?('Immunization'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -118,6 +118,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Immunization', ['patient'])
         @immunization_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -164,6 +165,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Immunization', ['patient', 'date'])
         skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -212,6 +214,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Immunization', ['patient', 'status'])
         skip 'No Immunization resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -81,6 +81,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Device', ['patient'])
         @device_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -124,6 +125,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Device', ['patient', 'type'])
         skip 'No Device resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -127,6 +127,8 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Location', ['name'])
+
         search_params = {
           'name': get_value_for_search_param(resolve_element_from_path(@location_ary, 'name'))
         }
@@ -161,6 +163,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Location', ['address'])
         skip 'No Location resources appear to be available.' unless @resources_found
 
         search_params = {
@@ -188,6 +191,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Location', ['address-city'])
         skip 'No Location resources appear to be available.' unless @resources_found
 
         search_params = {
@@ -215,6 +219,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Location', ['address-state'])
         skip 'No Location resources appear to be available.' unless @resources_found
 
         search_params = {
@@ -242,6 +247,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Location', ['address-postalcode'])
         skip 'No Location resources appear to be available.' unless @resources_found
 
         search_params = {

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -69,7 +69,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('MedicationRequest'),
+          assert @instance.server_capabilities&.search_documented?('MedicationRequest'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -149,6 +149,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent'])
         @medication_request_ary = {}
         @resources_found = false
 
@@ -199,6 +200,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent', 'status'])
         skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -244,6 +246,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent', 'encounter'])
         skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -292,6 +295,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent', 'authoredon'])
         skip 'No MedicationRequest resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -540,6 +544,8 @@ module Inferno
           )
           versions :r4
         end
+
+        skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent', 'status'])
 
         could_not_resolve_all = []
         resolved_one = false

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         @observation_ary = {}
         @resources_found = false
 
@@ -173,6 +174,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -214,6 +216,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -115,6 +115,8 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Organization', ['name'])
+
         search_params = {
           'name': get_value_for_search_param(resolve_element_from_path(@organization_ary, 'name'))
         }
@@ -149,6 +151,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Organization', ['address'])
         skip 'No Organization resources appear to be available.' unless @resources_found
 
         search_params = {

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -108,6 +108,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Patient', ['_id'])
         @patient_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -150,6 +151,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Patient', ['identifier'])
         skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -187,6 +189,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Patient', ['name'])
         skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -224,6 +227,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Patient', ['gender', 'name'])
         skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -262,6 +266,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Patient', ['birthdate', 'name'])
         skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -301,6 +306,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Patient', ['birthdate', 'family'])
         skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -340,6 +346,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Patient', ['family', 'gender'])
         skip 'No Patient resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -116,6 +116,8 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Practitioner', ['name'])
+
         search_params = {
           'name': get_value_for_search_param(resolve_element_from_path(@practitioner_ary, 'name'))
         }
@@ -150,6 +152,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Practitioner', ['identifier'])
         skip 'No Practitioner resources appear to be available.' unless @resources_found
 
         search_params = {

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -109,6 +109,8 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('PractitionerRole', ['specialty'])
+
         search_params = {
           'specialty': get_value_for_search_param(resolve_element_from_path(@practitioner_role_ary, 'specialty'))
         }
@@ -143,6 +145,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('PractitionerRole', ['practitioner'])
         skip 'No PractitionerRole resources appear to be available.' unless @resources_found
 
         search_params = {

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -47,7 +47,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Procedure'),
+          assert @instance.server_capabilities&.search_documented?('Procedure'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -122,6 +122,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Procedure', ['patient'])
         @procedure_ary = {}
         patient_ids.each do |patient|
           search_params = {
@@ -167,6 +168,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Procedure', ['patient', 'date'])
         skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -216,6 +218,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Procedure', ['patient', 'code', 'date'])
         skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -265,6 +268,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Procedure', ['patient', 'status'])
         skip 'No Procedure resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         end
 
         warning do
-          assert @instance.server_capabilities.search_documented?('Observation'),
+          assert @instance.server_capabilities&.search_documented?('Observation'),
                  %(Server returned a status of 400 with an OperationOutcome, but the
                  search interaction for this resource is not documented in the
                  CapabilityStatement. If this response was due to the server
@@ -127,6 +127,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
 
@@ -174,6 +175,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -222,6 +224,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -264,6 +267,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'code', 'date'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []
@@ -313,6 +317,7 @@ module Inferno
           versions :r4
         end
 
+        skip_if_known_search_not_supported('Observation', ['patient', 'category', 'status'])
         skip 'No Observation resources appear to be available. Please use patients with more information.' unless @resources_found
 
         could_not_resolve_all = []

--- a/test/unit/server_capabilities_test.rb
+++ b/test/unit/server_capabilities_test.rb
@@ -17,6 +17,16 @@ class ServerCapabilitiesTest < MiniTest::Test
                 { code: 'vread' },
                 { code: 'history-instance' },
                 { code: 'search-type', documentation: 'DOCUMENTATION' }
+              ],
+              searchParam: [
+                {
+                  name: '_id',
+                  type: 'token'
+                },
+                {
+                  name: 'birthdate',
+                  type: 'date'
+                }
               ]
             },
             {
@@ -144,5 +154,11 @@ class ServerCapabilitiesTest < MiniTest::Test
     assert @capabilities.search_documented?('Patient')
     refute @capabilities.search_documented?('Condition')
     refute @capabilities.search_documented?('Observation')
+  end
+
+  def test_supported_search_params
+    assert_equal ['_id', 'birthdate'], @capabilities.supported_search_params('Patient')
+    assert_equal [], @capabilities.supported_search_params('Condition')
+    assert_equal [], @capabilities.supported_search_params('Location')
   end
 end


### PR DESCRIPTION
This branch checks whether the search parameters in a particular test are supported by the server, and skips if a parameter is not supported.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-560
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
