### PR TITLE
FI-1294 Validate Resource.id

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,7 +55,7 @@ modules:
 # external_fhirpath_evaluator_url is only used if fhirpath_evaluator is set to
 # external.
 fhirpath_evaluator: external
-external_fhirpath_evaluator_url: http://localhost:8887
+external_fhirpath_evaluator_url: http://validator_service:4567
 
 # Optional preset server testing configurations.
 #
@@ -147,4 +147,3 @@ presets:
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     patient_ids: "85,355"
     token: SAMPLE_TOKEN
-  

--- a/config.yml
+++ b/config.yml
@@ -40,7 +40,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://localhost:8887
+external_fhirpath_evaluator_url: http://validator_service:4567
 
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.
@@ -147,13 +147,4 @@ presets:
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     patient_ids: "85,355"
     token: SAMPLE_TOKEN
-  localhost_8080:
-    inferno_uri: http://localhost:4567
-    name: Inferno Reference Server (USCore v3.1.1)
-    uri: http://localhost:8080/reference-server/r4
-    module: uscore_v3.1.1
-    client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
-    confidential_client: true
-    client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    patient_ids: "85,355"
-    token: SAMPLE_TOKEN    
+  

--- a/config.yml
+++ b/config.yml
@@ -40,7 +40,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_fhirpath_evaluator_url: http://validator_service:4567
+external_resource_validator_url: http://validator_service:4567
 
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.

--- a/config.yml
+++ b/config.yml
@@ -40,7 +40,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://validator_service:4567
+external_resource_validator_url: http://localhost:8887
 
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.
@@ -55,7 +55,7 @@ modules:
 # external_fhirpath_evaluator_url is only used if fhirpath_evaluator is set to
 # external.
 fhirpath_evaluator: external
-external_fhirpath_evaluator_url: http://validator_service:4567
+external_fhirpath_evaluator_url: http://localhost:8887
 
 # Optional preset server testing configurations.
 #
@@ -147,3 +147,13 @@ presets:
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     patient_ids: "85,355"
     token: SAMPLE_TOKEN
+  localhost_8080:
+    inferno_uri: http://localhost:4567
+    name: Inferno Reference Server (USCore v3.1.1)
+    uri: http://localhost:8080/reference-server/r4
+    module: uscore_v3.1.1
+    client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
+    confidential_client: true
+    client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
+    patient_ids: "85,355"
+    token: SAMPLE_TOKEN    

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -47,6 +47,24 @@ describe Inferno::HL7Validator do
       assert_equal 1, result[:warnings].length
       assert_equal 4, result[:information].length
     end
+
+    it 'adds Resource id error' do
+      outcome = load_fixture('hl7_validator_operation_outcome')
+      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
+
+      stub_request(:post, "#{@validator_url}/validate")
+        .with(
+          query: { 'profile': @profile },
+          body: @resource.source_contents
+        )
+        .to_return(
+          status: 200,
+          body: outcome
+        )
+
+      result = @validator.validate(@resource, FHIR, @profile)
+      assert(result[:errors].any? { |err| err.match?(/FHIR id value shall match Regex/) })
+    end
   end
 
   describe 'Fetching the validator version' do
@@ -61,6 +79,50 @@ describe Inferno::HL7Validator do
       stub_request(:get, "#{@validator_url}/version")
         .to_return(status: 404)
       assert_nil @validator.version
+    end
+  end
+
+  describe 'Validating Resource ID' do
+    before do
+      @resource = FHIR::Patient.new
+    end
+
+    it 'catches Resource id longer than 64 characters' do
+      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
+      result = @validator.validate_resource_id(@resource)
+
+      refute result.empty?
+      assert result.first.match?(/^Patient\.id: FHIR id value shall match Regex/)
+    end
+
+    it 'catches Resource id with invalid character' do
+      @resource.id = '1234567890$'
+      result = @validator.validate_resource_id(@resource)
+
+      refute result.empty?
+      assert result.first.match?(/^Patient\.id: FHIR id value shall match Regex/)
+    end
+
+    it 'catches Resource id in internal resource' do
+      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
+      bundle = wrap_resources_in_bundle(@resource)
+      bundle.id = '1234567890$'
+      result = @validator.validate_resource_id(bundle)
+
+      assert result.size == 2
+    end
+
+    it 'passes Resource without id' do
+      result = @validator.validate_resource_id(@resource)
+
+      assert result.empty?
+    end
+
+    it 'passes Resource with valid id' do
+      @resource.id = 'A-123.b'
+      result = @validator.validate_resource_id(@resource)
+
+      assert result.empty?
     end
   end
 end


### PR DESCRIPTION
# Summary
FHIR validator does not valid Resource.id 
So Inferno has to check Resource.id against this regex /^[A-Za-z0-9\-\.]{1,64}$/.

This PR addresses Issue #332 
 
## New behavior
Inferno will report "FHIR id value shall match Regex /^[A-Za-z0-9\-\.]{1,64}$/" error if the Resource.id does not match the regex

## Code changes

## Testing guidance
