### PR TITLE
FI-956: Add Generated Sequence to config.yml

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -25,6 +25,7 @@ require_relative 'version'
 require_relative 'app/models'
 require_relative 'app/utils/terminology'
 require_relative 'app/utils/startup_tasks'
+require_relative 'app/utils/config_manager'
 
 module Inferno
   class App

--- a/lib/app/utils/config_manager.rb
+++ b/lib/app/utils/config_manager.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'yaml'
+module Inferno
+  class ConfigManager
+    # define methods for which anything may be assigned
+    ['app_name', 'base_path', 'bind', 'default_scopes', 'log_level', 'badge_text', 'resource_validator', 'external_resource_validator_url'].each do |attribute|
+      define_method attribute.to_sym do
+        config[attribute]
+      end
+      define_method "#{attribute}=".to_sym do |value|
+        config[attribute] = value
+      end
+    end
+
+    # Define methds which should always assign a boolean value
+    ['purge_database_on_reload', 'disable_verify_peer', 'disable_tls_tests', 'log_to_file', 'logging_enabled', 'autorun_capability', 'include_extras'].each do |attribute|
+      define_method attribute.to_sym do
+        config[attribute]
+      end
+      define_method "#{attribute}=".to_sym do |value|
+        config[attribute] = value.to_s.downcase == 'true'
+      end
+    end
+
+    attr_reader :config
+    def initialize(initial_config = nil)
+      @config = YAML.load_file(initial_config) unless initial_config.nil?
+    end
+
+    def modules
+      config['modules']
+    end
+
+    def add_modules(modules)
+      self.modules |= Array(modules)
+    end
+
+    def remove_modules(modules)
+      self.modules -= modules
+    end
+
+    def presets
+      config['presets']
+    end
+
+    def remove_preset(name)
+      config['presets'].delete(name)
+    end
+
+    def add_preset(key, preset_values)
+      config[key.to_s] = preset_values
+    end
+
+    def write_to_file(filename)
+      File.open(filename, 'w+') { |f| f.write(config.to_yaml) }
+    end
+
+    private
+
+    attr_writer :config
+
+    def modules=(modules)
+      config['modules'] = modules
+    end
+  end
+end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -465,7 +465,8 @@ namespace :inferno do |_argv|
   end
 
   desc 'Generate Tests'
-  task :generate, [:generator, :path] do |_t, args|
+  task :generate, [:generator, :path, :add_to_config] do |_t, args|
+    args.with_defaults(add_to_config: 'true')
     require_relative("../../generator/#{args.generator}/#{args.generator}_generator")
     generator_class = Inferno::Generator::Base.subclasses.first do |c|
       c.name.demodulize.downcase.start_with?(args.generator)
@@ -473,6 +474,12 @@ namespace :inferno do |_argv|
 
     generator = generator_class.new(args.path, args.extras)
     generator.run
+    if args.add_to_config == 'true'
+      ConfigManager.new('config.yml').tap do |cm|
+        cm.add_modules(args.path)
+        cm.write_to_file('config.yml')
+      end
+    end
   end
 end
 

--- a/test/fixtures/test_config.yml
+++ b/test/fixtures/test_config.yml
@@ -1,0 +1,71 @@
+# Name of app
+app_name: Inferno
+
+# Base path of application
+# There are a few exceptions, such as "/" and "/landing".
+base_path: "inferno"
+
+# Useful during development to purge the database on each reload
+purge_database_on_reload: false
+
+# Disable peer SSL verification for environments that use SSL inspection
+disable_verify_peer: false
+
+# When running in a docker container, we have to listen to other than just 'localhost' which is the default
+bind: '0.0.0.0'
+
+# Omit TLS tests
+disable_tls_tests: false
+
+# Default scopes
+default_scopes: launch launch/patient offline_access openid profile user/*.* patient/*.*
+
+# Log Level: unkown, fatal, error, warn, info, debug
+log_level: info
+
+# Log to file
+log_to_file: false
+
+# Logging enabled?
+logging_enabled: true
+
+# Automatically Run Conformance Sequence on new server create
+autorun_capability: false
+
+# Include extra tests: true or false
+include_extras: true
+
+badge_text: Community
+
+# Resource validator options: must be one of "internal" or "external". external_resource_validator_url is only used if resource_validator is set to external.
+resource_validator: internal
+external_resource_validator_url: http://validator_service:4567
+
+# module options: one or more must be set.  The first option in the list will be checked by default
+modules:
+  - onc
+  - smart
+  - bdt
+  - argonaut
+  - uscore_v3.1.0
+
+# preset fhir servers: optional. Minimally requires name, uri, module, optional inferno_uri, client_id, client_secret, scopes, instructions link
+presets:
+  site_healthit_gov:
+    name: SITE DSTU2 FHIR Sandbox
+    uri: https://fhir.sitenv.org/secure/fhir
+    module: onc
+    inferno_uri: https://inferno.healthit.gov
+    client_id: vkPKDPcTIEMaw5Uf-DdUUtNMFMZaX0
+    confidential_client: true
+    client_secret: LS1nY3JFU3FDeEs0cWoxQWF6TVJFNU05RmZZNGZhZ2Vwb2JYWjdSWWJGakwwNTZ2Vng=
+    instructions: https://github.com/onc-healthit/inferno/wiki/SITE-Preset-Instructions
+  site_test_healthit_gov:
+    name: SITE DSTU2 FHIR Sandbox
+    uri: https://fhir.sitenv.org/secure/fhir
+    module: onc
+    inferno_uri: https://infernotest.healthit.gov
+    client_id: TrToU5piE-dJ1g6PBG1elFV4r9KLmH
+    confidential_client: true
+    client_secret: ckFqb1ZhbmFMQS13WDE0c1dTLWxSdGRLSE8yUXpWNS1vSnd6azNrMmU3Y0JPdDRja3U=
+    instructions: https://github.com/onc-healthit/inferno/wiki/SITE-Preset-Instructions

--- a/test/unit/config_manager_test.rb
+++ b/test/unit/config_manager_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'pathname'
+
+describe Inferno::ConfigManager do
+  before do
+    @config_manager = Inferno::ConfigManager.new('test/fixtures/test_config.yml')
+  end
+  it 'initializes with a default config' do
+    config_manager = Inferno::ConfigManager.new('test/fixtures/test_config.yml')
+    config = config_manager.config
+    assert config['app_name'] = 'Inferno'
+    assert config['modules'] = ['onc', 'smart', 'bdt', 'argonaut', 'uscore_v3.1.0']
+    assert config['presets']['site_healthit_gov']['name'] = 'SITE DSTU2 FHIR Sandbox'
+  end
+
+  it 'initializes without a default config' do
+    config_manager = Inferno::ConfigManager.new
+    assert config_manager.config.nil?
+  end
+
+  it 'will add modules if they do not already exist' do
+    refute_includes @config_manager.modules, 'foo'
+    @config_manager.add_modules 'foo'
+    assert_includes @config_manager.modules, 'foo'
+    @config_manager.add_modules 'foo'
+    assert @config_manager.modules.uniq.length == @config_manager.modules.length
+  end
+
+  it 'allows users to set an app_name' do
+    assert @config_manager.app_name == 'Inferno'
+    @config_manager.app_name = 'foo'
+    assert @config_manager.app_name = 'foo'
+  end
+
+  it 'makes sure that certain values are boolean' do
+    assert @config_manager.log_to_file == false
+    @config_manager.log_to_file = 'true'
+    assert @config_manager.log_to_file == true
+    @config_manager.log_to_file = 'false'
+    assert @config_manager.log_to_file == false
+  end
+
+  it 'will save the config to a file' do
+    @config_manager.add_modules 'foo'
+    refute File.exist? 'test_config.yml'
+    @config_manager.write_to_file('test_config.yml')
+    assert File.exist? 'test_config.yml'
+    File.delete 'test_config.yml'
+    refute File.exist? 'test_config.yml'
+  end
+end


### PR DESCRIPTION
This PR updates the `generate` rake task to automatically append the generated module to the configuration.  An optional argument allows the user to prevent this from happening.

A `ConfigManager` class was added to help manage loading, updating and writing the config.  I'm not sure if we'll want to use this in more places in the future (instead of `App::Endpoint::settings` and I figure that may be best left for a future PR as the real goal here is to update the `generate` task.

_Note: Adding the newly generated module to the config will remove and comments in an overwritten yaml file_