### PR TITLE
Allow custom header and fix vtrx identifier test.

### DIFF
--- a/lib/modules/smart_scheduling_links_module.yml
+++ b/lib/modules/smart_scheduling_links_module.yml
@@ -18,3 +18,6 @@ sequence_requirements:
   manifest_since:
     label: Manifest ?_since={} parameter (optional)
     description:  If provided an ISO8601 date, tests will reissue request for manifest with this value and expect a non-zero subset of output files to be returned.
+  custom_header:
+    label: Custom HTTP header (optional)
+    description: "If necessary, provide a custom HTTP header in the form 'header: value'"


### PR DESCRIPTION
# Summary
Some servers (particularly sandbox servers) require a custom header.  This IG does allow for custom security measures, which often are represented as custom headers.  However, it is discouraed, so we flag it as a warning.

## New behavior

You can now add a custom header and it will be sent in all requests.

## Code changes

Added input box and code to send them as a header.  Also included a minor fix on the vtrx test.

## Testing guidance

Fill out customer header field and you will see the custom header being sent.
