### PR TITLE
Remove Schedule extension-validation code in favor of validating it through the HL7 validator, and update one of the StructureDefinitions

### DIFF
--- a/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
+++ b/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
@@ -776,16 +776,6 @@ module Inferno
                 end
             @invalid_service_type_count += 1
           end
-
-          @invalid_vaccine_product_count += 1 if resource.extension.nil? || resource.extension.none? do |extension|
-            extension.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-product' &&
-            !extension.valueCoding.nil?
-          end
-
-          @invalid_vaccine_dose_number_count += 1 if resource.extension.nil? || resource.extension.none? do |extension|
-            extension.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-dose' &&
-            extension.valueInteger.is_a?(Integer)
-          end
         end
       end
 

--- a/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
+++ b/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
@@ -782,7 +782,7 @@ module Inferno
             !extension.valueCoding.nil?
           end
 
-          @invalid_vaccine_dose_number_count += 1 if resource.extension.nil? || resource.extension.none? do |_product|
+          @invalid_vaccine_dose_number_count += 1 if resource.extension.nil? || resource.extension.none? do |extension|
             extension.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-dose' &&
             extension.valueInteger.is_a?(Integer)
           end

--- a/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
+++ b/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
@@ -776,6 +776,16 @@ module Inferno
                 end
             @invalid_service_type_count += 1
           end
+
+          @invalid_vaccine_product_count += 1 if resource.extension.nil? || resource.extension.none? do |extension|
+            extension.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-product' &&
+            !extension.valueCoding.nil?
+          end
+
+          @invalid_vaccine_dose_number_count += 1 if resource.extension.nil? || resource.extension.none? do |extension|
+            extension.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-dose' &&
+            extension.valueInteger.is_a?(Integer)
+          end
         end
       end
 

--- a/resources/smart_scheduling_links/ImplementationGuide-smart.scheduling.links.json
+++ b/resources/smart_scheduling_links/ImplementationGuide-smart.scheduling.links.json
@@ -13,6 +13,13 @@
     "resource": [
       {
         "reference": {
+          "reference": "StructureDefinition/c19-service-codeable-concept"
+        },
+        "name": "C19ServiceCodeableConcept",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "StructureDefinition/vaccine-address"
         },
         "name": "VaccineAddress",

--- a/resources/smart_scheduling_links/StructureDefinition-c19-service-codeable-concept.json
+++ b/resources/smart_scheduling_links/StructureDefinition-c19-service-codeable-concept.json
@@ -1,0 +1,436 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "c19-service-codeable-concept",
+  "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/c19-service-codeable-concept",
+  "version": "0.1.0",
+  "name": "C19ServiceCodeableConcept",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "v2",
+      "uri": "http://hl7.org/v2",
+      "name": "HL7 v2 Mapping"
+    },
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    },
+    {
+      "identity": "orim",
+      "uri": "http://hl7.org/orim",
+      "name": "Ontological RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "type": "CodeableConcept",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/CodeableConcept",
+  "derivation": "constraint",
+  "snapshot": {
+    "element": [
+      {
+        "id": "CodeableConcept",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "normative"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
+            "valueCode": "4.0.0"
+          }
+        ],
+        "path": "CodeableConcept",
+        "short": "Concept - reference to a terminology or just  text",
+        "definition": "A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.",
+        "comment": "Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination.",
+        "min": 0,
+        "max": "*",
+        "base": {
+          "path": "CodeableConcept",
+          "min": 0,
+          "max": "*"
+        },
+        "condition": [
+          "ele-1"
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          },
+          {
+            "identity": "v2",
+            "map": "CE/CNE/CWE"
+          },
+          {
+            "identity": "rim",
+            "map": "CD"
+          },
+          {
+            "identity": "orim",
+            "map": "fhir:CodeableConcept rdfs:subClassOf dt:CD"
+          }
+        ]
+      },
+      {
+        "id": "CodeableConcept.id",
+        "path": "CodeableConcept.id",
+        "representation": [
+          "xmlAttr"
+        ],
+        "short": "Unique id for inter-element referencing",
+        "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Element.id",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "http://hl7.org/fhirpath/System.String",
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "string"
+              }
+            ]
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "CodeableConcept.extension",
+        "path": "CodeableConcept.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "description": "Extensions are always sliced by (at least) url",
+          "rules": "open"
+        },
+        "short": "Additional content defined by implementations",
+        "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+        "alias": [
+          "extensions",
+          "user content"
+        ],
+        "min": 0,
+        "max": "*",
+        "base": {
+          "path": "Element.extension",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          },
+          {
+            "key": "ext-1",
+            "severity": "error",
+            "human": "Must have either extensions or value[x], not both",
+            "expression": "extension.exists() != value.exists()",
+            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "CodeableConcept.coding",
+        "path": "CodeableConcept.coding",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "pattern",
+              "path": "$this"
+            }
+          ],
+          "rules": "open",
+          "description": "Slice based on Coding"
+        },
+        "short": "Code defined by a terminology system",
+        "definition": "A reference to a code defined by a terminology system.",
+        "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+        "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+        "min": 2,
+        "max": "*",
+        "base": {
+          "path": "CodeableConcept.coding",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Coding"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "C*E.1-8, C*E.10-22"
+          },
+          {
+            "identity": "rim",
+            "map": "union(., ./translation)"
+          },
+          {
+            "identity": "orim",
+            "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+          }
+        ]
+      },
+      {
+        "id": "CodeableConcept.coding:immunizationAppointment",
+        "path": "CodeableConcept.coding",
+        "sliceName": "immunizationAppointment",
+        "short": "Code defined by a terminology system",
+        "definition": "A reference to a code defined by a terminology system.",
+        "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+        "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "CodeableConcept.coding",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Coding"
+          }
+        ],
+        "patternCoding": {
+          "code": "57",
+          "system": "http://terminology.hl7.org/CodeSystem/service-type"
+        },
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "C*E.1-8, C*E.10-22"
+          },
+          {
+            "identity": "rim",
+            "map": "union(., ./translation)"
+          },
+          {
+            "identity": "orim",
+            "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+          }
+        ]
+      },
+      {
+        "id": "CodeableConcept.coding:c19ImmunizationAppointment",
+        "path": "CodeableConcept.coding",
+        "sliceName": "c19ImmunizationAppointment",
+        "short": "Code defined by a terminology system",
+        "definition": "A reference to a code defined by a terminology system.",
+        "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+        "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "CodeableConcept.coding",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Coding"
+          }
+        ],
+        "patternCoding": {
+          "code": "covid19-immunization",
+          "system": "http://fhir-registry.smarthealthit.org/CodeSystem/service-type"
+        },
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "C*E.1-8, C*E.10-22"
+          },
+          {
+            "identity": "rim",
+            "map": "union(., ./translation)"
+          },
+          {
+            "identity": "orim",
+            "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+          }
+        ]
+      },
+      {
+        "id": "CodeableConcept.text",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+            "valueBoolean": true
+          }
+        ],
+        "path": "CodeableConcept.text",
+        "short": "Plain text representation of the concept",
+        "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+        "comment": "Very often the text is the same as a displayName of one of the codings.",
+        "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "CodeableConcept.text",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "string"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "C*E.9. But note many systems use C*E.2 for this"
+          },
+          {
+            "identity": "rim",
+            "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+          },
+          {
+            "identity": "orim",
+            "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+          }
+        ]
+      }
+    ]
+  },
+  "differential": {
+    "element": [
+      {
+        "id": "CodeableConcept.coding",
+        "path": "CodeableConcept.coding",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "pattern",
+              "path": "$this"
+            }
+          ],
+          "rules": "open",
+          "description": "Slice based on Coding"
+        },
+        "min": 2
+      },
+      {
+        "id": "CodeableConcept.coding:immunizationAppointment",
+        "path": "CodeableConcept.coding",
+        "sliceName": "immunizationAppointment",
+        "min": 1,
+        "max": "1",
+        "patternCoding": {
+          "code": "57",
+          "system": "http://terminology.hl7.org/CodeSystem/service-type"
+        }
+      },
+      {
+        "id": "CodeableConcept.coding:c19ImmunizationAppointment",
+        "path": "CodeableConcept.coding",
+        "sliceName": "c19ImmunizationAppointment",
+        "min": 1,
+        "max": "1",
+        "patternCoding": {
+          "code": "covid19-immunization",
+          "system": "http://fhir-registry.smarthealthit.org/CodeSystem/service-type"
+        }
+      }
+    ]
+  }
+}

--- a/resources/smart_scheduling_links/StructureDefinition-vaccine-product.json
+++ b/resources/smart_scheduling_links/StructureDefinition-vaccine-product.json
@@ -289,7 +289,7 @@
         "isSummary": false,
         "binding": {
           "strength": "required",
-          "valueSet": "http://hl7.org/fhir/sid/cvx"
+          "valueSet": "http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/vaccination-credential-vaccine-value-set"
         },
         "mapping": [
           {
@@ -338,7 +338,7 @@
         "max": "1",
         "binding": {
           "strength": "required",
-          "valueSet": "http://hl7.org/fhir/sid/cvx"
+          "valueSet": "http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/vaccination-credential-vaccine-value-set"
         }
       }
     ]

--- a/resources/smart_scheduling_links/StructureDefinition-vaccine-schedule.json
+++ b/resources/smart_scheduling_links/StructureDefinition-vaccine-schedule.json
@@ -105,6 +105,20 @@
             "expression": "text.`div`.exists()",
             "xpath": "exists(f:text/h:div)",
             "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+          },
+          {
+            "key": "vaccine-schedule-1",
+            "severity": "warning",
+            "human": "Schedule should have an extension with the vaccine-product URL",
+            "expression": "extension.where(url.contains('vaccine-product')).exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-schedule"
+          },
+          {
+            "key": "vaccine-schedule-2",
+            "severity": "warning",
+            "human": "Schedule should have an extension with the vaccine-dose URL",
+            "expression": "extension.where(url.contains('vaccine-dose')).exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-schedule"
           }
         ],
         "isModifier": false,
@@ -684,6 +698,16 @@
       {
         "id": "Schedule.serviceType",
         "path": "Schedule.serviceType",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "profile",
+              "path": "$this"
+            }
+          ],
+          "rules": "open",
+          "description": "Slice based on whether the CodeableConcept has 'C19 Immunization Nature'"
+        },
         "short": "Specific service",
         "definition": "The specific service that is to be performed during this appointment.",
         "min": 1,
@@ -696,6 +720,60 @@
         "type": [
           {
             "code": "CodeableConcept"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "binding": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "service-type"
+            }
+          ],
+          "strength": "example",
+          "valueSet": "http://hl7.org/fhir/ValueSet/service-type"
+        },
+        "mapping": [
+          {
+            "identity": "w5",
+            "map": "FiveWs.class"
+          },
+          {
+            "identity": "ical",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "Schedule.serviceType:c19Service",
+        "path": "Schedule.serviceType",
+        "sliceName": "c19Service",
+        "short": "Specific service",
+        "definition": "The specific service that is to be performed during this appointment.",
+        "min": 1,
+        "max": "*",
+        "base": {
+          "path": "Schedule.serviceType",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "CodeableConcept",
+            "profile": [
+              "http://fhir-registry.smarthealthit.org/StructureDefinition/c19-service-codeable-concept"
+            ]
           }
         ],
         "constraint": [
@@ -907,6 +985,26 @@
   "differential": {
     "element": [
       {
+        "id": "Schedule",
+        "path": "Schedule",
+        "constraint": [
+          {
+            "key": "vaccine-schedule-1",
+            "severity": "warning",
+            "human": "Schedule should have an extension with the vaccine-product URL",
+            "expression": "extension.where(url.contains('vaccine-product')).exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-schedule"
+          },
+          {
+            "key": "vaccine-schedule-2",
+            "severity": "warning",
+            "human": "Schedule should have an extension with the vaccine-dose URL",
+            "expression": "extension.where(url.contains('vaccine-dose')).exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-schedule"
+          }
+        ]
+      },
+      {
         "id": "Schedule.extension",
         "path": "Schedule.extension",
         "slicing": {
@@ -955,7 +1053,32 @@
       {
         "id": "Schedule.serviceType",
         "path": "Schedule.serviceType",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "profile",
+              "path": "$this"
+            }
+          ],
+          "rules": "open",
+          "description": "Slice based on whether the CodeableConcept has 'C19 Immunization Nature'"
+        },
         "min": 1
+      },
+      {
+        "id": "Schedule.serviceType:c19Service",
+        "path": "Schedule.serviceType",
+        "sliceName": "c19Service",
+        "min": 1,
+        "max": "*",
+        "type": [
+          {
+            "code": "CodeableConcept",
+            "profile": [
+              "http://fhir-registry.smarthealthit.org/StructureDefinition/c19-service-codeable-concept"
+            ]
+          }
+        ]
       },
       {
         "id": "Schedule.actor",


### PR DESCRIPTION
# Summary
* Removes some buggy extension validation code in the `Schedule` test for SMART Scheduling Links. No longer needed, as the presence and format of the extensions is now tested through rules on `Schedule` in the profiles supplied to the validator.
* Update the profiles supplied to the validator.

## New behavior
* No longer test for presence of `vaccine-product` and `vaccine-dose` extensions on `Schedule` through the module code
* Add rules with a warning binding strength to the `Schedule` StructureDefinition checking for the presence of at least 1 of each extension
* Add Josh's slices on serviceType, as listed here: https://github.com/inferno-community/fsh-smart-scheduling-links/pull/6

## Code changes
* Remove code testing for presence of `vaccine-product` and `vaccine-dose` extensions
* Update `resources/smart_scheduling_links` structureDefinitions

## Testing guidance
* Test `smart_scheduling_basic` tests against Josh's Github manifest (`https://raw.githubusercontent.com/smart-on-fhir/smart-scheduling-links/master/examples/`), and ensure SLB-13 doesn't have a purple error any more.
* Bonus: test against a dataset that _doesn't_ have the recommended extensions on `Schedule` objects, and ensure you get a validation warning that the extensions are missing
* Bonus: test against a dataset that has a `Schedule` object that doesn't have a `serviceType` elements with two codings (one with `http://terminology.hl7.org/CodeSystem/service-type#57`, and one with `http://fhir-registry.smarthealthit.org/CodeSystem/service-type#covid19-immunization`)