### PR TITLE
add document operation test

### DIFF
--- a/lib/modules/ips/ips_compositionuvips_sequence.rb
+++ b/lib/modules/ips/ips_compositionuvips_sequence.rb
@@ -44,6 +44,46 @@ module Inferno
         skip 'No resource found from Read test' unless @resource_found.present?
         test_resources_against_profile('Composition', 'http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips')
       end
+
+      test :document_operator do
+        metadata do
+          id '03'
+          name 'Server returns a fully bundled document from a Composition resource'
+          link 'https://www.hl7.org/fhir/composition-operation-document.html'
+          description %(
+            This test will perform the $document operation on the chosen composition resource with the persist option on. 
+            It will verify that all referenced resources in the composition are in the document bundle and that we are able to retrieve the bundle after it's generated.
+          )
+          versions :r4
+        end
+
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        references_in_composition = []
+        walk_resource(@resource_found) do |value, meta, _path|
+          next if meta['type'] != 'Reference'
+          next if value.reference.blank?
+
+          references_in_composition << value
+        end
+        document_request_string = "Composition/#{@resource_found.id}/$document?persist=true"
+        document_response = @client.get(document_request_string)
+
+        assert_response_ok document_response
+        assert_valid_json(document_response.body)
+        bundle = FHIR.from_contents(document_response.body)
+
+        bundled_resources = bundle.entry.map(&:resource)
+        references_in_composition.each do |reference|
+          if reference.relative?
+            resource_class = reference.resource_class
+            resource_id = reference.reference.split('/').last
+            assert(bundled_resources.any? { |resource| resource.class == resource_class && resource.id == resource_id })
+          else
+            # don't know how to handle this yet
+          end
+        end
+      end
     end
   end
 end

--- a/lib/modules/ips/test/fixtures/composition.json
+++ b/lib/modules/ips/test/fixtures/composition.json
@@ -1,0 +1,167 @@
+{
+  "resourceType": "Composition",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<p>Consultation note for Henry Levin the 7th</p>\n\t\t\t<p>Managed by Good Health Clinic</p>\n\t\t</div>"
+  },
+  "identifier": {
+    "system": "http://healthintersections.com.au/test",
+    "value": "1"
+  },
+  "status": "final",
+  "type": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "11488-4",
+        "display": "Consult note"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "LP173421-1",
+          "display": "Report"
+        }
+      ]
+    }
+  ],
+  "subject": {
+    "reference": "Patient/xcda",
+    "display": "Henry Levin the 7th"
+  },
+  "encounter": {
+    "reference": "Encounter/xcda"
+  },
+  "date": "2012-01-04T09:10:14Z",
+  "author": [
+    {
+      "reference": "Practitioner/xcda-author",
+      "display": "Harold Hippocrates, MD"
+    }
+  ],
+  "title": "Consultation Note",
+  "confidentiality": "N",
+  "attester": [
+    {
+      "mode": "legal",
+      "time": "2012-01-04T09:10:14Z",
+      "party": {
+        "reference": "Practitioner/xcda-author",
+        "display": "Harold Hippocrates, MD"
+      }
+    }
+  ],
+  "custodian": {
+    "reference": "Organization/2.16.840.1.113883.19.5",
+    "display": "Good Health Clinic"
+  },
+  "relatesTo": [
+    {
+      "code": "replaces",
+      "targetReference": {
+        "reference": "Composition/old-example"
+      }
+    },
+    {
+      "code": "appends",
+      "targetIdentifier": {
+        "system": "http://example.org/fhir/NamingSystem/document-ids",
+        "value": "ABC123"
+      }
+    }
+  ],
+  "event": [
+    {
+      "code": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "HEALTHREC",
+              "display": "health record"
+            }
+          ]
+        }
+      ],
+      "period": {
+        "start": "2010-07-18",
+        "end": "2012-11-12"
+      },
+      "detail": [
+        {
+          "reference": "Observation/example"
+        }
+      ]
+    }
+  ],
+  "section": [
+    {
+      "title": "History of present illness",
+      "code": {
+        "coding": [
+          {
+            "system": "http://loinc.org",
+            "code": "11348-0",
+            "display": "History of past illness Narrative"
+          }
+        ]
+      },
+      "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t\t<table>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>\n\t\t\t\t\t\t\t<b>Code</b>\n\t\t\t\t\t\t</td>\n\t\t\t\t\t\t<td>\n\t\t\t\t\t\t\t<b>Date</b>\n\t\t\t\t\t\t</td>\n\t\t\t\t\t\t<td>\n\t\t\t\t\t\t\t<b>Type</b>\n\t\t\t\t\t\t</td>\n\t\t\t\t\t\t<td>\n\t\t\t\t\t\t\t<b>BodySite</b>\n\t\t\t\t\t\t</td>\n\t\t\t\t\t\t<td>\n\t\t\t\t\t\t\t<b>Severity</b>\n\t\t\t\t\t\t</td>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Stroke</td>\n\t\t\t\t\t\t<td>2010-07-18</td>\n\t\t\t\t\t\t<td>Diagnosis</td>\n\t\t\t\t\t\t<td/>\n\t\t\t\t\t\t<td/>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Burnt Ear</td>\n\t\t\t\t\t\t<td>2012-05-24</td>\n\t\t\t\t\t\t<td>Diagnosis</td>\n\t\t\t\t\t\t<td>Left Ear</td>\n\t\t\t\t\t\t<td/>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Asthma</td>\n\t\t\t\t\t\t<td>2012-11-12</td>\n\t\t\t\t\t\t<td>Finding</td>\n\t\t\t\t\t\t<td/>\n\t\t\t\t\t\t<td>Mild</td>\n\t\t\t\t\t</tr>\n\t\t\t\t</table>\n\t\t\t</div>"
+      },
+      "mode": "snapshot",
+      "orderedBy": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/list-order",
+            "code": "event-date",
+            "display": "Sorted by Event Date"
+          }
+        ]
+      },
+      "entry": [
+        {
+          "reference": "Condition/stroke"
+        },
+        {
+          "reference": "Condition/example"
+        },
+        {
+          "reference": "Condition/example2"
+        }
+      ]
+    },
+    {
+      "title": "History of family member diseases",
+      "code": {
+        "coding": [
+          {
+            "system": "http://loinc.org",
+            "code": "10157-6",
+            "display": "History of family member diseases Narrative"
+          }
+        ]
+      },
+      "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t\t<p>History of family member diseases - not available</p>\n\t\t\t</div>"
+      },
+      "mode": "snapshot",
+      "emptyReason": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/list-empty-reason",
+            "code": "withheld",
+            "display": "Information Withheld"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/lib/modules/ips/test/fixtures/document_response.json
+++ b/lib/modules/ips/test/fixtures/document_response.json
@@ -1,0 +1,60 @@
+{
+  "resourceType": "Bundle",
+  "type": "document",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "xcda"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "xcda"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "xcda-author"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Composition",
+        "id": "old-example"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "example"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Condition",
+        "id": "stroke"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Condition",
+        "id": "example"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Condition",
+        "id": "example2"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "2.16.840.1.113883.19.5"
+      }
+    }
+  ]
+}

--- a/lib/modules/ips/test/ips_composition_sequence_test.rb
+++ b/lib/modules/ips/test/ips_composition_sequence_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::IpsCompositionuvipsSequence do
+  before do
+    @sequence_class = Inferno::Sequence::IpsCompositionuvipsSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::TestingInstance.create(url: @base_url, token: @token, selected_module: 'ips')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @composition_resource = FHIR.from_contents(load_fixture(:composition))
+    @document_response = FHIR.from_contents(load_fixture(:document_response))
+  end
+
+  describe 'Document operation on composition' do
+    before do
+      @test = @sequence_class[:document_operator]
+      @sequence = @sequence_class.new(@instance, @client)
+      @sequence.instance_variable_set(:'@resource_found', @composition_resource)
+    end
+
+    it 'fails if search fails' do
+      stub_request(:get, "#{@base_url}/Composition/#{@composition_resource.id}/$document?persist=true")
+        .to_return(status: 401)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'Bad response code: expected 200, 201, but found 401. ', exception.message
+    end
+
+    it 'fails if a referenced resource is missing' do
+      @document_response.entry.pop
+      stub_request(:get, "#{@base_url}/Composition/#{@composition_resource.id}/$document?persist=true")
+        .to_return(status: 200, body: @document_response.to_json)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'succeeds if all referenced resources are returned' do
+      stub_request(:get, "#{@base_url}/Composition/#{@composition_resource.id}/$document?persist=true")
+        .to_return(status: 200, body: @document_response.to_json)
+
+      @sequence.run_test(@test)
+    end
+  end
+end


### PR DESCRIPTION
This adds a test for the $document operation on composition. It performs it on the given composition resource and checks if all the referenced resources in it are contained in the bundle returned. I'm not sure how to handle absolute references right now, but I made this PR to have something to test for the connectathon