### PR TITLE
Prefill bearer token on reference server for ease of use.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -145,3 +145,4 @@ presets:
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     patient_ids: "85,355"
+    token: SAMPLE_TOKEN


### PR DESCRIPTION
# Summary
We recently upgraded our reference server to allow users to preconfigure a static bearer token that always work.  Update the config to prefill that for the reference server for ease of use purposes.  Note that this will technically not work until the new reference server is deployed, but since it isn't prefilled now anyhow, this doesn't really hurt things.

See https://github.com/onc-healthit/inferno.healthit.gov/pull/71

## New behavior

Bearer token for single patient api tests will be prefilled for localhost us core v3.1.1 tests against https://inferno.healthit.gov/reference-server.   Note that it won't work on the currently deployed 