### PR TITLE
Validate transactionTime in scheduling links manifest.

### DIFF
--- a/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
+++ b/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
@@ -488,6 +488,14 @@ module Inferno
           assert_valid_http_uri file['url']
         end
 
+        begin
+          Date.iso8601(@manifest['transactionTime'])
+          has_timezone = /(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))/.match(@manifest['transactionTime']).present?
+          assert has_timezone, "Manifest transactionTime '#{has_timezone}' must contain a timezone offset or end in 'Z' for UTC."
+        rescue RuntimeError, ArgumentError
+          assert false, "transactionTime in manifest file is not a valid iso8601 date: '{@manifest['transactioTime]}'"
+        end
+
         pass "Manifest contains #{@location_urls.length} Location resource URL(s), #{@schedule_urls.length} Schedule resource URL(s), and #{@slot_urls.length} Slot resource URL(s)."
       end
 

--- a/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
+++ b/lib/modules/smart_scheduling_links/smart_scheduling_links_basic_sequence.rb
@@ -492,7 +492,7 @@ module Inferno
           Date.iso8601(@manifest['transactionTime'])
           has_timezone = /(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))/.match(@manifest['transactionTime']).present?
           assert has_timezone, "Manifest transactionTime '#{has_timezone}' must contain a timezone offset or end in 'Z' for UTC."
-        rescue RuntimeError, ArgumentError
+        rescue StandardError
           assert false, "transactionTime in manifest file is not a valid iso8601 date: '{@manifest['transactioTime]}'"
         end
 
@@ -544,7 +544,7 @@ module Inferno
         begin
           date_is_iso8601 = true
           Date.iso8601(@instance.manifest_since)
-        rescue RuntimeError, ArgumentError
+        rescue StandardError
           date_is_iso8601 = false
         end
 

--- a/lib/modules/smart_scheduling_links/test/smart_scheduling_basic_test.rb
+++ b/lib/modules/smart_scheduling_links/test/smart_scheduling_basic_test.rb
@@ -155,6 +155,22 @@ describe Inferno::Sequence::SmartSchedulingLinksBasicSequence do
       end
     end
 
+    ['2015-02-07T13:28:17.239+02:00',
+     '2015-02-07T13:28:17.239-02:00',
+     '2015-02-07T13:28:17.239Z',
+     '2015-02-07T13:28Z'].each do |transaction_time|
+      it 'succeeds when manifest file has transactionTime with different timezone offsets' do
+        instance_copy = @instance.clone
+        sequence = @sequence_class.new(instance_copy, @client)
+        manifest_with_offset = @sample_manifest_file.clone
+        manifest_with_offset['transactionTime'] = transaction_time
+        sequence.instance_variable_set(:@manifest, manifest_with_offset)
+        assert_raises(Inferno::PassException) do
+          sequence.run_test(@manifest_minimum_requirement_test)
+        end
+      end
+    end
+
     it 'fails when missing transactionTime' do
       instance_copy = @instance.clone
       sequence = @sequence_class.new(instance_copy, @client)
@@ -186,6 +202,22 @@ describe Inferno::Sequence::SmartSchedulingLinksBasicSequence do
 
       assert_raises(Inferno::AssertionException) do
         sequence.run_test(@manifest_minimum_requirement_test)
+      end
+    end
+
+    ['2021-03-10 18:16:34.535Z', '2021-03-10T18:16:34.535', '2021-03-10T18:16:34.535+11'].each do |invalid_time|
+      it 'fails when transactionTime is not a valid format' do
+        instance_copy = @instance.clone
+        sequence = @sequence_class.new(instance_copy, @client)
+
+        manifest_invalid_time = @sample_manifest_file.clone
+        manifest_invalid_time['transactionTime'] = invalid_time
+
+        sequence.instance_variable_set(:@manifest, manifest_invalid_time)
+
+        assert_raises(Inferno::AssertionException) do
+          sequence.run_test(@manifest_minimum_requirement_test)
+        end
       end
     end
 


### PR DESCRIPTION
# Summary

Validate that the transactionTime in the scheduling links manifest is a valid date and that it has a timezone offset as required in the spec.

See https://chat.fhir.org/#narrow/stream/281612-smart.2Fscheduling-links/topic/Publisher.3A.20Rite-Aid/near/243572426

## New behavior

Will fail if the transactionTime is not a valid time and is missing the timezone.

## Code changes

Updated one of the scheduling links tests and the tests of them.

## Testing guidance

It is difficult to mock up a failure case (hopefully the unit tests are good enough for that), but validate against valid cases to ensure it doesn't introduce incorrect failures.
