### PR TITLE
Switch from only POSTing StructureDefinitions to the validator service, to POSTing all conformance-related resource types

### DIFF
--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -8,6 +8,20 @@ require_relative '../models/module'
 module Inferno
   module StartupTasks
     class << self
+
+      CONFORMANCE_RESOURCE_TYPES = [
+        'ImplementationGuide',
+        'StructureDefinition',
+        'ValueSet',
+        'ConceptMap',
+        'CodeSystem',
+        'CapabilityStatement',
+        'OperationDefinition',
+        'SearchParameter',
+        'CompartmentDefinition',
+        'ElementDefinition'
+      ].freeze
+
       def run
         establish_db_connection
         check_validator_availability
@@ -62,7 +76,7 @@ module Inferno
       def load_profiles_in_validator(module_metadata)
         resource_name = module_metadata[:resource_path]
         resource_file_glob(resource_name, '*.json') do |filename, contents|
-          next unless JSON.parse(contents)['resourceType'] == 'StructureDefinition'
+          next unless CONFORMANCE_RESOURCE_TYPES.include?(JSON.parse(contents)['resourceType'])
 
           RestClient.post("#{validator_url}/profiles", contents)
         rescue JSON::ParserError

--- a/lib/app/utils/startup_tasks.rb
+++ b/lib/app/utils/startup_tasks.rb
@@ -8,7 +8,6 @@ require_relative '../models/module'
 module Inferno
   module StartupTasks
     class << self
-
       CONFORMANCE_RESOURCE_TYPES = [
         'ImplementationGuide',
         'StructureDefinition',


### PR DESCRIPTION
# Summary
This PR makes it so that `lib/app/utils/startup_tasks.rb` will upload resources from included IGs that match any of the Conformance resource types from https://www.hl7.org/fhir/conformance-module.html

Previously, it would only load `StructureDefinition` resources, which left out a number of the desired artifacts

## New behavior
* Added a `CONFORMANCE_RESOURCE_TYPES` array constant to `Inferno::StartupTasks`
* Load a resource if its type matches any in the above constant

## Testing guidance
Run Inferno with a local validator wrapper, and check that the number of `POST /profile` calls in the logs matches the number of resources for each IG that should be uploaded.
