### PR TITLE
Update so that fhir url can include $bulk-publish

### DIFF
--- a/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
+++ b/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
@@ -13,7 +13,7 @@ module Inferno
       requires :manifest_url, :manifest_since
 
       MAX_RECENT_LINE_SIZE = 500
-      SPEC_URL = 'https://github.com/smart-on-fhir/smart-scheduling-links/blob/master/specification.md#location-file'
+      SPEC_URL = 'https://github.com/smart-on-fhir/smart-scheduling-links/blob/master/specification.md'
 
       SCHEDULING_URIS = {
         "Address": 'http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location-address',
@@ -182,18 +182,6 @@ module Inferno
 
         # Otherwise, fall back to the base profile finder
         Inferno::ValidationUtil.guess_profile(resource, version)
-      end
-
-      def predefined_device_type?(resource)
-        return false if resource.nil?
-
-        return true if @instance.bulk_device_types_in_group.blank?
-
-        expected_types = Set.new(@instance.bulk_device_types_in_group.split(',').map(&:strip))
-
-        actual_types = resource&.type&.coding&.select { |coding| coding.system.nil? || coding.system == 'http://snomed.info/sct' }&.map { |coding| coding.code }
-
-        (expected_types & actual_types).any?
       end
 
       def process_profile_definition(profile_definitions, profile, resource, resource_validation_errors)
@@ -427,10 +415,14 @@ module Inferno
           versions :r4
         end
 
+        @instance.url.chomp!('$bulk-publish')
+
         @instance.manifest_url = @instance.url.chomp('/') + '/$bulk-publish' if @instance.manifest_url.empty?
 
         assert @instance.manifest_url.ends_with?('$bulk-publish'), 'Manifest file must end in $bulk-publish'
         assert_valid_http_uri @instance.manifest_url
+
+        pass "Will attempt to access manifest at #{@instance.manifest_url}"
       end
 
       test :manifest_downloadable do

--- a/lib/modules/smart_scheduling_links_module.yml
+++ b/lib/modules/smart_scheduling_links_module.yml
@@ -1,5 +1,5 @@
 name: smart_scheduling_links
-title: SMART Scheduling Links
+title: SMART Scheduling Links (Draft Tests)
 resource_path: smart_scheduling_links
 description : SMART Scheduling Links (Draft; 1 April)
 fhir_version: r4
@@ -8,12 +8,12 @@ test_sets:
   ad_hoc_testing:
     view: default
     tests:
-      - name: SMART Scheduling Links
+      - name: SMART Scheduling Links - Slot Publisher Tests
         sequences:
         - SmartSchedulingLinksBasicSequence
 sequence_requirements:
   manifest_url:
-    label: Manifest URL (only provide if not served from a FHIR-compliant server)
+    label: Non-standard Manifest URL (optional - only provide if URL dos not end if $bulk-publish)
     description: If your manifest URL does not end in $bulk-publish, you may fill it in here.  Otherwise leave this blank and the tests will assume it is located at {fhir_url}/$bulk-publish.
   manifest_since:
     label: Manifest ?_since={} parameter (optional)


### PR DESCRIPTION
# Summary

The current version of Inferno currently requires users to paste in a 'true' FHIR URL, but the way the IG is written makes it seem like the logical starting point should be {fhir_url}/$bulk-publish.  This just auto-removes $bulk-publish from the FHIR URL in the first test if someone pasts that in to avoid that confusion..

Also, some minor wording updates.

## New behavioru

If you paste in a url ending in $bulk-publish the tests should run properly.

## Code changes

Very minor update to first test.

## Testing guidance

Tests to both of the following URLs should now properly download the manifest:
* https://raw.githubusercontent.com/smart-on-fhir/smart-scheduling-links/master/examples
* https://raw.githubusercontent.com/smart-on-fhir/smart-scheduling-links/master/examples/$bulk-publish
