### PR TITLE
FI-957: Build .index.json for package tarball or upload standalone profiles

### DIFF
--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -50,16 +50,18 @@ module Inferno
       index
     end
 
-    # Indexes the folder at the given path <folder> or at <folder>/package.
+    # Indexes the folder at the given path <folder> or at <folder>/package if not already indexed.
     # @param folder [String] the path of the folder to index
-    # @return [nil]
+    # @return [Boolean] whether a new .index.json was created
+    # @raise [StandardError] if the given folder did not contain a package.json or there was an error reading a file
     def execute(folder)
       folder_package = File.join(folder, 'package')
       (folder = folder_package) if Dir.exist?(folder_package)
 
-      raise "Not a proper package? (can't find package.json)" unless File.exist?(File.join(folder, 'package.json'))
-
       Dir.chdir(folder) do
+        raise "Not a proper package? (can't find package.json)" unless File.exist?('package.json')
+        return false if File.exist?('.index.json')
+
         start
         Dir.glob('*.json').select { |f| File.file?(f) }.each do |filename|
           see_file(filename, File.read(filename))
@@ -67,7 +69,7 @@ module Inferno
         File.write('.index.json', build)
       end
 
-      nil
+      true
     end
   end
 end

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -58,8 +58,8 @@ module Inferno
       return unless file['resourceType'].is_a?(String)
 
       file.slice!('resourceType', 'id', 'url', 'version', 'kind', 'type', 'supplements')
-        .delete_if { |_, val| val.is_a?(Hash) || val.is_a?(Array) }
-        .transform_values! { |val| val.is_a?(String) ? val : val.to_json }
+      file.reject! { |_, val| val.is_a?(Hash) || val.is_a?(Array) }
+      file.transform_values! { |val| val.is_a?(String) ? val : val.to_json }
       file['filename'] = filename
       @files << file
       file

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -9,7 +9,7 @@ module Inferno
       raise ArgumentError, "'#{folder}' is not a directory" unless Dir.exist?(folder)
 
       package_folder = File.join(folder, 'package')
-      (folder = package_folder) if Dir.exist?(package_folder)
+      folder = package_folder if Dir.exist?(package_folder)
       package_json = File.join(folder, 'package.json')
       raise ArgumentError, 'Could not find package.json' unless File.exist?(package_json)
 

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -30,7 +30,7 @@ module Inferno
       end
 
       return true unless json.is_a?(Hash)
-      return true unless (type = json.dig('resourceType'))
+      return true unless (type = json['resourceType'])
 
       file = { filename: filename, resourceType: type.to_s }
       props = json.slice('id', 'url', 'version', 'kind', 'type', 'supplements')

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -51,7 +51,7 @@ module Inferno
     #
     # @param filename [String] the name of the file to index
     # @param contents [String] the contents of the file to index
-    # @return [String, nil] the contents of the JSON file or nil if the file was ignored
+    # @return [Hash, nil] the hash representation of the added file or nil if the file was ignored
     def add_json_file(filename, contents)
       file = JSON.parse(contents)
       return unless file.is_a?(Hash)
@@ -62,7 +62,7 @@ module Inferno
         .transform_values! { |val| val.is_a?(String) ? val : val.to_json }
       file['filename'] = filename
       @files << file
-      contents
+      file
     end
   end
 end

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -53,13 +53,12 @@ module Inferno
     # Indexes the folder at the given path <folder> or at <folder>/package if not already indexed.
     # @param folder [String] the path of the folder to index
     # @return [Boolean] whether a new .index.json was created
-    # @raise [StandardError] if the given folder did not contain a package.json or there was an error reading a file
+    # @raise [StandardError] if there was an error reading a file
     def execute(folder)
       folder_package = File.join(folder, 'package')
       (folder = folder_package) if Dir.exist?(folder_package)
 
       Dir.chdir(folder) do
-        raise "Not a proper package? (can't find package.json)" unless File.exist?('package.json')
         return false if File.exist?('.index.json')
 
         start

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -5,7 +5,7 @@ require 'json'
 module Inferno
   class IndexBuilder
 
-    # @param folder [String] the path of the folder to index
+    # @param folder [String] the path of the package to index
     def initialize(folder)
       raise ArgumentError, "'#{folder}' is not a directory" unless Dir.exist?(folder)
 
@@ -19,14 +19,13 @@ module Inferno
       @index = { 'index-version': 1, files: @files }
     end
 
-    # @return [Boolean] whether or not the given folder has been indexed
+    # @return [Boolean] whether or not the given package has been indexed
     def indexed?
       File.exist?(index_path)
     end
 
-    # Builds and returns the string representing the contents of an .index.json file for the given folder.
-    #
-    # @return [String] a string representing the contents of an .index.json file
+    # Builds the .index.json contents if it doesn't exist, otherwise immediately returns.
+    # Yields the built contents if a block was given, otherwise writes it to .index.json at the root.
     def build
       return if indexed?
 
@@ -37,6 +36,7 @@ module Inferno
       end
       contents = JSON.pretty_generate(@index)
       block_given? ? yield(contents) : File.write(index_path, contents)
+      nil
     end
 
     private
@@ -61,6 +61,7 @@ module Inferno
         .transform_values! { |val| val.is_a?(String) ? val : val.to_json }
       file['filename'] = filename
       @files << file
+      nil
     end
   end
 end

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -20,7 +20,7 @@ module Inferno
     # @param contents [String] the contents of the file to index
     # @return [Boolean] true, unless there was an error parsing and the filename contained "openapi" (then false)
     def see_file(filename, contents)
-      return unless filename.end_with?('.json')
+      return true unless filename.end_with?('.json')
 
       begin
         json = JSON.parse(contents)

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -9,14 +9,19 @@ module Inferno
     def initialize(folder)
       raise ArgumentError, "'#{folder}' is not a directory" unless Dir.exist?(folder)
 
-      @folder = folder
+      package_folder = File.join(folder, 'package')
+      (folder = package_folder) if Dir.exist?(package_folder)
+      package_json = File.join(folder, 'package.json')
+      raise ArgumentError, 'Could not find package.json' unless File.exist?(package_json)
+
+      @package_root = folder
       @files = []
       @index = { 'index-version': 1, files: @files }
     end
 
     # @return [Boolean] whether or not the given folder has been indexed
     def indexed?
-      File.exist?(File.join(@folder, '.index.json'))
+      File.exist?(index_path)
     end
 
     # Builds and returns the string representing the contents of an .index.json file for the given folder.
@@ -32,6 +37,11 @@ module Inferno
     end
 
     private
+
+    # @return [String] the path where the .index.json file should be
+    def index_path
+      File.join(@package_root, '.index.json')
+    end
 
     # Adds a JSON file with the given name and contents to the index being built.
     # Ignores files that don't contain a valid "resourceType" property.

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -4,7 +4,6 @@ require 'json'
 
 module Inferno
   class IndexBuilder
-
     # @param folder [String] the path of the package to index
     def initialize(folder)
       raise ArgumentError, "'#{folder}' is not a directory" unless Dir.exist?(folder)

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -25,6 +25,7 @@ module Inferno
 
     # Builds the .index.json contents if it doesn't exist, otherwise immediately returns.
     # Yields the built contents if a block was given, otherwise writes it to .index.json at the root.
+    # @return [String, nil] the contents of the generated index or nil if already indexed
     def build
       return if indexed?
 
@@ -35,7 +36,7 @@ module Inferno
       end
       contents = JSON.pretty_generate(@index)
       block_given? ? yield(contents) : File.write(index_path, contents)
-      nil
+      contents
     end
 
     private
@@ -50,6 +51,7 @@ module Inferno
     #
     # @param filename [String] the name of the file to index
     # @param contents [String] the contents of the file to index
+    # @return [String, nil] the contents of the JSON file or nil if the file was ignored
     def add_json_file(filename, contents)
       file = JSON.parse(contents)
       return unless file.is_a?(Hash)
@@ -60,7 +62,7 @@ module Inferno
         .transform_values! { |val| val.is_a?(String) ? val : val.to_json }
       file['filename'] = filename
       @files << file
-      nil
+      contents
     end
   end
 end

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -4,65 +4,50 @@ require 'json'
 
 module Inferno
   class IndexBuilder
-    @files = nil
-    @index = nil
 
-    # Prepares the IndexBuilder to start indexing files
-    def start
+    # @param folder [String] the path of the folder to index
+    def initialize(folder)
+      raise ArgumentError, "'#{folder}' is not a directory" unless Dir.exist?(folder)
+
+      @folder = folder
       @files = []
       @index = { 'index-version': 1, files: @files }
-      nil
     end
 
-    # Indexes the file with the given name and contents.
+    # @return [Boolean] whether or not the given folder has been indexed
+    def indexed?
+      File.exist?(File.join(@folder, '.index.json'))
+    end
+
+    # Builds and returns the string representing the contents of an .index.json file for the given folder.
+    #
+    # @return [String] a string representing the contents of an .index.json file
+    def build
+      Dir.chdir(@folder) do
+        Dir.glob('*.json').select { |f| File.file?(f) }.each do |filename|
+          add_json_file(filename, File.read(filename))
+        end
+      end
+      JSON.pretty_generate(@index)
+    end
+
+    private
+
+    # Adds a JSON file with the given name and contents to the index being built.
+    # Ignores files that don't contain a valid "resourceType" property.
+    #
     # @param filename [String] the name of the file to index
     # @param contents [String] the contents of the file to index
-    def see_file(filename, contents)
-      return unless filename.end_with?('.json')
+    def add_json_file(filename, contents)
+      file = JSON.parse(contents)
+      return unless file.is_a?(Hash)
+      return unless file['resourceType'].is_a?(String)
 
-      json = JSON.parse(contents)
-      return unless json.is_a?(Hash)
-      return unless (type = json['resourceType'])
-
-      file = { filename: filename, resourceType: type.to_s }
-      props = json.slice('id', 'url', 'version', 'kind', 'type', 'supplements')
-        .reject { |_, val| val.is_a?(Hash) || val.is_a?(Array) }
-        .transform_values { |val| val.is_a?(String) ? val : val.to_json }
-      @files << file.merge(props)
-
-      nil
-    rescue JSON::ParserError
-      Inferno.logger.error("Error parsing #{filename}: Invalid JSON")
-    end
-
-    # Builds and returns the string representing the contents of an .index.json file.
-    # @return [String] a string representing the contents of the .index.json file
-    def build
-      index = JSON.pretty_generate(@index)
-      @files = nil
-      @index = nil
-      index
-    end
-
-    # Indexes the folder at the given path <folder> or at <folder>/package if not already indexed.
-    # @param folder [String] the path of the folder to index
-    # @return [Boolean] whether a new .index.json was created
-    # @raise [StandardError] if there was an error reading a file
-    def execute(folder)
-      folder_package = File.join(folder, 'package')
-      (folder = folder_package) if Dir.exist?(folder_package)
-
-      Dir.chdir(folder) do
-        return false if File.exist?('.index.json')
-
-        start
-        Dir.glob('*.json').select { |f| File.file?(f) }.each do |filename|
-          see_file(filename, File.read(filename))
-        end
-        File.write('.index.json', build)
-      end
-
-      true
+      file.slice!('resourceType', 'id', 'url', 'version', 'kind', 'type', 'supplements')
+        .delete_if { |_, val| val.is_a?(Hash) || val.is_a?(Array) }
+        .transform_values! { |val| val.is_a?(String) ? val : val.to_json }
+      file['filename'] = filename
+      @files << file
     end
   end
 end

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -28,12 +28,15 @@ module Inferno
     #
     # @return [String] a string representing the contents of an .index.json file
     def build
-      Dir.chdir(@folder) do
+      return if indexed?
+
+      Dir.chdir(@package_root) do
         Dir.glob('*.json').select { |f| File.file?(f) }.each do |filename|
           add_json_file(filename, File.read(filename))
         end
       end
-      JSON.pretty_generate(@index)
+      contents = JSON.pretty_generate(@index)
+      block_given? ? yield(contents) : File.write(index_path, contents)
     end
 
     private

--- a/lib/app/utils/index_builder.rb
+++ b/lib/app/utils/index_builder.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Inferno
+  class IndexBuilder
+    @files = nil
+    @index = nil
+
+    # Prepares the IndexBuilder to start indexing files
+    # @return [nil]
+    def start
+      @files = []
+      @index = { 'index-version': 1, files: @files }
+      nil
+    end
+
+    # Indexes the file with the given name and contents.
+    # @param filename [String] the name of the file to index
+    # @param contents [String] the contents of the file to index
+    # @return [Boolean] true, unless there was an error parsing and the filename contained "openapi" (then false)
+    def see_file(filename, contents)
+      return unless filename.end_with?('.json')
+
+      begin
+        json = JSON.parse(contents)
+      rescue JSON::ParserError => e
+        Inferno.logger.error("Error parsing #{filename}: #{e.message}")
+        return !filename.include?('openapi')
+      end
+
+      return true unless json.is_a?(Hash)
+      return true unless (type = json.dig('resourceType'))
+
+      file = { filename: filename, resourceType: type.to_s }
+      props = json.slice('id', 'url', 'version', 'kind', 'type', 'supplements')
+        .reject { |_, val| val.is_a?(Hash) || val.is_a?(Array) }
+        .transform_values { |val| val.is_a?(String) ? val : val.to_json }
+      @files << file.merge(props)
+
+      true
+    end
+
+    # Builds and returns the string representing the contents of an .index.json file.
+    # @return [String] a string representing the contents of the .index.json file
+    def build
+      index = JSON.pretty_generate(@index)
+      @files = nil
+      @index = nil
+      index
+    end
+
+    # Indexes the folder at the given path <folder> or at <folder>/package.
+    # @param folder [String] the path of the folder to index
+    # @return [nil]
+    def execute(folder)
+      folder_package = File.join(folder, 'package')
+      (folder = folder_package) if Dir.exist?(folder_package)
+
+      raise "Not a proper package? (can't find package.json)" unless File.exist?(File.join(folder, 'package.json'))
+
+      Dir.chdir(folder) do
+        start
+        Dir.glob('*.json').select { |f| File.file?(f) }.each do |filename|
+          see_file(filename, File.read(filename))
+        end
+        File.write('.index.json', build)
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rubygems/package'
+require 'json'
 require_relative './index_builder'
 
 module Inferno
@@ -50,6 +51,9 @@ module Inferno
           next if File.directory?(full_file_path)
 
           begin
+            contents = JSON.parse(File.read(full_file_path))
+            next unless contents['resourceType'] == 'StructureDefinition'
+
             RestClient.post("#{validator_url}/profiles", File.read(full_file_path))
           rescue StandardError => e
             Inferno.logger.error "Unable to post profile '#{File.basename(full_file_path)}' to validator"

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -55,6 +55,8 @@ module Inferno
             next unless JSON.parse(contents)['resourceType'] == 'StructureDefinition'
 
             RestClient.post("#{validator_url}/profiles", contents)
+          rescue JSON::ParserError
+            Inferno.logger.error "'#{File.basename(full_file_path)}' was not valid JSON"
           rescue StandardError => e
             Inferno.logger.error "Unable to post profile '#{File.basename(full_file_path)}' to validator"
             Inferno.logger.error e.full_message

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rubygems/package'
+require_relative './index_builder'
 
 module Inferno
   module StartupTasks

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -67,6 +67,12 @@ module Inferno
       end
 
       def create_ig_zip(file, module_metadata)
+        # Index root and all subdirectories of IG
+        index_builder = Inferno::IndexBuilder.new
+        ig_files(module_metadata[:resource_path])
+          .select { |full_path| File.directory?(full_path) }
+          .each { |full_folder_path| index_builder.execute(full_folder_path) }
+
         Zlib::GzipWriter.wrap(file) do |gzip|
           Gem::Package::TarWriter.new(gzip) do |tar|
             ig_files(module_metadata[:resource_path]).each do |full_file_path|
@@ -97,7 +103,7 @@ module Inferno
 
       def ig_files(path)
         resource_path = File.join(__dir__, '..', '..', '..', 'resources', path)
-        Dir.glob(File.join(resource_path, '**', '*')) + Dir.glob(File.join(resource_path, '**', '.*'))
+        Dir.glob(File.join(resource_path, '**', '{*,.*}')) << resource_path
       end
     end
   end

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -51,10 +51,10 @@ module Inferno
           next if File.directory?(full_file_path)
 
           begin
-            contents = JSON.parse(File.read(full_file_path))
-            next unless contents['resourceType'] == 'StructureDefinition'
+            contents = File.read(full_file_path)
+            next unless JSON.parse(contents)['resourceType'] == 'StructureDefinition'
 
-            RestClient.post("#{validator_url}/profiles", File.read(full_file_path))
+            RestClient.post("#{validator_url}/profiles", contents)
           rescue StandardError => e
             Inferno.logger.error "Unable to post profile '#{File.basename(full_file_path)}' to validator"
             Inferno.logger.error e.full_message

--- a/test/fixtures/sample_ig/StructureDefinition-Patient.json
+++ b/test/fixtures/sample_ig/StructureDefinition-Patient.json
@@ -1,0 +1,8 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "Patient",
+  "url": "http://foo.bar/Patient",
+  "version": "1.2.3",
+  "kind": "resource",
+  "type": "Patient"
+}

--- a/test/fixtures/sample_ig/package.json
+++ b/test/fixtures/sample_ig/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "sample",
+  "version": "1.0.0",
+  "description": "This is a sample IG",
+  "author": "Team Inferno"
+}

--- a/test/unit/index_builder_test.rb
+++ b/test/unit/index_builder_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../test_helper'
+
+describe Inferno::IndexBuilder do
+  before do
+    @index_builder = Inferno::IndexBuilder.new
+  end
+
+  describe 'Index produced when no files are indexed' do
+    it 'Contains "index-version" and "files" properties' do
+      @index_builder.start
+      index = JSON.parse(@index_builder.build)
+
+      assert_equal 1, index['index-version']
+      assert_equal [], index['files']
+    end
+  end
+
+  describe 'IndexBuilder.see_file' do
+    it 'Ignores files that do not have .json extension' do
+      @index_builder.start
+      @index_builder.see_file('foo.json', '{"resourceType": "Patient"}')
+      @index_builder.see_file('bar.txt', '{"resourceType": "MedicationRequest"}')
+      index = JSON.parse(@index_builder.build)
+
+      assert_equal [
+        {
+          'filename' => 'foo.json',
+          'resourceType' => 'Patient'
+        }
+      ], index['files']
+    end
+
+    it 'Ignores files that cannot be parsed (invalid JSON)' do
+      @index_builder.start
+      @index_builder.see_file('invalid.json', '<NotJSON></NotJSON>')
+      index = JSON.parse(@index_builder.build)
+
+      assert_equal [], index['files']
+    end
+  end
+
+  describe 'IndexBuilder.execute' do
+    it 'Can index a directory' do
+      fixture_path = find_fixture_directory
+      folder = File.join(fixture_path, 'sample_ig')
+      index_file = File.join(folder, '.index.json')
+
+      assert !File.exist?(index_file)
+      @index_builder.execute(folder)
+
+      assert File.exist?(index_file)
+      index = JSON.parse(File.read(index_file))
+
+      assert_equal [
+        {
+          'filename' => 'StructureDefinition-Patient.json',
+          'resourceType' => 'StructureDefinition',
+          'id' => 'Patient',
+          'version' => '1.2.3',
+          'url' => 'http://foo.bar/Patient',
+          'kind' => 'resource',
+          'type' => 'Patient'
+        }
+      ], index['files']
+
+      File.delete(index_file)
+    end
+  end
+end

--- a/test/unit/index_builder_test.rb
+++ b/test/unit/index_builder_test.rb
@@ -43,15 +43,19 @@ describe Inferno::IndexBuilder do
   end
 
   describe 'IndexBuilder.execute' do
-    it 'Can index a directory' do
+    it 'Can index a directory and returns whether an .index.json was created' do
       fixture_path = find_fixture_directory
       folder = File.join(fixture_path, 'sample_ig')
       index_file = File.join(folder, '.index.json')
 
+      # .index.json doesn't exist, so IndexBuilder will create an .index.json
       assert !File.exist?(index_file)
-      @index_builder.execute(folder)
+      assert @index_builder.execute(folder)
 
+      # .index.json now exists, so IndexBuilder will not create an .index.json
       assert File.exist?(index_file)
+      assert !@index_builder.execute(folder)
+
       index = JSON.parse(File.read(index_file))
 
       assert_equal [


### PR DESCRIPTION
[FI-957](https://oncprojectracking.healthit.gov/support/browse/FI-957): This PR adds an `IndexBuilder` utility class to handle indexing IG packages (creating an `.index.json` at the root and for all subdirectories). It also `POST`s profiles one-by-one to the validator if no `package.json` is present.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-957
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
