### PR TITLE
FI-928: Integrate generation with validator

### DIFF
--- a/generator/generic/generic_generator.rb
+++ b/generator/generic/generic_generator.rb
@@ -51,6 +51,7 @@ module Inferno
         module_info = {
           title: @path,
           sequences: sequence_metadata,
+          resource_path: @path,
           description: ''
         }
         template = ERB.new(File.read(File.join(__dir__, 'templates/module.yml.erb')))

--- a/generator/generic/templates/module.yml.erb
+++ b/generator/generic/templates/module.yml.erb
@@ -1,5 +1,6 @@
 name: <%= title.underscore %>
 title: <%= title %>
+resource_path: <%= resource_path %>
 description : <%= description %>
 fhir_version: r4
 default_test_set: ad_hoc_testing

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -24,11 +24,14 @@ require_relative 'app/models/module'
 require_relative 'version'
 require_relative 'app/models'
 require_relative 'app/utils/terminology'
+require_relative 'app/utils/startup_tasks'
 
 module Inferno
   class App
     attr_reader :app
     def initialize
+      StartupTasks.run
+
       @app = Rack::Builder.app do
         Endpoint.subclasses.each do |endpoint|
           map(endpoint.prefix) { run(endpoint.new) }

--- a/lib/app/models/module.rb
+++ b/lib/app/models/module.rb
@@ -76,10 +76,5 @@ module Inferno
     def self.available_modules
       @modules
     end
-
-    Dir.glob(File.join(__dir__, '..', '..', 'modules', '*_module.yml')).each do |file|
-      this_module = YAML.load_file(file).deep_symbolize_keys
-      new(this_module)
-    end
   end
 end

--- a/lib/app/models/module.rb
+++ b/lib/app/models/module.rb
@@ -18,6 +18,7 @@ module Inferno
     attr_accessor :tags
     attr_accessor :test_sets
     attr_accessor :title
+    attr_accessor :resource_path
 
     def initialize(params)
       @name = params[:name]
@@ -29,6 +30,7 @@ module Inferno
       @tags = params[:tags]&.map do |tag|
         Tag.new(tag[:name], tag[:description], tag[:url])
       end || []
+      @resource_path = params[:resource_path]
       @test_sets = {}.tap do |test_sets|
         params[:test_sets].each do |test_set_key, test_set|
           self.default_test_set ||= test_set_key.to_s

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -96,7 +96,7 @@ module Inferno
 
       def ig_files(path)
         resource_path = File.join(__dir__, '..', '..', '..', 'resources', path)
-        Dir.glob(File.join(resource_path, '**', '*'))
+        Dir.glob(File.join(resource_path, '**', '*')) + Dir.glob(File.join(resource_path, '**', '.*'))
       end
     end
   end

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rubygems/package'
+
 module Inferno
   module StartupTasks
     class << self
@@ -10,18 +12,27 @@ module Inferno
 
       def load_all_modules
         Dir.glob(File.join(__dir__, '..', '..', 'modules', '*_module.yml')).each do |file|
-          this_module = YAML.load_file(file).deep_symbolize_keys
-          Module.new(this_module)
+          module_metadata = YAML.load_file(file).deep_symbolize_keys
+          Module.new(module_metadata)
+
+          load_ig_in_validator(module_metadata) if external_validator? && module_metadata.key?(:resource_path)
         end
       end
 
+      def external_validator?
+        App::Endpoint.settings.resource_validator == 'external'
+      end
+
+      def validator_url
+        App::Endpoint.settings.external_resource_validator_url
+      end
+
       def check_validator_availability
-        if App::Endpoint.settings.resource_validator == 'internal'
+        unless external_validator?
           Inferno.logger.info 'Using internal validator'
           return
         end
 
-        validator_url = App::Endpoint.settings.external_resource_validator_url
         loop do
           Inferno.logger.info "Checking that validator is available at #{validator_url}"
           validator_version = RestClient.get("#{validator_url}/version")
@@ -31,6 +42,47 @@ module Inferno
           Inferno.logger.error "Unable to reach validator at #{validator_url}"
           sleep 1
         end
+      end
+
+      def load_ig_in_validator(module_metadata)
+        Inferno.logger.info "Creating ig package for #{module_metadata[:resource_path]}"
+        Tempfile.open([module_metadata[:resource_path], '.tar.gz']) do |file|
+          create_ig_zip(file, module_metadata)
+
+          begin
+            Inferno.logger.info "Posting IG for #{module_metadata[:title].presence || module_metadata[:name]} to validator"
+            RestClient.post("#{validator_url}/igs", File.read(file.path))
+          rescue StandardError => e
+            Inferno.logger.error 'Unable to post IG to validator'
+            Inferno.logger.error e.full_message
+          end
+        end
+      end
+
+      def create_ig_zip(file, module_metadata)
+        resource_path = File.join(__dir__, '..', '..', '..', 'resources', module_metadata[:resource_path])
+        Zlib::GzipWriter.wrap(file) do |gzip|
+          Gem::Package::TarWriter.new(gzip) do |tar|
+            Dir.glob(File.join(resource_path, '**', '*')).each do |full_file_path|
+              next if File.directory?(full_file_path)
+
+              content = File.read(full_file_path)
+              tar_file_path = relative_path_for(full_file_path)
+              tar.add_file_simple(tar_file_path, 0o0644, content.bytesize) do |io|
+                io.write(content)
+              end
+            end
+          end
+        end
+      end
+
+      def relative_path_for(full_file_path)
+        relative_path =
+          full_file_path
+            .split(File.join('resources', 'ig', ''))
+            .last
+            .delete_prefix("package#{File::SEPARATOR}")
+        File.join('package', relative_path)
       end
     end
   end

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -4,6 +4,7 @@ module Inferno
   module StartupTasks
     class << self
       def run
+        check_validator_availability
         load_all_modules
       end
 
@@ -11,6 +12,24 @@ module Inferno
         Dir.glob(File.join(__dir__, '..', '..', 'modules', '*_module.yml')).each do |file|
           this_module = YAML.load_file(file).deep_symbolize_keys
           Module.new(this_module)
+        end
+      end
+
+      def check_validator_availability
+        if App::Endpoint.settings.resource_validator == 'internal'
+          Inferno.logger.info 'Using internal validator'
+          return
+        end
+
+        validator_url = App::Endpoint.settings.external_resource_validator_url
+        loop do
+          Inferno.logger.info "Checking that validator is available at #{validator_url}"
+          validator_version = RestClient.get("#{validator_url}/version")
+          Inferno.logger.info "External validator version #{validator_version} is available"
+          break
+        rescue StandardError
+          Inferno.logger.error "Unable to reach validator at #{validator_url}"
+          sleep 1
         end
       end
     end

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Inferno
+  module StartupTasks
+    class << self
+      def run
+        load_all_modules
+      end
+
+      def load_all_modules
+        Dir.glob(File.join(__dir__, '..', '..', 'modules', '*_module.yml')).each do |file|
+          this_module = YAML.load_file(file).deep_symbolize_keys
+          Module.new(this_module)
+        end
+      end
+    end
+  end
+end

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -72,7 +72,7 @@ module Inferno
               next if File.directory?(full_file_path)
 
               content = File.read(full_file_path)
-              tar_file_path = relative_path_for(full_file_path)
+              tar_file_path = relative_path_for(full_file_path, module_metadata[:resource_path])
               tar.add_file_simple(tar_file_path, 0o0644, content.bytesize) do |io|
                 io.write(content)
               end
@@ -81,10 +81,10 @@ module Inferno
         end
       end
 
-      def relative_path_for(full_file_path)
+      def relative_path_for(full_file_path, resource_folder)
         relative_path =
           full_file_path
-            .split(File.join('resources', 'ig', ''))
+            .split(File.join('resources', resource_folder, ''))
             .last
             .delete_prefix("package#{File::SEPARATOR}")
         File.join('package', relative_path)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ if create_assertion_report?
 end
 
 require_relative '../lib/app'
+Inferno::StartupTasks.load_all_modules
 
 def find_fixture_directory(test_directory = nil)
   test_directory ||=


### PR DESCRIPTION
This branch integrates the generic generator with the validator service. When Inferno starts up, the resources for any module created via the generic will be posted to the validator service so that it can validate resources. This only works for the contents of an IG package containing the corresponding `package.json`. If no `package.json` is present, the resources are not uploaded to the validator.

This functionality depends on https://github.com/inferno-community/fhir-validator-wrapper/pull/16 and https://github.com/inferno-community/fhir-validator-wrapper/pull/18

Loading inferno's modules has been moved from `Inferno::Module` to a new `Inferno::StartupTasks`. Loading modules now may involve making a POST to an external service, so this change makes it so that you won't make external HTTP requests just by requiring `lib/app/models/module.rb`.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
