### PR TITLE
FI-1302: Catch error from invalid headers

### DIFF
--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -21,14 +21,20 @@ module Inferno
         direction: direction || req&.direction,
         request_method: request[:method],
         request_url: request[:url],
-        request_headers: request[:headers].to_json,
+        request_headers: stringify_headers(request[:headers]),
         request_payload: request[:payload],
         response_code: response[:code],
-        response_headers: response[:headers].to_json,
+        response_headers: stringify_headers(response[:headers]),
         response_body: escaped_body,
         instance_id: instance_id,
         timestamp: response[:timestamp]
       )
+    end
+
+    def self.stringify_headers(headers)
+      headers.to_json
+    rescue StandardError => e
+      { 'ERROR' => "#{e.class}: #{e.message}" }.to_json
     end
 
     # This is needed to escape HTML when the html tags are unicode escape sequences

--- a/test/unit/request_response_test.rb
+++ b/test/unit/request_response_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../lib/app/models/testing_instance'
+require_relative '../../lib/app/models/sequence_result'
+require_relative '../../lib/app/models/test_result'
+
+describe Inferno::RequestResponse do
+  before do
+    @instance = Inferno::TestingInstance.create(selected_module: 'uscore_v3.1.1')
+    @instance_id = @instance.id
+    @sequence_result = Inferno::SequenceResult.create(testing_instance: @instance)
+    @result = Inferno::TestResult.new(sequence_result: @sequence_result)
+    @result.save!
+  end
+
+  it 'returns the request and responses in the correct order' do
+    10.times do |index|
+      @result.request_responses << Inferno::RequestResponse.create(
+        request_url: "http://#{index}"
+      )
+      @result.save!
+    end
+
+    instance = Inferno::TestingInstance.find(@instance_id)
+    result = instance.sequence_results.first.test_results.first
+    result.request_responses.each_with_index do |request_response, index|
+      assert_equal request_response.request_url, "http://#{index}"
+    end
+  end
+
+  it "doesn't raise an error when invalid headers are received" do
+    bad_header = { 'abc' => (0..255).map(&:chr).join }
+
+    request = Inferno::RequestResponse.from_request(
+      OpenStruct.new(
+        request: { headers: bad_header },
+        response: {}
+      ),
+      'abc'
+    )
+
+    assert(request.request_headers.match?(/"ERROR":/))
+  end
+end


### PR DESCRIPTION
Prevents receiving an invalid header from crashing Inferno. If you get rid of the rescue in `RequestResponse.stringify_headers`, an exception will cause the unit test to fail. Also copied over the other unit test that existed in program but not community.