### PR TITLE
Move values_found to inside the patients loop, so we get at least one patient with 2 status values

### DIFF
--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -325,14 +325,12 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
           'patient': @sequence.patient_ids.first,
           '<%= fixed_value_search_param %>': value
         }
-
         body =
-        if @sequence.resolve_element_from_path(@<%= resource_var_name %>, '<%= fixed_value_search_path %>') == value
-          wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json
-        else
-          FHIR::Bundle.new.to_json
-        end
-
+          if @sequence.resolve_element_from_path(@<%= resource_var_name %>, '<%= fixed_value_search_path %>') == value
+            wrap_resources_in_bundle([@<%= resource_var_name %>]).to_json
+          else
+            FHIR::Bundle.new.to_json
+          end
         stub_request(:get, "#{@base_url}/<%= resource_type %>")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1013,7 +1013,7 @@ module Inferno
           #{skip_if_search_not_supported_code(sequence, search_parameters)}
           @#{sequence[:resource].underscore}_ary = {}
           @resources_found = false
-          validated_search_param_variants = false
+          search_query_variants_tested_once = false
           #{values_variable_name} = [#{search_param[:values].map { |val| "'#{val}'" }.join(', ')}]
           patient_ids.each do |patient|
             @#{sequence[:resource].underscore}_ary[patient] = []
@@ -1035,9 +1035,7 @@ module Inferno
               save_delayed_sequence_references(resources_returned, #{sequence[:class_name]}Definitions::DELAYED_REFERENCES)
               validate_reply_entries(resources_returned, search_params)
 
-              #{'test_medication_inclusion(@medication_request_ary[patient], search_params)' if sequence[:resource] == 'MedicationRequest'}
-
-              next if validated_search_param_variants
+              next if search_query_variants_tested_once
               #{get_token_system_search_code(search_parameters, sequence)}
 
               search_params_with_type = search_params.merge('patient': "Patient/\#{patient}")
@@ -1047,7 +1045,10 @@ module Inferno
               assert_bundle_response(reply)
               search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
               assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-              validated_search_param_variants = true
+
+              #{'test_medication_inclusion(@medication_request_ary[patient], search_params)' if sequence[:resource] == 'MedicationRequest'}
+
+              search_query_variants_tested_once = true
 
             end
           end

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1014,9 +1014,9 @@ module Inferno
           #{skip_if_search_not_supported_code(sequence, search_parameters)}
           @#{sequence[:resource].underscore}_ary = {}
           @resources_found = false
-          #{'values_found = 0' if find_two_values}
           #{values_variable_name} = [#{search_param[:values].map { |val| "'#{val}'" }.join(', ')}]
           patient_ids.each do |patient|
+            #{'values_found = 0' if find_two_values}
             @#{sequence[:resource].underscore}_ary[patient] = []
             #{values_variable_name}.each do |val|
               search_params = { 'patient': patient, '#{search_param[:name]}': val }

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['8302-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodyheightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['8302-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodyheightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['8302-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['8310-5']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodytempSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['8310-5']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['8310-5']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodytempSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['29463-7']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['29463-7']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodyweightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['29463-7']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodyweightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['85354-9']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['85354-9']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BpSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['85354-9']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BpSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['9843-4']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310HeadcircumSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['9843-4']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310HeadcircumSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['9843-4']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['8867-4']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310HeartrateSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['8867-4']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310HeartrateSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['8867-4']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['59576-9']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PediatricBmiForAgeSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['59576-9']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['59576-9']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PediatricBmiForAgeSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['77606-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PediatricWeightForHeightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['77606-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['77606-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PediatricWeightForHeightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['9279-1']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310ResprateSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['9279-1']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['9279-1']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310ResprateSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310BodytempSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310BodytempSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310BpSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310BpSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310ResprateSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310ResprateSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310CareplanSequence do
             'patient': @sequence.patient_ids.first,
             'category': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@care_plan, 'CarePlan.category.coding.code') == value
-              wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@care_plan, 'category.coding.code') == value
+              wrap_resources_in_bundle([@care_plan]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/CarePlan")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310CareplanSequence do
             'category': value
           }
           body =
-            if @sequence.resolve_element_from_path(@care_plan, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@care_plan, 'CarePlan.category.coding.code') == value
               wrap_resources_in_bundle([@care_plan]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
             'category': value
           }
           body =
-            if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
               wrap_resources_in_bundle([@diagnostic_report]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
             'patient': @sequence.patient_ids.first,
             'category': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
-              wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+              wrap_resources_in_bundle([@diagnostic_report]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/DiagnosticReport")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
             'category': value
           }
           body =
-            if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
               wrap_resources_in_bundle([@diagnostic_report]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
             'patient': @sequence.patient_ids.first,
             'category': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@diagnostic_report, 'DiagnosticReport.category.coding.code') == value
-              wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
+              wrap_resources_in_bundle([@diagnostic_report]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/DiagnosticReport")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -239,14 +239,12 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
             'patient': @sequence.patient_ids.first,
             'intent': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@medication_request, 'MedicationRequest.intent') == value
-              wrap_resources_in_bundle(@medication_request_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@medication_request, 'intent') == value
+              wrap_resources_in_bundle([@medication_request]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/MedicationRequest")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -240,7 +240,7 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
             'intent': value
           }
           body =
-            if @sequence.resolve_element_from_path(@medication_request, 'intent') == value
+            if @sequence.resolve_element_from_path(@medication_request, 'MedicationRequest.intent') == value
               wrap_resources_in_bundle([@medication_request]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
             'patient': @sequence.patient_ids.first,
             'category': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.category.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'category.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
             'category': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'category.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.category.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -222,14 +222,12 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
             'patient': @sequence.patient_ids.first,
             'code': value
           }
-
           body =
-            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
-              wrap_resources_in_bundle(@observation_ary.values.flatten).to_json
+            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+              wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json
             end
-
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params, headers: @auth_header)
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -223,7 +223,7 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
             'code': value
           }
           body =
-            if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
+            if @sequence.resolve_element_from_path(@observation, 'Observation.code.coding.code') == value
               wrap_resources_in_bundle([@observation]).to_json
             else
               FHIR::Bundle.new.to_json

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -158,6 +158,7 @@ module Inferno
         skip_if_known_search_not_supported('CarePlan', ['patient', 'category'])
         @care_plan_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         category_val = ['assess-plan']
         patient_ids.each do |patient|
           @care_plan_ary[patient] = []
@@ -181,6 +182,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310CareplanSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
@@ -195,8 +198,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'CarePlan', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -158,7 +158,6 @@ module Inferno
         skip_if_known_search_not_supported('CarePlan', ['patient', 'category'])
         @care_plan_ary = {}
         @resources_found = false
-
         category_val = ['assess-plan']
         patient_ids.each do |patient|
           @care_plan_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -158,7 +158,7 @@ module Inferno
         skip_if_known_search_not_supported('CarePlan', ['patient', 'category'])
         @care_plan_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         category_val = ['assess-plan']
         patient_ids.each do |patient|
           @care_plan_ary[patient] = []
@@ -182,7 +182,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310CareplanSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -198,7 +198,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'CarePlan', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -140,7 +140,7 @@ module Inferno
         skip_if_known_search_not_supported('CareTeam', ['patient', 'status'])
         @care_team_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         status_val = ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error']
         patient_ids.each do |patient|
           @care_team_ary[patient] = []
@@ -162,7 +162,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310CareteamSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
             reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params_with_type)
@@ -171,7 +171,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'CareTeam', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -140,9 +140,9 @@ module Inferno
         skip_if_known_search_not_supported('CareTeam', ['patient', 'status'])
         @care_team_ary = {}
         @resources_found = false
-        values_found = 0
         status_val = ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error']
         patient_ids.each do |patient|
+          values_found = 0
           @care_team_ary[patient] = []
           status_val.each do |val|
             search_params = { 'patient': patient, 'status': val }

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -176,7 +176,6 @@ module Inferno
         skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
-
         category_val = ['LAB']
         patient_ids.each do |patient|
           @diagnostic_report_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -176,6 +176,7 @@ module Inferno
         skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         category_val = ['LAB']
         patient_ids.each do |patient|
           @diagnostic_report_ary[patient] = []
@@ -199,6 +200,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310DiagnosticreportLabSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
@@ -213,8 +216,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -176,7 +176,7 @@ module Inferno
         skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         category_val = ['LAB']
         patient_ids.each do |patient|
           @diagnostic_report_ary[patient] = []
@@ -200,7 +200,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310DiagnosticreportLabSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -216,7 +216,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -176,7 +176,6 @@ module Inferno
         skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
-
         category_val = ['LP29684-5', 'LP29708-2', 'LP7839-6']
         patient_ids.each do |patient|
           @diagnostic_report_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -176,6 +176,7 @@ module Inferno
         skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         category_val = ['LP29684-5', 'LP29708-2', 'LP7839-6']
         patient_ids.each do |patient|
           @diagnostic_report_ary[patient] = []
@@ -199,6 +200,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310DiagnosticreportNoteSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
@@ -213,8 +216,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -176,7 +176,7 @@ module Inferno
         skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         category_val = ['LP29684-5', 'LP29708-2', 'LP7839-6']
         patient_ids.each do |patient|
           @diagnostic_report_ary[patient] = []
@@ -200,7 +200,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310DiagnosticreportNoteSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -216,7 +216,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -193,7 +193,7 @@ module Inferno
         skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent'])
         @medication_request_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         intent_val = ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option']
         patient_ids.each do |patient|
           @medication_request_ary[patient] = []
@@ -217,9 +217,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310MedicationrequestSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            test_medication_inclusion(@medication_request_ary[patient], search_params)
-
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
             reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params_with_type)
@@ -230,7 +228,10 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            test_medication_inclusion(@medication_request_ary[patient], search_params)
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -193,7 +193,6 @@ module Inferno
         skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent'])
         @medication_request_ary = {}
         @resources_found = false
-
         intent_val = ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option']
         patient_ids.each do |patient|
           @medication_request_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -193,6 +193,7 @@ module Inferno
         skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent'])
         @medication_request_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         intent_val = ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option']
         patient_ids.each do |patient|
           @medication_request_ary[patient] = []
@@ -216,6 +217,10 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310MedicationrequestSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            test_medication_inclusion(@medication_request_ary[patient], search_params)
+
+            next if validated_search_param_variants
+
             search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
             reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params_with_type)
 
@@ -225,9 +230,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            test_medication_inclusion(@medication_request_ary[patient], search_params)
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         category_val = ['laboratory']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310ObservationLabSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         @observation_ary = {}
         @resources_found = false
-
         category_val = ['laboratory']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         category_val = ['laboratory']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310ObservationLabSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['2708-6', '59408-5']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -173,7 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['2708-6', '59408-5']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -197,7 +197,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PulseOximetrySequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -213,7 +213,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -173,6 +173,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['2708-6', '59408-5']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -196,6 +197,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PulseOximetrySequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -210,8 +213,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -177,6 +177,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
+        validated_search_param_variants = false
         code_val = ['72166-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -200,6 +201,8 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310SmokingstatusSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            next if validated_search_param_variants
+
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
@@ -214,8 +217,7 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            break
+            validated_search_param_variants = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -177,7 +177,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['72166-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -177,7 +177,7 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-        validated_search_param_variants = false
+        search_query_variants_tested_once = false
         code_val = ['72166-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []
@@ -201,7 +201,7 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310SmokingstatusSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
-            next if validated_search_param_variants
+            next if search_query_variants_tested_once
 
             value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -217,7 +217,8 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-            validated_search_param_variants = true
+
+            search_query_variants_tested_once = true
           end
         end
         skip_if_not_found(resource_type: 'Observation', delayed: false)


### PR DESCRIPTION
This PR moves the values_found counter in the US Core search tests into the patient loop, so we look for at least two statuses for each resource type for each patient. This is needed to allow for the multipleOr tests that occur later on in the test suites.
