### PR TITLE
FI-482: Allow error message formatting

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -517,7 +517,7 @@ module Inferno
           # This checks to see if the base resource conforms to the specification
           # It does not validate any profiles.
           resource_validation_errors = Inferno::RESOURCE_VALIDATOR.validate(entry.resource, versioned_resource_class)
-          assert resource_validation_errors[:errors].empty?, "Invalid #{entry.resource.resourceType}: #{resource_validation_errors[:errors].join("<br/>\n")}"
+          assert resource_validation_errors[:errors].empty?, "Invalid #{entry.resource.resourceType}: \n\n* #{resource_validation_errors[:errors].join("\n* ")}"
 
           search_params.each do |key, value|
             validate_resource_item(entry.resource, key.to_s, value)
@@ -613,7 +613,7 @@ module Inferno
           end
         end
 
-        assert(errors.empty?, errors.join("<br/>\n"))
+        assert(errors.empty?, "\n* " + errors.join("\n* "))
       end
 
       def test_resources_against_profile(resource_type, specified_profile = nil, &block)
@@ -652,7 +652,7 @@ module Inferno
           validate_resource(resource_type, resource, profile, &block)
         end
 
-        assert(errors.empty?, errors.join("<br/>\n"))
+        assert(errors.empty?, "\n* " + errors.join("\n* "))
       end
 
       # Set max_resolutions in a single sequence to a large number by default
@@ -686,7 +686,7 @@ module Inferno
 
         Inferno.logger.info "Surpassed the maximum reference resolutions: #{max_resolutions}" if resolved_references.length > max_resolutions
 
-        assert(problems.empty?, problems.join("<br/>\n"))
+        assert(problems.empty?, "\n* " + problems.join("\n* "))
       end
 
       def save_delayed_sequence_references(resources)
@@ -722,7 +722,7 @@ module Inferno
           resource_validation_errors = Inferno::RESOURCE_VALIDATOR.validate(entry.resource, versioned_resource_class)
           errors = resource_validation_errors[:errors]
         end
-        assert(errors.empty?, errors.join("<br/>\n"))
+        assert(errors.empty?, "\n* " + errors.join("\n* "))
       end
 
       def resolve_path(elements, path)

--- a/lib/app/views/test_inputs.erb
+++ b/lib/app/views/test_inputs.erb
@@ -1,6 +1,6 @@
 <ul class='input-list test-list'>
   <% JSON.parse(sequence_result.input_params).each do |type, value| %>
-    <li>
+    <li class='test-list-item'>
     <span>
         <strong>
         <%= type.sub('_', ' ').titlecase %> &nbsp;

--- a/lib/app/views/test_list.erb
+++ b/lib/app/views/test_list.erb
@@ -66,9 +66,11 @@
       <button class="test-results-more" data-testing-instance-id="<%=sequence_result.testing_instance.id%>" data-test-result-id="<%=result.id%>">results...</button>
       <% unless result.message.nil? %>
         <div class="result-details-message">
-            Details:  <%= CGI.escapeHTML result.message %>
-            <%# TODO: Make this dependent on a flag for community/guided edition %>
-            <% unless result.required %> <br/>This optional test is not required for conformance. <% end %>
+          <%= markdown_to_html CGI.escapeHTML(result.message) %>
+          <%# TODO: Make this dependent on a flag for community/guided edition %>
+          <% unless result.required %>
+            <p class="result-details-optional-fail">This optional test is not required for conformance.<p>
+          <% end %>
         </div>
       <% end %>
     </li>

--- a/lib/app/views/test_list.erb
+++ b/lib/app/views/test_list.erb
@@ -1,6 +1,6 @@
 <ul class='test-list'>
   <% sequence_result && sequence_result.test_results.each do |result, index| %>
-    <li>
+    <li class='test-list-item'>
       <% case result.result
         when 'pass' %>
           <div class="result-details-icon result-details-icon-pass" data-toggle="tooltip" title="Test passed.">
@@ -76,7 +76,7 @@
   <% start_at = 0%>
   <% start_at = [sequence_result.test_results.length, sequence_class.tests(instance.module).length].min unless sequence_result.nil? %>
   <% sequence_class.tests(instance.module)[start_at..-1].each_with_index do |test, index| %>
-    <li>
+    <li class='test-list-item'>
       <strong><%= test_case_prefix %><%= test.id %></strong>:
         <% if test.optional? %> OPTIONAL |  <% end %>
         <%= test.name %>

--- a/lib/app/views/test_log.erb
+++ b/lib/app/views/test_log.erb
@@ -1,7 +1,7 @@
 <ul class='test-list'>
   <% sequence_result && sequence_result.test_results.each do |result, index| %>
     <% result.request_responses.each do |rr|%>
-      <li>
+      <li class='test-list-item'>
         <span>
           <strong>
             <%= rr.request_method.upcase %> &nbsp;

--- a/lib/app/views/test_outputs.erb
+++ b/lib/app/views/test_outputs.erb
@@ -1,6 +1,6 @@
 <ul class='input-list test-list'>
   <% JSON.parse(sequence_result.output_results).each do |output_name, output_value| %>
-    <li>
+    <li class='test-list-item'>
     <span>
         <strong>
         <%= output_name.sub('_', ' ').titlecase %> &nbsp;

--- a/lib/app/views/test_result_details.erb
+++ b/lib/app/views/test_result_details.erb
@@ -53,7 +53,7 @@
 
     <% unless @test_result.message.nil? %>
       <div class="test-result-details-message">
-        <span class="test-result-details-message-label">Error Message:</span> <%= CGI.escapeHTML @test_result.message %>
+        <span class="test-result-details-message-label">Error Message:</span> <%= markdown_to_html CGI.escapeHTML(@test_result.message) %>
       </div>
     <% end %>
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -712,7 +712,7 @@ body {
   margin: 0;
 }
 
-.test-list li {
+.test-list-item {
   list-style: none;
   font-size: .9em;
   padding: 10px 15px;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -815,13 +815,28 @@ body {
 .result-details h1{
   font-size: 1.5em;
 }
- .result-details h2 {
+
+.result-details h2 {
   font-size: 1.3em;
 }
- .result-details h3, .result-details h4, .result-details h5 {
+
+.result-details h3, .result-details h4, .result-details h5 {
   font-size: 1.1em;
 }
- .more-information {
+
+.result-details-message p {
+  margin-bottom: 0.25em;
+}
+
+.result-details-message ul {
+  padding-left: 1em;
+}
+
+.result-details-optional-fail {
+  margin-top: 0.5em;
+}
+
+.more-information {
   padding: 10px;
 }
 


### PR DESCRIPTION
This branch allows markdown formatting of error messages, mainly so that we can have multiline error messages. You will probably need to run this in a private window to load the new css.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
