### PR TITLE
Update test patients on reference server

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -144,7 +144,7 @@ presets:
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    patient_ids: "76,185"
+    patient_ids: "85,355"
   localhost_311_reference_server:
     inferno_uri: http://localhost:4567
     name: Inferno Reference Server (USCore v3.1.1)
@@ -153,4 +153,4 @@ presets:
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    patient_ids: "76,185"
+    patient_ids: "85,355"


### PR DESCRIPTION
Update presets to inferno.healthit.gov to be the right patient ids based on the most recent data set.