### PR TITLE
FI-964 fix bugs with _id search parameter and .where in search validation

### DIFF
--- a/generator/generic/search_test.rb
+++ b/generator/generic/search_test.rb
@@ -43,7 +43,7 @@ module Inferno
         # remove non-character elements from beginning and end of name
         param_variable_name = parameter
           .gsub(/^[\W_]+|[\W_]+$"/, '')
-          .gsub('-', '_')
+          .tr('-', '_')
         "#{param_variable_name}_val"
       end
     end

--- a/generator/generic/search_test.rb
+++ b/generator/generic/search_test.rb
@@ -23,11 +23,6 @@ module Inferno
               .drop(1)
               .join('.')
 
-            # handle some fhir path stuff. Remove this once fhir path server is added
-            path = path.gsub(/.where\((.*)/, '')
-            as_type = path.scan(/.as\((.*?)\)/).flatten.first
-            path = path.gsub(/.as\((.*?)\)/, capitalize_first_letter(as_type)) if as_type.present?
-
             "#{search_param_value_name(parameter)} = find_search_parameter_value_from_resource(@resource_found, '#{path}')"
           end
           search_test.code = %(
@@ -45,12 +40,11 @@ module Inferno
       end
 
       def search_param_value_name(parameter)
-        parameter.gsub!(/^[\W_]+|[\W_]+$"/, '') # remove non-character elements from beginning and end of name
-        "#{parameter.gsub('-', '_')}_val"
-      end
-
-      def capitalize_first_letter(str)
-        str.slice(0).capitalize + str.slice(1..-1)
+        # remove non-character elements from beginning and end of name
+        param_variable_name = parameter
+          .gsub(/^[\W_]+|[\W_]+$"/, '')
+          .gsub('-', '_')
+        "#{param_variable_name}_val"
       end
     end
   end

--- a/generator/search_parameter_metadata.rb
+++ b/generator/search_parameter_metadata.rb
@@ -42,12 +42,8 @@ module Inferno
       def expression_without_fhir_path(path)
         # handle some fhir path stuff. Remove this once fhir path server is added
         as_type = path.scan(/.as\((.*?)\)/).flatten.first
-        path = path.gsub(/.as\((.*?)\)/, capitalize_first_letter(as_type)) if as_type.present?
+        path = path.gsub(/.as\((.*?)\)/, as_type.upcase_first) if as_type.present?
         path.gsub(/.where\((.*)/, '')
-      end
-
-      def capitalize_first_letter(str)
-        str.slice(0).capitalize + str.slice(1..-1)
       end
 
       # whether multiple or is allowed

--- a/generator/search_parameter_metadata.rb
+++ b/generator/search_parameter_metadata.rb
@@ -36,7 +36,18 @@ module Inferno
       end
 
       def expression
-        @expression ||= @search_parameter_json['expression']
+        @expression ||= expression_without_fhir_path(@search_parameter_json['expression'])
+      end
+
+      def expression_without_fhir_path(path)
+        # handle some fhir path stuff. Remove this once fhir path server is added
+        as_type = path.scan(/.as\((.*?)\)/).flatten.first
+        path = path.gsub(/.as\((.*?)\)/, capitalize_first_letter(as_type)) if as_type.present?
+        path.gsub(/.where\((.*)/, '')
+      end
+
+      def capitalize_first_letter(str)
+        str.slice(0).capitalize + str.slice(1..-1)
       end
 
       # whether multiple or is allowed


### PR DESCRIPTION
This PR addresses some bugs in the generic generator involving search parameters. One issue is that the search validation code used to have fhir path expressions that we couldn't handle. For example, the us core laboratory result sequence had the ".where" in the search validation code. This removes the ".where" part. The second is that the patient id parameter was being set to `id` instead of `_id`.  

To test, run the generic generator on the us core resources. Check that the patient sequence's id search is _id instead id and that the ".where" is not included in the lab result sequence.