### PR TITLE
run_umls task now uses correct .prop file

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -581,7 +581,7 @@ namespace :terminology do |_argv|
   task :run_umls, [:my_config] do |_t, args|
     # More information on batch running UMLS
     # https://www.nlm.nih.gov/research/umls/implementation_resources/community/mmsys/BatchMetaMorphoSys.html
-    args.with_defaults(my_config: 'inferno.prop')
+    args.with_defaults(my_config: 'all-active-exportconfig.prop')
     jre_version = if !(/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
                     'windows64'
                   elsif !(/darwin/ =~ RUBY_PLATFORM).nil?


### PR DESCRIPTION
# Summary

Running `bundle exec rake terminology:run_umls` fails (even after setting up a local version of UMLS) because it's looking for a config called `inferno.prop` that doesn't exist. This PR updates the rake task argument to use the available `all-active-exportconfig.prop` config, which appears to be the correct name for the config in this repo.

## New behavior

No new behavior other than addressing this bug. 

## Code changes

The `terminology:run_umls` rake task now uses the appropriate .prop config file. 

## Testing guidance

With the local terminology service up and running, confirm that you can successfully run the UMLS task.