### PR TITLE
FI-1206 use tx.fhir.org

### DIFF
--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -51,7 +51,7 @@ module Inferno
       information = []
 
       issues.each do |iss|
-        if iss.severity == 'information' || iss.code == 'code-invalid' || ISSUE_DETAILS_FILTER.any? { |filter| filter.match?(iss&.details&.text) }
+        if iss.severity == 'information' || ISSUE_DETAILS_FILTER.any? { |filter| filter.match?(iss&.details&.text) }
           information << issue_message(iss)
         elsif iss.severity == 'warning'
           warnings << issue_message(iss)

--- a/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
@@ -143,47 +143,6 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Location', delayed: true)
         test_resources_against_profile('Location')
-        bindings = USCore311LocationSequenceDefinitions::BINDINGS
-        invalid_binding_messages = []
-        invalid_binding_resources = Set.new
-        bindings.select { |binding_def| binding_def[:strength] == 'required' }.each do |binding_def|
-          begin
-            invalid_bindings = resources_with_invalid_binding(binding_def, @location_ary)
-          rescue Inferno::Terminology::UnknownValueSetException => e
-            warning do
-              assert false, e.message
-            end
-            invalid_bindings = []
-          end
-          invalid_bindings.each { |invalid| invalid_binding_resources << "#{invalid[:resource]&.resourceType}/#{invalid[:resource].id}" }
-          invalid_binding_messages.concat(invalid_bindings.map { |invalid| invalid_binding_message(invalid, binding_def) })
-        end
-        assert invalid_binding_messages.blank?, "#{invalid_binding_messages.count} invalid required #{'binding'.pluralize(invalid_binding_messages.count)}" \
-        " found in #{invalid_binding_resources.count} #{'resource'.pluralize(invalid_binding_resources.count)}: " \
-        "#{invalid_binding_messages.join('. ')}"
-
-        bindings.select { |binding_def| binding_def[:strength] == 'extensible' }.each do |binding_def|
-          begin
-            invalid_bindings = resources_with_invalid_binding(binding_def, @location_ary)
-            binding_def_new = binding_def
-            # If the valueset binding wasn't valid, check if the codes are in the stated codesystem
-            if invalid_bindings.present?
-              invalid_bindings = resources_with_invalid_binding(binding_def.except(:system), @location_ary)
-              binding_def_new = binding_def.except(:system)
-            end
-          rescue Inferno::Terminology::UnknownValueSetException, Inferno::Terminology::ValueSet::UnknownCodeSystemException => e
-            warning do
-              assert false, e.message
-            end
-            invalid_bindings = []
-          end
-          invalid_binding_messages.concat(invalid_bindings.map { |invalid| invalid_binding_message(invalid, binding_def_new) })
-        end
-        warning do
-          invalid_binding_messages.each do |error_message|
-            assert false, error_message
-          end
-        end
       end
 
       test 'All must support elements are provided in the Location resources returned.' do

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -43,9 +43,9 @@ describe Inferno::HL7Validator do
         )
 
       result = @validator.validate(@resource, FHIR, @profile)
-      assert result[:errors].length == 2
-      assert result[:warnings].length == 1
-      assert result[:information].length == 5
+      assert_equal 3, result[:errors].length
+      assert_equal 1, result[:warnings].length
+      assert_equal 4, result[:information].length
     end
   end
 


### PR DESCRIPTION
# Summary
This PR switches off terminology validation in Inferno-community, and re-enables displaying warnings from the validator wrapper regarding invalid codes

## New behavior
* Remove a call to validate a code in one of the US Core sequences
* Stop treating `code-invalid` errors as informational messages

## Code changes

## Testing guidance
