### PR TITLE
Update the smart scheduling links IG to provide its own CVX ValueSet for Vaccine Product

### DIFF
--- a/resources/smart_scheduling_links/ImplementationGuide-smart.scheduling.links.json
+++ b/resources/smart_scheduling_links/ImplementationGuide-smart.scheduling.links.json
@@ -90,6 +90,13 @@
       },
       {
         "reference": {
+          "reference": "ValueSet/vaccine-product-cvx"
+        },
+        "name": "VaccineProductCVX",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "ValueSet/vaccine-slot-status"
         },
         "name": "VaccineSlotStatus",

--- a/resources/smart_scheduling_links/StructureDefinition-vaccine-product.json
+++ b/resources/smart_scheduling_links/StructureDefinition-vaccine-product.json
@@ -289,7 +289,7 @@
         "isSummary": false,
         "binding": {
           "strength": "required",
-          "valueSet": "http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/vaccination-credential-vaccine-value-set"
+          "valueSet": "http://fhir-registry.smarthealthit.org/ValueSet/vaccine-product-cvx"
         },
         "mapping": [
           {
@@ -338,7 +338,7 @@
         "max": "1",
         "binding": {
           "strength": "required",
-          "valueSet": "http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/vaccination-credential-vaccine-value-set"
+          "valueSet": "http://fhir-registry.smarthealthit.org/ValueSet/vaccine-product-cvx"
         }
       }
     ]

--- a/resources/smart_scheduling_links/ValueSet-vaccine-product-cvx.json
+++ b/resources/smart_scheduling_links/ValueSet-vaccine-product-cvx.json
@@ -1,0 +1,15 @@
+{
+  "resourceType": "ValueSet",
+  "status": "active",
+  "name": "VaccineProductCVX",
+  "id": "vaccine-product-cvx",
+  "version": "0.1.0",
+  "url": "http://fhir-registry.smarthealthit.org/ValueSet/vaccine-product-cvx",
+  "compose": {
+    "include": [
+      {
+        "system": "http://hl7.org/fhir/sid/cvx"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Summary
This PR updates the SMART Scheduling Links IG resources to add a CVX-based ValueSet for `vaccine-product`. This avoids a dependency on the VCI IG when validating SMART Scheduling Links resources

## New behavior
* None
## Code changes
* Updated SMART Scheduling Links resources

## Testing guidance
