### PR TITLE
Fix IG Resource Validator Loading

### DIFF
--- a/lib/app/ext/fhir_models.rb
+++ b/lib/app/ext/fhir_models.rb
@@ -31,7 +31,7 @@ end
 module InfernoJson
   def from_json(json)
     resource = super(json)
-    resource.source_text = json
+    resource&.source_text = json
     resource
   end
 end
@@ -41,7 +41,7 @@ end
 module InfernoXml
   def from_xml(xml)
     resource = super(xml)
-    resource.source_text = xml
+    resource&.source_text = xml
     resource
   end
 end

--- a/lib/app/utils/validation.rb
+++ b/lib/app/utils/validation.rb
@@ -29,6 +29,8 @@ module Inferno
       json = File.read(definition)
       version = VERSION_MAP[JSON.parse(json)['fhirVersion']]
       resource = get_resource(json, version)
+      next unless resource
+
       DEFINITIONS[resource.url] = resource
       if resource.resourceType == 'StructureDefinition'
         profiled_type = resource.snapshot.element.first.path # will this always be the first?


### PR DESCRIPTION
A recent PR added a monkey patch to `fhir_models` which caused an exception when trying to load resources into a package. For example if a `package.json` is in the resources directory for an IG then it will fail. This breaks loading resources for an IG like IPS