### PR TITLE
Update version file.

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Inferno
-  VERSION = '2.11.0'
+  VERSION = '2.12.0'
 end


### PR DESCRIPTION
Missed updating the version file in v2.12.0.  Since this is community, and it is only really 'informational' for the user, I don't think it is a huge deal that our release doesn't reflect it, but if there is an easy way to fix the tags we can give it a shot (probably not).  We could alternatively do a quick v2.12.1 release that updates it again?