### PR TITLE
FI-955 Default to External

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,7 +38,7 @@ include_extras: true
 badge_text: Community
 
 # Resource validator options: must be one of "internal" or "external". external_resource_validator_url is only used if resource_validator is set to external.
-resource_validator: internal
+resource_validator: external
 external_resource_validator_url: http://validator_service:4567
 
 # module options: one or more must be set.  The first option in the list will be checked by default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   bdt_service:
     image: infernocommunity/inferno-bdt-service
   validator_service:
-    image: infernocommunity/fhir-validator-wrapper
+    image: infernocommunity/fhir-validator-service
   nginx_server:
     image: nginx
     volumes:

--- a/lib/app/utils/resource_validator_factory.rb
+++ b/lib/app/utils/resource_validator_factory.rb
@@ -7,6 +7,8 @@ module Inferno
   class App
     module ResourceValidatorFactory
       def self.new_validator(selected_validator, external_validator_url)
+        return Inferno::FHIRModelsValidator.new if ENV['RACK_ENV'] == 'test'
+
         case selected_validator
         when 'internal'
           Inferno::FHIRModelsValidator.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,8 @@ SimpleCov.start do
   add_filter '/test/'
 end
 
-ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = ENV['RACK_ENV'] = 'test'
+
 require 'minitest/autorun'
 require 'webmock/minitest'
 require 'rack/test'
@@ -23,6 +24,7 @@ if create_assertion_report?
 end
 
 require_relative '../lib/app'
+Inferno::App::Endpoint.settings.resource_validator = 'internal'
 Inferno::StartupTasks.load_all_modules
 
 def find_fixture_directory(test_directory = nil)


### PR DESCRIPTION
Defaults the `config.yml` to the external validator and ports the updates from `inferno-program` which enable to unit tests to continue to use the internal validator.  See https://github.com/onc-healthit/inferno-program/pull/22

This PR also updates the `docker-compose.yml` to use `infernocommunity/fhir-validator-service`, which includes the features required by https://github.com/onc-healthit/inferno/pull/476, instead of `infernocommunity/fhir-validator-wrapper`.

`Inferno::App::Endpoint.settings.resource_validator = 'internal'` is also set in `test_helper` because `StartupTasks` directly accesses it in `#external_validator?`.  I debated adding a similar ENV check there, but figured it would be better to contain the logic in the test specific `test_helper` file.