### PR TITLE
FI-930: Support FHIRPath for generating searches

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,6 +49,12 @@ modules:
   - argonaut
   - uscore_v3.1.0
   - uscore_v3.1.1
+  
+# FHIRPath evaluator options: must be one of "internal" or "external".
+# external_fhirpath_evaluator_url is only used if fhirpath_evaluator is set to
+# external.
+fhirpath_evaluator: external
+external_fhirpath_evaluator_url: http://validator_service:4567
 
 # Optional preset server testing configurations.
 #

--- a/generator/generic/search_test.rb
+++ b/generator/generic/search_test.rb
@@ -16,12 +16,8 @@ module Inferno
 
           search_parameter_assignments = search[:parameters].map do |parameter|
             param_metadata = metadata.search_parameter_metadata.find { |parameter_metadata| parameter_metadata.code == parameter }
-            path = param_metadata
-              .expression
-              .gsub(/(?<!\w)class(?!\w)/, 'local_class')
-              .split('.')
-              .drop(1)
-              .join('.')
+            path = param_metadata.expression
+            path = path.gsub(/\.where\(.*\)/, '') # TODO: remove once FHIRPath resolve() function is handled
 
             "#{search_param_value_name(parameter)} = find_search_parameter_value_from_resource(@resource_found, '#{path}')"
           end
@@ -40,11 +36,8 @@ module Inferno
       end
 
       def search_param_value_name(parameter)
-        # remove non-character elements from beginning and end of name
-        param_variable_name = parameter
-          .gsub(/^[\W_]+|[\W_]+$"/, '')
-          .tr('-', '_')
-        "#{param_variable_name}_val"
+        parameter.gsub!(/^[\W_]+|[\W_]+$"/, '') # remove non-character elements from beginning and end of name
+        "#{parameter.tr('-', '_')}_val"
       end
     end
   end

--- a/generator/generic_generator_utilities.rb
+++ b/generator/generic_generator_utilities.rb
@@ -32,10 +32,6 @@ module Inferno
         sequence_metadata.search_parameter_metadata&.each do |parameter_metadata|
           type = sequence_metadata.element_type_by_path(parameter_metadata.expression) || parameter_metadata.type
           path = parameter_metadata.expression
-            .gsub(/(?<!\w)class(?!\w)/, 'local_class')
-            .split('.')
-            .drop(1)
-            .join('.')
           path += get_value_path_by_type(type) unless ['Period', 'date', 'HumanName', 'Address', 'CodeableConcept', 'Coding', 'Identifier'].include? type
           parameter_code = parameter_metadata.code
           resource_type = sequence_metadata.resource_type

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -316,7 +316,7 @@ module Inferno
               type_code = type_element['type'].first['code']
               must_support_element[:discriminator] = {
                 type: 'type',
-                code: capitalize_first_letter(type_code)
+                code: type_code.upcase_first
               }
             elsif discriminators.first['type'] == 'value'
               must_support_element[:discriminator] = {
@@ -364,9 +364,7 @@ module Inferno
         sequence[:search_param_descriptions].each_key do |param|
           search_param_definition = @resource_by_path[search_param_path(sequence[:resource], param.to_s)]
           path = search_param_definition['expression']
-          path = path.gsub(/.where\((.*)/, '')
-          as_type = path.scan(/.as\((.*?)\)/).flatten.first
-          path = path.gsub(/.as\((.*?)\)/, capitalize_first_letter(as_type)) if as_type.present?
+          path = path.gsub(/\.where\(.*\)/, '') # TODO: remove once FHIRPath resolve() function is handled
           profile_element = profile_definition['snapshot']['element'].select { |el| el['id'] == path }.first
           param_metadata = {
             path: path,
@@ -557,10 +555,6 @@ module Inferno
 
         sequence[:searches].delete(search)
         sequence[:searches].unshift(search)
-      end
-
-      def capitalize_first_letter(str)
-        str.slice(0).capitalize + str.slice(1..-1)
       end
     end
   end

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -180,7 +180,7 @@ module Inferno
       #   get_value_for_search_param(resolve_element_from_path(@careplan_ary, 'category'))
       # this method extracts the variable name '@careplan_ary' and the path 'category'
       def dynamic_search_param(param_value)
-        match = param_value.match(/(@[^,]+).*'([\w\.]+)'/)
+        match = param_value.match(/(@[^,]+).*'([^']+)'/)
         {
           variable_name: match[1],
           resource_path: match[2]

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -6,6 +6,7 @@ require 'sinatra/cookies'
 require_relative 'helpers/configuration'
 require_relative 'helpers/browser_logic'
 require_relative 'utils/resource_validator_factory'
+require_relative 'utils/fhirpath_evaluator_factory'
 
 module Inferno
   class App
@@ -20,6 +21,7 @@ module Inferno
       Inferno::ENVIRONMENT = settings.environment
       Inferno::PURGE_ON_RELOAD = settings.purge_database_on_reload
       Inferno::RESOURCE_VALIDATOR = Inferno::App::ResourceValidatorFactory.new_validator(settings.resource_validator, settings.external_resource_validator_url)
+      Inferno::FHIRPATH_EVALUATOR = Inferno::App::FHIRPathEvaluatorFactory.new_evaluator(settings.fhirpath_evaluator, settings.external_fhirpath_evaluator_url)
 
       if settings.logging_enabled
         $stdout.sync = true # output in Docker is heavily delayed without this

--- a/lib/app/utils/basic_fhirpath_evaluator.rb
+++ b/lib/app/utils/basic_fhirpath_evaluator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Inferno
+  class BasicFHIRPathEvaluator
+    def evaluate(elements, path, patched = false)
+      path = patch_path(path) unless patched
+      elements = Array.wrap(elements)
+      return elements if path.blank?
+
+      first_path, *rest_paths = path.split('.')
+      rest_path = rest_paths.join('.')
+
+      elements.flat_map do |element|
+        evaluate(element&.send(first_path), rest_path, true)
+      end.compact
+    end
+
+    private
+
+    def patch_path(path)
+      path = path.dup
+      path.sub!(/^[A-Z]\w*\./, '')
+      path.gsub!(/\bclass\b/, 'local_class')
+      path.gsub!(/\.where\(.*\)/, '')
+      as_type = path.scan(/\.as\((.*?)\)/).flatten.first
+      path.gsub!(/\.as\((.*?)\)/, as_type.upcase_first) if as_type.present?
+      path
+    end
+  end
+end

--- a/lib/app/utils/fhirpath_evaluator.rb
+++ b/lib/app/utils/fhirpath_evaluator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rest-client'
+require 'json'
+require 'fhir_models'
+
+module Inferno
+  class FHIRPathEvaluator
+    # @param fhirpath_url [String] the base url for the FHIRPath /evaluate endpoint
+    def initialize(fhirpath_url)
+      raise ArgumentError, 'FHIRPath URL is unset' if fhirpath_url.blank?
+
+      @fhirpath_url = fhirpath_url
+    end
+
+    # Evaluates the given FHIRPath expression against the given elements by posting each element
+    # to the FHIRPath wrapper.
+    # @param elements [Array]
+    # @param path [String]
+    def evaluate(elements, path)
+      elements = Array.wrap(elements)
+      return elements if path.blank?
+
+      types = elements.map { |e| e.class.name.demodulize }
+      Inferno.logger.info("Evaluating path '#{path}' on types: #{types}")
+
+      elements.flat_map do |element|
+        type = type_path(element)
+        Inferno.logger.info("POST #{@fhirpath_url}/evaluate?path=#{path}&type=#{type}")
+        result = RestClient.post "#{@fhirpath_url}/evaluate", element.to_json, params: { path: path, type: type }
+        collection = JSON.parse(result.body)
+
+        collection.map { |container| deserialize(container['element'], container['type']) }
+      end.compact
+    end
+
+    private
+
+    # Examples:
+    # type_path(FHIR::Patient.new) -> 'Patient'
+    # type_path(FHIR::Patient::Contact.new) -> 'Patient.contact'
+    # type_path(FHIR::RiskEvidenceSynthesis::Certainty::CertaintySubcomponent.new)
+    #   -> 'RiskEvidenceSynthesis.certainty.certaintySubcomponent'
+    def type_path(element)
+      parts = element.class.name.split('::').drop(1)
+      # Assumes that BackboneElements are named by capitalizing path components
+      parts[1..-1].each { |part| part[0] = part[0].downcase }
+      parts.join('.')
+    end
+
+    def deserialize(element, type)
+      if element.is_a?(Hash)
+        first_component, *rest_components = type.split('.')
+        klass = FHIR.const_get(first_component)
+        rest_components.each do |component|
+          klass = FHIR.const_get(klass::METADATA[component]['type'])
+        end
+        klass.new(element)
+      else
+        element
+      end
+    end
+  end
+end

--- a/lib/app/utils/fhirpath_evaluator_factory.rb
+++ b/lib/app/utils/fhirpath_evaluator_factory.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'fhirpath_evaluator'
+require_relative 'basic_fhirpath_evaluator'
+
+module Inferno
+  class App
+    module FHIRPathEvaluatorFactory
+      def self.new_evaluator(selected_evaluator, external_evaluator_url)
+        return Inferno::BasicFHIRPathEvaluator.new if ENV['RACK_ENV'] == 'test'
+
+        case selected_evaluator
+        when 'internal'
+          Inferno::BasicFHIRPathEvaluator.new
+        when 'external'
+          Inferno::FHIRPathEvaluator.new(external_evaluator_url)
+        end
+      end
+    end
+  end
+end

--- a/lib/app/utils/sequence_utilities.rb
+++ b/lib/app/utils/sequence_utilities.rb
@@ -3,14 +3,7 @@
 module Inferno
   module SequenceUtilities
     def resolve_path(elements, path)
-      elements = Array.wrap(elements)
-      return elements if path.blank?
-
-      paths = path.split('.')
-
-      elements.flat_map do |element|
-        resolve_path(element&.send(paths.first), paths.drop(1).join('.'))
-      end.compact
+      Inferno::FHIRPATH_EVALUATOR.evaluate(elements, path)
     end
 
     def find_search_parameter_value_from_resource(resource, path)

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,20 +548,34 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
+            dataAbsentReason
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,20 +548,34 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
+            dataAbsentReason
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,20 +548,34 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
+            dataAbsentReason
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,15 +548,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * subject
-            * effective[x]
-            * dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            subject
+
+            effective[x]
+
+            dataAbsentReason
+
             * Observation.category:VSCat
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,20 +548,34 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
+            dataAbsentReason
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,20 +548,34 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
+            dataAbsentReason
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,18 +548,30 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
             * Observation.category:VSCat
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,18 +548,30 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
             * Observation.category:VSCat
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
@@ -20,7 +20,7 @@ module Inferno
             path: 'status'
           },
           {
-            path: 'local_class'
+            path: 'class'
           },
           {
             path: 'type'

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,20 +548,34 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
+            dataAbsentReason
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310BpSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310BpSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
           'category': value
         }
         body =
-          if @sequence.resolve_element_from_path(@care_plan, 'category.coding.code') == value
+          if @sequence.resolve_element_from_path(@care_plan, 'CarePlan.category.coding.code') == value
             wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@care_plan, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@care_plan, 'CarePlan.category.coding.code') == value
               wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -115,7 +115,7 @@ describe Inferno::Sequence::USCore310CareteamSequence do
           'status': value
         }
         body =
-          if @sequence.resolve_element_from_path(@care_team, 'status') == value
+          if @sequence.resolve_element_from_path(@care_team, 'CareTeam.status') == value
             wrap_resources_in_bundle(@care_team_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
           'category': value
         }
         body =
-          if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+          if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
             wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
               wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
           'category': value
         }
         body =
-          if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+          if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
             wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
               wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -115,7 +115,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
           'intent': value
         }
         body =
-          if @sequence.resolve_element_from_path(@medication_request, 'intent') == value
+          if @sequence.resolve_element_from_path(@medication_request, 'MedicationRequest.intent') == value
             wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -241,7 +241,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@medication_request, 'intent') == value
+            if @sequence.resolve_element_from_path(@medication_request, 'MedicationRequest.intent') == value
               wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
           'category': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'category.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.category.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.category.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -70,7 +70,7 @@ module Inferno
         case property
 
         when 'clinical-status'
-          values_found = resolve_path(resource, 'clinicalStatus')
+          values_found = resolve_path(resource, 'AllergyIntolerance.clinicalStatus')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -83,7 +83,7 @@ module Inferno
           assert match_found, "clinical-status in AllergyIntolerance/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'patient.reference')
+          values_found = resolve_path(resource, 'AllergyIntolerance.patient.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in AllergyIntolerance/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -363,10 +363,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the AllergyIntolerance resources found previously for the following must support elements:
 
-            * clinicalStatus
-            * verificationStatus
-            * code
-            * patient
+            clinicalStatus
+
+            verificationStatus
+
+            code
+
+            patient
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -70,7 +70,7 @@ module Inferno
         case property
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'CarePlan.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -83,18 +83,18 @@ module Inferno
           assert match_found, "category in CarePlan/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'period')
+          values_found = resolve_path(resource, 'CarePlan.period')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in CarePlan/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'CarePlan.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in CarePlan/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'CarePlan.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in CarePlan/#{resource.id} (#{values_found}) does not match status requested (#{value})"
@@ -376,12 +376,18 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the CarePlan resources found previously for the following must support elements:
 
-            * text
-            * text.status
-            * status
-            * intent
-            * category
-            * subject
+            text
+
+            text.status
+
+            status
+
+            intent
+
+            category
+
+            subject
+
             * CarePlan.category:AssessPlan
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -70,13 +70,13 @@ module Inferno
         case property
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'CareTeam.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in CareTeam/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'CareTeam.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in CareTeam/#{resource.id} (#{values_found}) does not match status requested (#{value})"
@@ -304,11 +304,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the CareTeam resources found previously for the following must support elements:
 
-            * status
-            * subject
-            * participant
-            * participant.role
-            * participant.member
+            status
+
+            subject
+
+            participant
+
+            participant.role
+
+            participant.member
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -70,7 +70,7 @@ module Inferno
         case property
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Condition.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -83,7 +83,7 @@ module Inferno
           assert match_found, "category in Condition/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'clinical-status'
-          values_found = resolve_path(resource, 'clinicalStatus')
+          values_found = resolve_path(resource, 'Condition.clinicalStatus')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -96,18 +96,18 @@ module Inferno
           assert match_found, "clinical-status in Condition/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Condition.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Condition/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'onset-date'
-          values_found = resolve_path(resource, 'onsetDateTime')
+          values_found = resolve_path(resource, 'Condition.onset.as(dateTime)')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "onset-date in Condition/#{resource.id} (#{values_found}) does not match onset-date requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Condition.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -484,11 +484,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Condition resources found previously for the following must support elements:
 
-            * clinicalStatus
-            * verificationStatus
-            * category
-            * code
-            * subject
+            clinicalStatus
+
+            verificationStatus
+
+            category
+
+            code
+
+            subject
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -75,19 +75,19 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'DiagnosticReport.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'DiagnosticReport.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'DiagnosticReport.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -100,7 +100,7 @@ module Inferno
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'DiagnosticReport.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -113,7 +113,7 @@ module Inferno
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'DiagnosticReport.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in DiagnosticReport/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
@@ -575,14 +575,22 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DiagnosticReport resources found previously for the following must support elements:
 
-            * status
-            * category
-            * code
-            * subject
-            * effective[x]
-            * issued
-            * performer
-            * result
+            status
+
+            category
+
+            code
+
+            subject
+
+            effective[x]
+
+            issued
+
+            performer
+
+            result
+
             * DiagnosticReport.category:LaboratorySlice
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -75,19 +75,19 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'DiagnosticReport.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'DiagnosticReport.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'DiagnosticReport.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -100,7 +100,7 @@ module Inferno
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'DiagnosticReport.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -113,7 +113,7 @@ module Inferno
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'DiagnosticReport.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in DiagnosticReport/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
@@ -575,15 +575,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DiagnosticReport resources found previously for the following must support elements:
 
-            * status
-            * category
-            * code
-            * subject
-            * encounter
-            * effective[x]
-            * issued
-            * performer
-            * presentedForm
+            status
+
+            category
+
+            code
+
+            subject
+
+            encounter
+
+            effective[x]
+
+            issued
+
+            performer
+
+            presentedForm
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -74,25 +74,25 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path(resource, 'DocumentReference.id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in DocumentReference/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'DocumentReference.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in DocumentReference/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'DocumentReference.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DocumentReference/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'DocumentReference.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -105,7 +105,7 @@ module Inferno
           assert match_found, "category in DocumentReference/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'type'
-          values_found = resolve_path(resource, 'type')
+          values_found = resolve_path(resource, 'DocumentReference.type')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -118,13 +118,13 @@ module Inferno
           assert match_found, "type in DocumentReference/#{resource.id} (#{values_found}) does not match type requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'date')
+          values_found = resolve_path(resource, 'DocumentReference.date')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "date in DocumentReference/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'period'
-          values_found = resolve_path(resource, 'context.period')
+          values_found = resolve_path(resource, 'DocumentReference.context.period')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "period in DocumentReference/#{resource.id} (#{values_found}) does not match period requested (#{value})"
 
@@ -630,23 +630,40 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DocumentReference resources found previously for the following must support elements:
 
-            * identifier
-            * status
-            * type
-            * category
-            * subject
-            * date
-            * author
-            * custodian
-            * content
-            * content.attachment
-            * content.attachment.contentType
-            * content.attachment.data
-            * content.attachment.url
-            * content.format
-            * context
-            * context.encounter
-            * context.period
+            identifier
+
+            status
+
+            type
+
+            category
+
+            subject
+
+            date
+
+            author
+
+            custodian
+
+            content
+
+            content.attachment
+
+            content.attachment.contentType
+
+            content.attachment.data
+
+            content.attachment.url
+
+            content.format
+
+            context
+
+            context.encounter
+
+            context.period
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -55,24 +55,24 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path(resource, 'Encounter.id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in Encounter/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'class'
-          values_found = resolve_path(resource, 'local_class')
+          values_found = resolve_path(resource, 'Encounter.class')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "class in Encounter/#{resource.id} (#{values_found}) does not match class requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'period')
+          values_found = resolve_path(resource, 'Encounter.period')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Encounter/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier')
+          values_found = resolve_path(resource, 'Encounter.identifier')
           identifier_system = value.split('|').first.empty? ? nil : value.split('|').first
           identifier_value = value.split('|').last
           match_found = values_found.any? do |identifier|
@@ -81,19 +81,19 @@ module Inferno
           assert match_found, "identifier in Encounter/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Encounter.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Encounter/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Encounter.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Encounter/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'type'
-          values_found = resolve_path(resource, 'type')
+          values_found = resolve_path(resource, 'Encounter.type')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -203,23 +203,40 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Encounter resources found previously for the following must support elements:
 
-            * identifier
-            * identifier.system
-            * identifier.value
-            * status
-            * class
-            * type
-            * subject
-            * participant
-            * participant.type
-            * participant.period
-            * participant.individual
-            * period
-            * reasonCode
-            * hospitalization
-            * hospitalization.dischargeDisposition
-            * location
-            * location.location
+            identifier
+
+            identifier.system
+
+            identifier.value
+
+            status
+
+            class
+
+            type
+
+            subject
+
+            participant
+
+            participant.type
+
+            participant.period
+
+            participant.individual
+
+            period
+
+            reasonCode
+
+            hospitalization
+
+            hospitalization.dischargeDisposition
+
+            location
+
+            location.location
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -70,19 +70,19 @@ module Inferno
         case property
 
         when 'lifecycle-status'
-          values_found = resolve_path(resource, 'lifecycleStatus')
+          values_found = resolve_path(resource, 'Goal.lifecycleStatus')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "lifecycle-status in Goal/#{resource.id} (#{values_found}) does not match lifecycle-status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Goal.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Goal/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'target-date'
-          values_found = resolve_path(resource, 'target.dueDate')
+          values_found = resolve_path(resource, 'Goal.target.dueDate')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "target-date in Goal/#{resource.id} (#{values_found}) does not match target-date requested (#{value})"
 
@@ -392,10 +392,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Goal resources found previously for the following must support elements:
 
-            * lifecycleStatus
-            * description
-            * subject
-            * target
+            lifecycleStatus
+
+            description
+
+            subject
+
+            target
+
             * Goal.target.due[x]:dueDate
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -70,19 +70,19 @@ module Inferno
         case property
 
         when 'patient'
-          values_found = resolve_path(resource, 'patient.reference')
+          values_found = resolve_path(resource, 'Immunization.patient.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Immunization/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Immunization.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Immunization/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'occurrence')
+          values_found = resolve_path(resource, 'Immunization.occurrence')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Immunization/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
@@ -392,12 +392,18 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Immunization resources found previously for the following must support elements:
 
-            * status
-            * statusReason
-            * vaccineCode
-            * patient
-            * occurrence[x]
-            * primarySource
+            status
+
+            statusReason
+
+            vaccineCode
+
+            patient
+
+            occurrence[x]
+
+            primarySource
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -73,13 +73,13 @@ module Inferno
         case property
 
         when 'patient'
-          values_found = resolve_path(resource, 'patient.reference')
+          values_found = resolve_path(resource, 'Device.patient.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Device/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'type'
-          values_found = resolve_path(resource, 'type')
+          values_found = resolve_path(resource, 'Device.type')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -325,17 +325,28 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Device resources found previously for the following must support elements:
 
-            * udiCarrier
-            * udiCarrier.deviceIdentifier
-            * udiCarrier.carrierAIDC
-            * udiCarrier.carrierHRF
-            * distinctIdentifier
-            * manufactureDate
-            * expirationDate
-            * lotNumber
-            * serialNumber
-            * type
-            * patient
+            udiCarrier
+
+            udiCarrier.deviceIdentifier
+
+            udiCarrier.carrierAIDC
+
+            udiCarrier.carrierHRF
+
+            distinctIdentifier
+
+            manufactureDate
+
+            expirationDate
+
+            lotNumber
+
+            serialNumber
+
+            type
+
+            patient
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -55,13 +55,13 @@ module Inferno
         case property
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path(resource, 'Location.name')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "name in Location/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'
-          values_found = resolve_path(resource, 'address')
+          values_found = resolve_path(resource, 'Location.address')
           match_found = values_found.any? do |address|
             address&.text&.start_with?(value) ||
               address&.city&.start_with?(value) ||
@@ -72,19 +72,19 @@ module Inferno
           assert match_found, "address in Location/#{resource.id} (#{values_found}) does not match address requested (#{value})"
 
         when 'address-city'
-          values_found = resolve_path(resource, 'address.city')
+          values_found = resolve_path(resource, 'Location.address.city')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-city in Location/#{resource.id} (#{values_found}) does not match address-city requested (#{value})"
 
         when 'address-state'
-          values_found = resolve_path(resource, 'address.state')
+          values_found = resolve_path(resource, 'Location.address.state')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-state in Location/#{resource.id} (#{values_found}) does not match address-state requested (#{value})"
 
         when 'address-postalcode'
-          values_found = resolve_path(resource, 'address.postalCode')
+          values_found = resolve_path(resource, 'Location.address.postalCode')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-postalcode in Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{value})"
@@ -154,15 +154,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Location resources found previously for the following must support elements:
 
-            * status
-            * name
-            * telecom
-            * address
-            * address.line
-            * address.city
-            * address.state
-            * address.postalCode
-            * managingOrganization
+            status
+
+            name
+
+            telecom
+
+            address
+
+            address.line
+
+            address.city
+
+            address.state
+
+            address.postalCode
+
+            managingOrganization
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -71,31 +71,31 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'MedicationRequest.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in MedicationRequest/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'intent'
-          values_found = resolve_path(resource, 'intent')
+          values_found = resolve_path(resource, 'MedicationRequest.intent')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "intent in MedicationRequest/#{resource.id} (#{values_found}) does not match intent requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'MedicationRequest.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in MedicationRequest/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'encounter'
-          values_found = resolve_path(resource, 'encounter.reference')
+          values_found = resolve_path(resource, 'MedicationRequest.encounter.reference')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "encounter in MedicationRequest/#{resource.id} (#{values_found}) does not match encounter requested (#{value})"
 
         when 'authoredon'
-          values_found = resolve_path(resource, 'authoredOn')
+          values_found = resolve_path(resource, 'MedicationRequest.authoredOn')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "authoredon in MedicationRequest/#{resource.id} (#{values_found}) does not match authoredon requested (#{value})"
@@ -561,16 +561,26 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the MedicationRequest resources found previously for the following must support elements:
 
-            * status
-            * intent
-            * reported[x]
-            * medication[x]
-            * subject
-            * encounter
-            * authoredOn
-            * requester
-            * dosageInstruction
-            * dosageInstruction.text
+            status
+
+            intent
+
+            reported[x]
+
+            medication[x]
+
+            subject
+
+            encounter
+
+            authoredOn
+
+            requester
+
+            dosageInstruction
+
+            dosageInstruction.text
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,13 +548,20 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * code
-            * subject
-            * effective[x]
-            * value[x]
-            * dataAbsentReason
+            status
+
+            category
+
+            code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            dataAbsentReason
+
             * Observation.category:Laboratory
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -55,13 +55,13 @@ module Inferno
         case property
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path(resource, 'Organization.name')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "name in Organization/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'
-          values_found = resolve_path(resource, 'address')
+          values_found = resolve_path(resource, 'Organization.address')
           match_found = values_found.any? do |address|
             address&.text&.start_with?(value) ||
               address&.city&.start_with?(value) ||
@@ -136,18 +136,30 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Organization resources found previously for the following must support elements:
 
-            * identifier
-            * identifier.system
-            * identifier.value
-            * active
-            * name
-            * telecom
-            * address
-            * address.line
-            * address.city
-            * address.state
-            * address.postalCode
-            * address.country
+            identifier
+
+            identifier.system
+
+            identifier.value
+
+            active
+
+            name
+
+            telecom
+
+            address
+
+            address.line
+
+            address.city
+
+            address.state
+
+            address.postalCode
+
+            address.country
+
             * Organization.identifier:NPI
             * Organization.identifier:CLIA
           )

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -74,36 +74,36 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path(resource, 'Patient.id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in Patient/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'birthdate'
-          values_found = resolve_path(resource, 'birthDate')
+          values_found = resolve_path(resource, 'Patient.birthDate')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "birthdate in Patient/#{resource.id} (#{values_found}) does not match birthdate requested (#{value})"
 
         when 'family'
-          values_found = resolve_path(resource, 'name.family')
+          values_found = resolve_path(resource, 'Patient.name.family')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "family in Patient/#{resource.id} (#{values_found}) does not match family requested (#{value})"
 
         when 'gender'
-          values_found = resolve_path(resource, 'gender')
+          values_found = resolve_path(resource, 'Patient.gender')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "gender in Patient/#{resource.id} (#{values_found}) does not match gender requested (#{value})"
 
         when 'given'
-          values_found = resolve_path(resource, 'name.given')
+          values_found = resolve_path(resource, 'Patient.name.given')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "given in Patient/#{resource.id} (#{values_found}) does not match given requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier')
+          values_found = resolve_path(resource, 'Patient.identifier')
           identifier_system = value.split('|').first.empty? ? nil : value.split('|').first
           identifier_value = value.split('|').last
           match_found = values_found.any? do |identifier|
@@ -112,7 +112,7 @@ module Inferno
           assert match_found, "identifier in Patient/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path(resource, 'Patient.name')
           value_downcase = value.downcase
           match_found = values_found.any? do |name|
             name&.text&.downcase&.start_with?(value_downcase) ||
@@ -523,26 +523,46 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Patient resources found previously for the following must support elements:
 
-            * identifier
-            * identifier.system
-            * identifier.value
-            * name
-            * name.family
-            * name.given
-            * telecom
-            * telecom.system
-            * telecom.value
-            * telecom.use
-            * gender
-            * birthDate
-            * address
-            * address.line
-            * address.city
-            * address.state
-            * address.postalCode
-            * address.period
-            * communication
-            * communication.language
+            identifier
+
+            identifier.system
+
+            identifier.value
+
+            name
+
+            name.family
+
+            name.given
+
+            telecom
+
+            telecom.system
+
+            telecom.value
+
+            telecom.use
+
+            gender
+
+            birthDate
+
+            address
+
+            address.line
+
+            address.city
+
+            address.state
+
+            address.postalCode
+
+            address.period
+
+            communication
+
+            communication.language
+
             * Patient.extension:race
             * Patient.extension:ethnicity
             * Patient.extension:birthsex

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
         case property
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path(resource, 'Practitioner.name')
           value_downcase = value.downcase
           match_found = values_found.any? do |name|
             name&.text&.downcase&.start_with?(value_downcase) ||
@@ -67,7 +67,7 @@ module Inferno
           assert match_found, "name in Practitioner/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier')
+          values_found = resolve_path(resource, 'Practitioner.identifier')
           identifier_system = value.split('|').first.empty? ? nil : value.split('|').first
           identifier_value = value.split('|').last
           match_found = values_found.any? do |identifier|
@@ -140,11 +140,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Practitioner resources found previously for the following must support elements:
 
-            * identifier
-            * identifier.system
-            * identifier.value
-            * name
-            * name.family
+            identifier
+
+            identifier.system
+
+            identifier.value
+
+            name
+
+            name.family
+
             * Practitioner.identifier:NPI
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
         case property
 
         when 'specialty'
-          values_found = resolve_path(resource, 'specialty')
+          values_found = resolve_path(resource, 'PractitionerRole.specialty')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -68,7 +68,7 @@ module Inferno
           assert match_found, "specialty in PractitionerRole/#{resource.id} (#{values_found}) does not match specialty requested (#{value})"
 
         when 'practitioner'
-          values_found = resolve_path(resource, 'practitioner.reference')
+          values_found = resolve_path(resource, 'PractitionerRole.practitioner.reference')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "practitioner in PractitionerRole/#{resource.id} (#{values_found}) does not match practitioner requested (#{value})"
@@ -138,15 +138,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the PractitionerRole resources found previously for the following must support elements:
 
-            * practitioner
-            * organization
-            * code
-            * specialty
-            * location
-            * telecom
-            * telecom.system
-            * telecom.value
-            * endpoint
+            practitioner
+
+            organization
+
+            code
+
+            specialty
+
+            location
+
+            telecom
+
+            telecom.system
+
+            telecom.value
+
+            endpoint
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -71,24 +71,24 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Procedure.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Procedure/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Procedure.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Procedure/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'performed')
+          values_found = resolve_path(resource, 'Procedure.performed')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Procedure/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Procedure.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -462,10 +462,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Procedure resources found previously for the following must support elements:
 
-            * status
-            * code
-            * subject
-            * performed[x]
+            status
+
+            code
+
+            subject
+
+            performed[x]
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -112,14 +112,22 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Provenance resources found previously for the following must support elements:
 
-            * target
-            * recorded
-            * agent
-            * agent.type
-            * agent.who
-            * agent.onBehalfOf
-            * agent.type.coding.code
-            * agent.type.coding.code
+            target
+
+            recorded
+
+            agent
+
+            agent.type
+
+            agent.who
+
+            agent.onBehalfOf
+
+            agent.type.coding.code
+
+            agent.type.coding.code
+
             * Provenance.agent:ProvenanceAuthor
             * Provenance.agent:ProvenanceTransmitter
           )

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,35 +548,64 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * code.coding
-            * code.coding.system
-            * code.coding.code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
-            * component
-            * component.code
-            * component.code.coding.code
-            * component.value[x].system
-            * component.value[x].code
-            * component.code.coding.code
-            * component.value[x]
-            * component.value[x].value
-            * component.value[x].unit
-            * component.value[x].system
-            * component.value[x].code
-            * component.dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            code.coding
+
+            code.coding.system
+
+            code.coding.code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
+            dataAbsentReason
+
+            component
+
+            component.code
+
+            component.code.coding.code
+
+            component.value[x].system
+
+            component.value[x].code
+
+            component.code.coding.code
+
+            component.value[x]
+
+            component.value[x].value
+
+            component.value[x].unit
+
+            component.value[x].system
+
+            component.value[x].code
+
+            component.dataAbsentReason
+
             * Observation.category:VSCat
             * Observation.code.coding:PulseOx
             * Observation.value[x]:valueQuantity

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -76,13 +76,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -95,7 +95,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -108,12 +108,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -351,10 +351,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * code
-            * subject
-            * issued
+            status
+
+            code
+
+            subject
+
+            issued
+
             * Observation.value[x]:valueCodeableConcept
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -541,19 +541,32 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code.coding.code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code.coding.code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -541,19 +541,32 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code.coding.code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code.coding.code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -541,19 +541,32 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code.coding.code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code.coding.code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
           )

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_encounter_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_encounter_definitions.rb
@@ -20,7 +20,7 @@ module Inferno
             path: 'status'
           },
           {
-            path: 'local_class'
+            path: 'class'
           },
           {
             path: 'type'

--- a/lib/modules/uscore_v3.1.1/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_careplan_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore311CareplanSequence do
           'category': value
         }
         body =
-          if @sequence.resolve_element_from_path(@care_plan, 'category.coding.code') == value
+          if @sequence.resolve_element_from_path(@care_plan, 'CarePlan.category.coding.code') == value
             wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore311CareplanSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@care_plan, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@care_plan, 'CarePlan.category.coding.code') == value
               wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.1/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_careteam_test.rb
@@ -115,7 +115,7 @@ describe Inferno::Sequence::USCore311CareteamSequence do
           'status': value
         }
         body =
-          if @sequence.resolve_element_from_path(@care_team, 'status') == value
+          if @sequence.resolve_element_from_path(@care_team, 'CareTeam.status') == value
             wrap_resources_in_bundle(@care_team_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_lab_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
           'category': value
         }
         body =
-          if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+          if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
             wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
               wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_note_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
           'category': value
         }
         body =
-          if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+          if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
             wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
               wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.1/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_medicationrequest_test.rb
@@ -115,7 +115,7 @@ describe Inferno::Sequence::USCore311MedicationrequestSequence do
           'intent': value
         }
         body =
-          if @sequence.resolve_element_from_path(@medication_request, 'intent') == value
+          if @sequence.resolve_element_from_path(@medication_request, 'MedicationRequest.intent') == value
             wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -241,7 +241,7 @@ describe Inferno::Sequence::USCore311MedicationrequestSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@medication_request, 'intent') == value
+            if @sequence.resolve_element_from_path(@medication_request, 'MedicationRequest.intent') == value
               wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.1/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_observation_lab_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore311ObservationLabSequence do
           'category': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'category.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.category.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore311ObservationLabSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.category.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.1/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_smokingstatus_test.rb
@@ -120,7 +120,7 @@ describe Inferno::Sequence::USCore311SmokingstatusSequence do
           'code': value
         }
         body =
-          if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+          if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
             wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
           else
             FHIR::Bundle.new.to_json
@@ -224,7 +224,7 @@ describe Inferno::Sequence::USCore311SmokingstatusSequence do
           }
 
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -70,7 +70,7 @@ module Inferno
         case property
 
         when 'clinical-status'
-          values_found = resolve_path(resource, 'clinicalStatus')
+          values_found = resolve_path(resource, 'AllergyIntolerance.clinicalStatus')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -83,7 +83,7 @@ module Inferno
           assert match_found, "clinical-status in AllergyIntolerance/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'patient.reference')
+          values_found = resolve_path(resource, 'AllergyIntolerance.patient.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in AllergyIntolerance/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -363,12 +363,18 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the AllergyIntolerance resources found previously for the following must support elements:
 
-            * clinicalStatus
-            * verificationStatus
-            * code
-            * patient
-            * reaction
-            * reaction.manifestation
+            clinicalStatus
+
+            verificationStatus
+
+            code
+
+            patient
+
+            reaction
+
+            reaction.manifestation
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -70,7 +70,7 @@ module Inferno
         case property
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'CarePlan.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -83,18 +83,18 @@ module Inferno
           assert match_found, "category in CarePlan/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'period')
+          values_found = resolve_path(resource, 'CarePlan.period')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in CarePlan/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'CarePlan.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in CarePlan/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'CarePlan.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in CarePlan/#{resource.id} (#{values_found}) does not match status requested (#{value})"
@@ -376,12 +376,18 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the CarePlan resources found previously for the following must support elements:
 
-            * text
-            * text.status
-            * status
-            * intent
-            * category
-            * subject
+            text
+
+            text.status
+
+            status
+
+            intent
+
+            category
+
+            subject
+
             * CarePlan.category:AssessPlan
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -70,13 +70,13 @@ module Inferno
         case property
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'CareTeam.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in CareTeam/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'CareTeam.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in CareTeam/#{resource.id} (#{values_found}) does not match status requested (#{value})"
@@ -304,11 +304,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the CareTeam resources found previously for the following must support elements:
 
-            * status
-            * subject
-            * participant
-            * participant.role
-            * participant.member
+            status
+
+            subject
+
+            participant
+
+            participant.role
+
+            participant.member
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -70,7 +70,7 @@ module Inferno
         case property
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Condition.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -83,7 +83,7 @@ module Inferno
           assert match_found, "category in Condition/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'clinical-status'
-          values_found = resolve_path(resource, 'clinicalStatus')
+          values_found = resolve_path(resource, 'Condition.clinicalStatus')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -96,18 +96,18 @@ module Inferno
           assert match_found, "clinical-status in Condition/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Condition.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Condition/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'onset-date'
-          values_found = resolve_path(resource, 'onsetDateTime')
+          values_found = resolve_path(resource, 'Condition.onset.as(dateTime)')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "onset-date in Condition/#{resource.id} (#{values_found}) does not match onset-date requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Condition.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -484,11 +484,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Condition resources found previously for the following must support elements:
 
-            * clinicalStatus
-            * verificationStatus
-            * category
-            * code
-            * subject
+            clinicalStatus
+
+            verificationStatus
+
+            category
+
+            code
+
+            subject
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -75,19 +75,19 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'DiagnosticReport.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'DiagnosticReport.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'DiagnosticReport.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -100,7 +100,7 @@ module Inferno
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'DiagnosticReport.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -113,7 +113,7 @@ module Inferno
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'DiagnosticReport.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in DiagnosticReport/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
@@ -575,14 +575,22 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DiagnosticReport resources found previously for the following must support elements:
 
-            * status
-            * category
-            * code
-            * subject
-            * effective[x]
-            * issued
-            * performer
-            * result
+            status
+
+            category
+
+            code
+
+            subject
+
+            effective[x]
+
+            issued
+
+            performer
+
+            result
+
             * DiagnosticReport.category:LaboratorySlice
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -75,19 +75,19 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'DiagnosticReport.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'DiagnosticReport.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'DiagnosticReport.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -100,7 +100,7 @@ module Inferno
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'DiagnosticReport.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -113,7 +113,7 @@ module Inferno
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'DiagnosticReport.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in DiagnosticReport/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
@@ -575,15 +575,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DiagnosticReport resources found previously for the following must support elements:
 
-            * status
-            * category
-            * code
-            * subject
-            * encounter
-            * effective[x]
-            * issued
-            * performer
-            * presentedForm
+            status
+
+            category
+
+            code
+
+            subject
+
+            encounter
+
+            effective[x]
+
+            issued
+
+            performer
+
+            presentedForm
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -74,25 +74,25 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path(resource, 'DocumentReference.id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in DocumentReference/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'DocumentReference.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in DocumentReference/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'DocumentReference.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DocumentReference/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'DocumentReference.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -105,7 +105,7 @@ module Inferno
           assert match_found, "category in DocumentReference/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'type'
-          values_found = resolve_path(resource, 'type')
+          values_found = resolve_path(resource, 'DocumentReference.type')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -118,13 +118,13 @@ module Inferno
           assert match_found, "type in DocumentReference/#{resource.id} (#{values_found}) does not match type requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'date')
+          values_found = resolve_path(resource, 'DocumentReference.date')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "date in DocumentReference/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'period'
-          values_found = resolve_path(resource, 'context.period')
+          values_found = resolve_path(resource, 'DocumentReference.context.period')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "period in DocumentReference/#{resource.id} (#{values_found}) does not match period requested (#{value})"
 
@@ -630,23 +630,40 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DocumentReference resources found previously for the following must support elements:
 
-            * identifier
-            * status
-            * type
-            * category
-            * subject
-            * date
-            * author
-            * custodian
-            * content
-            * content.attachment
-            * content.attachment.contentType
-            * content.attachment.data
-            * content.attachment.url
-            * content.format
-            * context
-            * context.encounter
-            * context.period
+            identifier
+
+            status
+
+            type
+
+            category
+
+            subject
+
+            date
+
+            author
+
+            custodian
+
+            content
+
+            content.attachment
+
+            content.attachment.contentType
+
+            content.attachment.data
+
+            content.attachment.url
+
+            content.format
+
+            context
+
+            context.encounter
+
+            context.period
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
@@ -55,24 +55,24 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path(resource, 'Encounter.id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in Encounter/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'class'
-          values_found = resolve_path(resource, 'local_class')
+          values_found = resolve_path(resource, 'Encounter.class')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "class in Encounter/#{resource.id} (#{values_found}) does not match class requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'period')
+          values_found = resolve_path(resource, 'Encounter.period')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Encounter/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier')
+          values_found = resolve_path(resource, 'Encounter.identifier')
           identifier_system = value.split('|').first.empty? ? nil : value.split('|').first
           identifier_value = value.split('|').last
           match_found = values_found.any? do |identifier|
@@ -81,19 +81,19 @@ module Inferno
           assert match_found, "identifier in Encounter/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Encounter.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Encounter/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Encounter.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Encounter/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'type'
-          values_found = resolve_path(resource, 'type')
+          values_found = resolve_path(resource, 'Encounter.type')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -203,23 +203,40 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Encounter resources found previously for the following must support elements:
 
-            * identifier
-            * identifier.system
-            * identifier.value
-            * status
-            * class
-            * type
-            * subject
-            * participant
-            * participant.type
-            * participant.period
-            * participant.individual
-            * period
-            * reasonCode
-            * hospitalization
-            * hospitalization.dischargeDisposition
-            * location
-            * location.location
+            identifier
+
+            identifier.system
+
+            identifier.value
+
+            status
+
+            class
+
+            type
+
+            subject
+
+            participant
+
+            participant.type
+
+            participant.period
+
+            participant.individual
+
+            period
+
+            reasonCode
+
+            hospitalization
+
+            hospitalization.dischargeDisposition
+
+            location
+
+            location.location
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -70,19 +70,19 @@ module Inferno
         case property
 
         when 'lifecycle-status'
-          values_found = resolve_path(resource, 'lifecycleStatus')
+          values_found = resolve_path(resource, 'Goal.lifecycleStatus')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "lifecycle-status in Goal/#{resource.id} (#{values_found}) does not match lifecycle-status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Goal.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Goal/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'target-date'
-          values_found = resolve_path(resource, 'target.dueDate')
+          values_found = resolve_path(resource, 'Goal.target.dueDate')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "target-date in Goal/#{resource.id} (#{values_found}) does not match target-date requested (#{value})"
 
@@ -392,10 +392,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Goal resources found previously for the following must support elements:
 
-            * lifecycleStatus
-            * description
-            * subject
-            * target
+            lifecycleStatus
+
+            description
+
+            subject
+
+            target
+
             * Goal.target.due[x]:dueDate
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -70,19 +70,19 @@ module Inferno
         case property
 
         when 'patient'
-          values_found = resolve_path(resource, 'patient.reference')
+          values_found = resolve_path(resource, 'Immunization.patient.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Immunization/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Immunization.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Immunization/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'occurrence')
+          values_found = resolve_path(resource, 'Immunization.occurrence')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Immunization/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
@@ -392,12 +392,18 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Immunization resources found previously for the following must support elements:
 
-            * status
-            * statusReason
-            * vaccineCode
-            * patient
-            * occurrence[x]
-            * primarySource
+            status
+
+            statusReason
+
+            vaccineCode
+
+            patient
+
+            occurrence[x]
+
+            primarySource
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -73,13 +73,13 @@ module Inferno
         case property
 
         when 'patient'
-          values_found = resolve_path(resource, 'patient.reference')
+          values_found = resolve_path(resource, 'Device.patient.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Device/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'type'
-          values_found = resolve_path(resource, 'type')
+          values_found = resolve_path(resource, 'Device.type')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -325,17 +325,28 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Device resources found previously for the following must support elements:
 
-            * udiCarrier
-            * udiCarrier.deviceIdentifier
-            * udiCarrier.carrierAIDC
-            * udiCarrier.carrierHRF
-            * distinctIdentifier
-            * manufactureDate
-            * expirationDate
-            * lotNumber
-            * serialNumber
-            * type
-            * patient
+            udiCarrier
+
+            udiCarrier.deviceIdentifier
+
+            udiCarrier.carrierAIDC
+
+            udiCarrier.carrierHRF
+
+            distinctIdentifier
+
+            manufactureDate
+
+            expirationDate
+
+            lotNumber
+
+            serialNumber
+
+            type
+
+            patient
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
@@ -55,13 +55,13 @@ module Inferno
         case property
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path(resource, 'Location.name')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "name in Location/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'
-          values_found = resolve_path(resource, 'address')
+          values_found = resolve_path(resource, 'Location.address')
           match_found = values_found.any? do |address|
             address&.text&.start_with?(value) ||
               address&.city&.start_with?(value) ||
@@ -72,19 +72,19 @@ module Inferno
           assert match_found, "address in Location/#{resource.id} (#{values_found}) does not match address requested (#{value})"
 
         when 'address-city'
-          values_found = resolve_path(resource, 'address.city')
+          values_found = resolve_path(resource, 'Location.address.city')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-city in Location/#{resource.id} (#{values_found}) does not match address-city requested (#{value})"
 
         when 'address-state'
-          values_found = resolve_path(resource, 'address.state')
+          values_found = resolve_path(resource, 'Location.address.state')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-state in Location/#{resource.id} (#{values_found}) does not match address-state requested (#{value})"
 
         when 'address-postalcode'
-          values_found = resolve_path(resource, 'address.postalCode')
+          values_found = resolve_path(resource, 'Location.address.postalCode')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-postalcode in Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{value})"
@@ -154,15 +154,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Location resources found previously for the following must support elements:
 
-            * status
-            * name
-            * telecom
-            * address
-            * address.line
-            * address.city
-            * address.state
-            * address.postalCode
-            * managingOrganization
+            status
+
+            name
+
+            telecom
+
+            address
+
+            address.line
+
+            address.city
+
+            address.state
+
+            address.postalCode
+
+            managingOrganization
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -71,31 +71,31 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'MedicationRequest.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in MedicationRequest/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'intent'
-          values_found = resolve_path(resource, 'intent')
+          values_found = resolve_path(resource, 'MedicationRequest.intent')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "intent in MedicationRequest/#{resource.id} (#{values_found}) does not match intent requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'MedicationRequest.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in MedicationRequest/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'encounter'
-          values_found = resolve_path(resource, 'encounter.reference')
+          values_found = resolve_path(resource, 'MedicationRequest.encounter.reference')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "encounter in MedicationRequest/#{resource.id} (#{values_found}) does not match encounter requested (#{value})"
 
         when 'authoredon'
-          values_found = resolve_path(resource, 'authoredOn')
+          values_found = resolve_path(resource, 'MedicationRequest.authoredOn')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "authoredon in MedicationRequest/#{resource.id} (#{values_found}) does not match authoredon requested (#{value})"
@@ -562,16 +562,26 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the MedicationRequest resources found previously for the following must support elements:
 
-            * status
-            * intent
-            * reported[x]
-            * medication[x]
-            * subject
-            * encounter
-            * authoredOn
-            * requester
-            * dosageInstruction
-            * dosageInstruction.text
+            status
+
+            intent
+
+            reported[x]
+
+            medication[x]
+
+            subject
+
+            encounter
+
+            authoredOn
+
+            requester
+
+            dosageInstruction
+
+            dosageInstruction.text
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -548,13 +548,20 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * code
-            * subject
-            * effective[x]
-            * value[x]
-            * dataAbsentReason
+            status
+
+            category
+
+            code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            dataAbsentReason
+
             * Observation.category:Laboratory
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
@@ -55,13 +55,13 @@ module Inferno
         case property
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path(resource, 'Organization.name')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "name in Organization/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'
-          values_found = resolve_path(resource, 'address')
+          values_found = resolve_path(resource, 'Organization.address')
           match_found = values_found.any? do |address|
             address&.text&.start_with?(value) ||
               address&.city&.start_with?(value) ||
@@ -136,18 +136,30 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Organization resources found previously for the following must support elements:
 
-            * identifier
-            * identifier.system
-            * identifier.value
-            * active
-            * name
-            * telecom
-            * address
-            * address.line
-            * address.city
-            * address.state
-            * address.postalCode
-            * address.country
+            identifier
+
+            identifier.system
+
+            identifier.value
+
+            active
+
+            name
+
+            telecom
+
+            address
+
+            address.line
+
+            address.city
+
+            address.state
+
+            address.postalCode
+
+            address.country
+
             * Organization.identifier:NPI
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -74,36 +74,36 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path(resource, 'Patient.id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in Patient/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'birthdate'
-          values_found = resolve_path(resource, 'birthDate')
+          values_found = resolve_path(resource, 'Patient.birthDate')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "birthdate in Patient/#{resource.id} (#{values_found}) does not match birthdate requested (#{value})"
 
         when 'family'
-          values_found = resolve_path(resource, 'name.family')
+          values_found = resolve_path(resource, 'Patient.name.family')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "family in Patient/#{resource.id} (#{values_found}) does not match family requested (#{value})"
 
         when 'gender'
-          values_found = resolve_path(resource, 'gender')
+          values_found = resolve_path(resource, 'Patient.gender')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "gender in Patient/#{resource.id} (#{values_found}) does not match gender requested (#{value})"
 
         when 'given'
-          values_found = resolve_path(resource, 'name.given')
+          values_found = resolve_path(resource, 'Patient.name.given')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "given in Patient/#{resource.id} (#{values_found}) does not match given requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier')
+          values_found = resolve_path(resource, 'Patient.identifier')
           identifier_system = value.split('|').first.empty? ? nil : value.split('|').first
           identifier_value = value.split('|').last
           match_found = values_found.any? do |identifier|
@@ -112,7 +112,7 @@ module Inferno
           assert match_found, "identifier in Patient/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path(resource, 'Patient.name')
           value_downcase = value.downcase
           match_found = values_found.any? do |name|
             name&.text&.downcase&.start_with?(value_downcase) ||
@@ -523,26 +523,46 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Patient resources found previously for the following must support elements:
 
-            * identifier
-            * identifier.system
-            * identifier.value
-            * name
-            * name.family
-            * name.given
-            * telecom
-            * telecom.system
-            * telecom.value
-            * telecom.use
-            * gender
-            * birthDate
-            * address
-            * address.line
-            * address.city
-            * address.state
-            * address.postalCode
-            * address.period
-            * communication
-            * communication.language
+            identifier
+
+            identifier.system
+
+            identifier.value
+
+            name
+
+            name.family
+
+            name.given
+
+            telecom
+
+            telecom.system
+
+            telecom.value
+
+            telecom.use
+
+            gender
+
+            birthDate
+
+            address
+
+            address.line
+
+            address.city
+
+            address.state
+
+            address.postalCode
+
+            address.period
+
+            communication
+
+            communication.language
+
             * Patient.extension:race
             * Patient.extension:ethnicity
             * Patient.extension:birthsex

--- a/lib/modules/uscore_v3.1.1/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitioner_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
         case property
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path(resource, 'Practitioner.name')
           value_downcase = value.downcase
           match_found = values_found.any? do |name|
             name&.text&.downcase&.start_with?(value_downcase) ||
@@ -67,7 +67,7 @@ module Inferno
           assert match_found, "name in Practitioner/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier')
+          values_found = resolve_path(resource, 'Practitioner.identifier')
           identifier_system = value.split('|').first.empty? ? nil : value.split('|').first
           identifier_value = value.split('|').last
           match_found = values_found.any? do |identifier|
@@ -140,11 +140,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Practitioner resources found previously for the following must support elements:
 
-            * identifier
-            * identifier.system
-            * identifier.value
-            * name
-            * name.family
+            identifier
+
+            identifier.system
+
+            identifier.value
+
+            name
+
+            name.family
+
             * Practitioner.identifier:NPI
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
         case property
 
         when 'specialty'
-          values_found = resolve_path(resource, 'specialty')
+          values_found = resolve_path(resource, 'PractitionerRole.specialty')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -68,7 +68,7 @@ module Inferno
           assert match_found, "specialty in PractitionerRole/#{resource.id} (#{values_found}) does not match specialty requested (#{value})"
 
         when 'practitioner'
-          values_found = resolve_path(resource, 'practitioner.reference')
+          values_found = resolve_path(resource, 'PractitionerRole.practitioner.reference')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "practitioner in PractitionerRole/#{resource.id} (#{values_found}) does not match practitioner requested (#{value})"
@@ -138,15 +138,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the PractitionerRole resources found previously for the following must support elements:
 
-            * practitioner
-            * organization
-            * code
-            * specialty
-            * location
-            * telecom
-            * telecom.system
-            * telecom.value
-            * endpoint
+            practitioner
+
+            organization
+
+            code
+
+            specialty
+
+            location
+
+            telecom
+
+            telecom.system
+
+            telecom.value
+
+            endpoint
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -71,24 +71,24 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Procedure.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Procedure/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Procedure.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Procedure/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'performed')
+          values_found = resolve_path(resource, 'Procedure.performed')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Procedure/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Procedure.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -462,10 +462,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Procedure resources found previously for the following must support elements:
 
-            * status
-            * code
-            * subject
-            * performed[x]
+            status
+
+            code
+
+            subject
+
+            performed[x]
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
@@ -112,14 +112,22 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Provenance resources found previously for the following must support elements:
 
-            * target
-            * recorded
-            * agent
-            * agent.type
-            * agent.who
-            * agent.onBehalfOf
-            * agent.type.coding.code
-            * agent.type.coding.code
+            target
+
+            recorded
+
+            agent
+
+            agent.type
+
+            agent.who
+
+            agent.onBehalfOf
+
+            agent.type.coding.code
+
+            agent.type.coding.code
+
             * Provenance.agent:ProvenanceAuthor
             * Provenance.agent:ProvenanceTransmitter
           )

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -72,13 +72,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -91,7 +91,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -104,12 +104,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -541,35 +541,64 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * code.coding
-            * code.coding.system
-            * code.coding.code
-            * subject
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
-            * component
-            * component.code
-            * component.code.coding.code
-            * component.value[x].system
-            * component.value[x].code
-            * component.code.coding.code
-            * component.value[x]
-            * component.value[x].value
-            * component.value[x].unit
-            * component.value[x].system
-            * component.value[x].code
-            * component.dataAbsentReason
+            status
+
+            category
+
+            category.coding
+
+            category.coding.system
+
+            category.coding.code
+
+            code
+
+            code.coding
+
+            code.coding.system
+
+            code.coding.code
+
+            subject
+
+            effective[x]
+
+            value[x]
+
+            value[x].value
+
+            value[x].unit
+
+            value[x].system
+
+            value[x].code
+
+            dataAbsentReason
+
+            component
+
+            component.code
+
+            component.code.coding.code
+
+            component.value[x].system
+
+            component.value[x].code
+
+            component.code.coding.code
+
+            component.value[x]
+
+            component.value[x].value
+
+            component.value[x].unit
+
+            component.value[x].system
+
+            component.value[x].code
+
+            component.dataAbsentReason
+
             * Observation.category:VSCat
             * Observation.code.coding:PulseOx
             * Observation.value[x]:valueQuantity

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -76,13 +76,13 @@ module Inferno
         case property
 
         when 'status'
-          values_found = resolve_path(resource, 'status')
+          values_found = resolve_path(resource, 'Observation.status')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category')
+          values_found = resolve_path(resource, 'Observation.category')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -95,7 +95,7 @@ module Inferno
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code')
+          values_found = resolve_path(resource, 'Observation.code')
           coding_system = value.split('|').first.empty? ? nil : value.split('|').first
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
@@ -108,12 +108,12 @@ module Inferno
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'effective')
+          values_found = resolve_path(resource, 'Observation.effective')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path(resource, 'Observation.subject.reference')
           value = value.split('Patient/').last
           match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
@@ -351,10 +351,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * code
-            * subject
-            * issued
+            status
+
+            code
+
+            subject
+
+            issued
+
             * Observation.value[x]:valueCodeableConcept
           )
           versions :r4

--- a/test/unit/fhirpath_evaluator_test.rb
+++ b/test/unit/fhirpath_evaluator_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'fhir_client'
+require_relative '../test_helper'
+
+describe Inferno::FHIRPathEvaluator do
+  before do
+    @fhirpath_url = 'http://example.com:8080'
+    @evaluator = Inferno::FHIRPathEvaluator.new(@fhirpath_url)
+  end
+
+  describe 'Evaluating a FHIRPath against elements' do
+    it 'Should return an empty collection if given an empty array' do
+      assert_equal [], @evaluator.evaluate([], 'Patient')
+    end
+
+    it 'Should accept a single element and return fhir_models' do
+      patient = FHIR::Patient.new(id: 'foo')
+      response = "[{ \"type\": \"Patient\", \"element\": #{patient.to_json} }]"
+
+      stub_request(:post, "#{@fhirpath_url}/evaluate")
+        .with(query: hash_including(path: 'Patient'), body: patient.to_json)
+        .to_return(body: response)
+
+      assert_equal [patient], @evaluator.evaluate(patient, 'Patient')
+    end
+
+    it 'Should return a collection of ids' do
+      patients = (1..3).map { |id| FHIR::Patient.new(id: id.to_s) }
+      responses = patients.map { |p| { body: [{ type: 'string', element: p.id }].to_json } }
+
+      stub_request(:post, "#{@fhirpath_url}/evaluate")
+        .with(query: hash_including(path: 'Patient.id'))
+        .to_return(*responses)
+
+      assert_equal ['1', '2', '3'], @evaluator.evaluate(patients, 'Patient.id')
+    end
+
+    it 'Should successfully return Element fhir_models' do
+      patients = (1..3).map { |name| FHIR::Patient.new(name: [{ given: [name.to_s] }]) }
+      names = patients.map { |p| p.name[0] }
+      responses = names.map do |name|
+        { body: "[{ \"type\": \"HumanName\", \"element\": #{name.to_json} }]" }
+      end
+
+      stub_request(:post, "#{@fhirpath_url}/evaluate")
+        .with(query: hash_including(path: 'Patient.name'))
+        .to_return(*responses)
+
+      assert(names.all? { |name| name.is_a?(FHIR::HumanName) })
+      assert_equal names, @evaluator.evaluate(patients, 'Patient.name')
+    end
+
+    it 'Should successfully return BackboneElement fhir_models' do
+      patient = FHIR::Patient.new(contact: [{ name: { given: ['1'] } }])
+      contact = patient.contact[0]
+      response = "[{ \"type\": \"Patient.contact\", \"element\": #{contact.to_json} }]"
+
+      stub_request(:post, "#{@fhirpath_url}/evaluate")
+        .with(query: hash_including(path: 'Patient.contact'))
+        .to_return(body: response)
+
+      assert_equal [contact], @evaluator.evaluate(patient, 'Patient.contact')
+    end
+
+    it 'Should successfully post Element fhir_models' do
+      name = FHIR::HumanName.new(given: ['Foo'])
+      response = '[{ "type": "string", "element": "Foo" }]'
+
+      stub_request(:post, "#{@fhirpath_url}/evaluate")
+        .with(query: hash_including(path: 'HumanName.given', type: 'HumanName'), body: name.to_json)
+        .to_return(body: response)
+
+      assert_equal ['Foo'], @evaluator.evaluate(name, 'HumanName.given')
+    end
+
+    it 'Should successfully post BackboneElement fhir_models' do
+      contact = FHIR::Patient::Contact.new(name: { given: ['1'] }, gender: 'male')
+      response = '[{ "type": "code", "element": "male"}]'
+
+      stub_request(:post, "#{@fhirpath_url}/evaluate")
+        .with(query: hash_including(path: 'gender', type: 'Patient.contact'), body: contact.to_json)
+        .to_return(body: response)
+
+      assert_equal ['male'], @evaluator.evaluate(contact, 'gender')
+    end
+  end
+end


### PR DESCRIPTION
[FI-930](https://oncprojectracking.healthit.gov/support/browse/FI-930): SearchParameters that have complicated FHIRPath expressions (e.g. use descendants() or |) cannot be generically processed by Inferno.  Inferno uses the FHIRPath in order to determine the value of the searchParameter to be used in the search and validate that the results returned conform to the value.

This PR creates a `FHIRPathEvaluator` class that posts elements to the FHIRPath endpoint. It also adds two new config options, `fhirpath_evaluator` and `external_fhirpath_evaluator_url`, which are analogous to the `resource_validator` and `external_resource_validator_url` config options. When `fhirpath_evaluator` is set to `external`, POST requests will be made to the FHIRPath endpoint in order to resolve FHIRPath expressions against a given complex datatype.

The goal was to substitute out the logic that was previously `resolve_path` and `resolve_element_from_path` with a more complete FHIRPath solution. This allows us to remove some of the FHIRPath patching (e.g. removing `.as()` and truncating the path) that was done in the sequences. However, one patch that has not been removed is `.where(resolve() ...)` because the external FHIRPath evaluator does not know how to resolve references of the form `[Resource]/[id]`.

~NOTE: This PR requires running [wrapper/FI-931-add-fhirpath-endpoint](https://github.com/inferno-community/fhir-validator-wrapper/pull/19) locally to work.~ UPDATE: this is no longer true; you will just have to re-pull the `master` branch of `f-v-w` and rebuild.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-930
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code